### PR TITLE
build: add cfn-nag task for local validation

### DIFF
--- a/source/common/config/rush/pnpm-lock.yaml
+++ b/source/common/config/rush/pnpm-lock.yaml
@@ -466,6 +466,7 @@ importers:
       '@types/react-dom': ^18.0.6
       depcheck: ^1.4.3
       eslint: ^8.7.0
+      eslint-config-next: 12.1.5
       eslint-plugin-import: ^2.26.0
       istanbul-badges-readme: 1.8.1
       license-check-and-add: ^4.0.5
@@ -500,6 +501,7 @@ importers:
       '@types/react-dom': 18.0.6
       depcheck: 1.4.3
       eslint: 8.16.0
+      eslint-config-next: 12.1.5_613ce9cf4c3b1789789bd001816c16e7
       eslint-plugin-import: 2.26.0_eslint@8.16.0
       istanbul-badges-readme: 1.8.1
       license-check-and-add: 4.0.5
@@ -866,6 +868,7 @@ importers:
       '@types/react-dom': ^18.0.6
       depcheck: ^1.4.3
       eslint: ^8.7.0
+      eslint-config-next: 12.1.5
       eslint-plugin-import: ^2.26.0
       istanbul-badges-readme: 1.8.1
       license-check-and-add: ^4.0.5
@@ -900,6 +903,7 @@ importers:
       '@types/react-dom': 18.0.6
       depcheck: 1.4.3
       eslint: 8.16.0
+      eslint-config-next: 12.1.5_613ce9cf4c3b1789789bd001816c16e7
       eslint-plugin-import: 2.26.0_eslint@8.16.0
       istanbul-badges-readme: 1.8.1
       license-check-and-add: 4.0.5
@@ -1029,6 +1033,7 @@ importers:
       '@types/react-dom': ^18.0.6
       depcheck: ^1.4.3
       eslint: ^8.7.0
+      eslint-config-next: 12.1.5
       eslint-plugin-import: ^2.26.0
       istanbul-badges-readme: 1.8.1
       license-check-and-add: ^4.0.5
@@ -1066,6 +1071,7 @@ importers:
       '@types/react-dom': 18.0.6
       depcheck: 1.4.3
       eslint: 8.16.0
+      eslint-config-next: 12.1.5_613ce9cf4c3b1789789bd001816c16e7
       eslint-plugin-import: 2.26.0_eslint@8.16.0
       istanbul-badges-readme: 1.8.1
       license-check-and-add: 4.0.5
@@ -1401,6 +1407,7 @@ importers:
       date-fns: ^2.28.0
       depcheck: ^1.4.3
       eslint: ^8.7.0
+      eslint-config-next: 12.1.5
       eslint-plugin-import: ^2.26.0
       istanbul-badges-readme: 1.8.1
       jwt-decode: ^3.1.2
@@ -1441,6 +1448,7 @@ importers:
       '@types/uuid': 8.3.4
       depcheck: 1.4.3
       eslint: 8.16.0
+      eslint-config-next: 12.1.5_613ce9cf4c3b1789789bd001816c16e7
       eslint-plugin-import: 2.26.0_eslint@8.16.0
       istanbul-badges-readme: 1.8.1
       license-check-and-add: 4.0.5

--- a/source/dea-backend/README.md
+++ b/source/dea-backend/README.md
@@ -6,7 +6,7 @@
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-97.22%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-80%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.14%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-97.93%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-80%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.89%25-brightgreen.svg?style=flat) |
 
 ## Useful commands
 

--- a/source/dea-backend/cfn-deny
+++ b/source/dea-backend/cfn-deny
@@ -1,0 +1,3 @@
+RulesToSuppress:
+- id: W92
+  reason: Lets talk about reserved concurrency

--- a/source/dea-backend/package.json
+++ b/source/dea-backend/package.json
@@ -29,6 +29,7 @@
     "license-checker": "license-checker --onlyAllow 'MIT; Apache-2.0; ISC; BSD'",
     "lint:fix": "eslint . --fix",
     "make-badges": "istanbul-badges-readme --coverageDir=./temp/coverage --exitCode=1",
+    "nag": "cfn_nag_scan --deny-list-path cfn-deny --fail-on-warnings --input-path ./cdk.out/DeaBackendStack.template.json",
     "pkg-json-lint": "npmPkgJsonLint -c ../../../ .",
     "sort-package-json": "sort-package-json package.json",
     "test": "STAGE=test rushx test:only && rushx make-badges",

--- a/source/dea-backend/src/__snapshots__/dea-backend-stack.unit.test.ts.snap
+++ b/source/dea-backend/src/__snapshots__/dea-backend-stack.unit.test.ts.snap
@@ -55,6 +55,34 @@ Object {
         ],
       },
     },
+    "cognitoDomainName": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "DigitalEvidenceArchiveCognitoWorkbenchUserPoolDomain2E16F07A",
+            },
+            ".auth.",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            ".amazoncognito.com",
+          ],
+        ],
+      },
+    },
+    "cognitoUserPoolClientId": Object {
+      "Value": Object {
+        "Ref": "DigitalEvidenceArchiveCognitoWorkbenchUserPoolClient36D1EB5A",
+      },
+    },
+    "cognitoUserPoolId": Object {
+      "Value": Object {
+        "Ref": "DigitalEvidenceArchiveCognitoWorkbenchUserPoolEC3F0768",
+      },
+    },
   },
   "Parameters": Object {
     "BootstrapVersion": Object {
@@ -67,7 +95,7 @@ Object {
     "APIGatewayAPI321F7D19": Object {
       "Properties": Object {
         "Description": "Backend API",
-        "Name": "Backend API Name",
+        "Name": "API-Gateway API",
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
@@ -104,6 +132,12 @@ Object {
       },
       "Type": "AWS::ApiGateway::Account",
     },
+    "APIGatewayAPIBackendUsagePlan7F2BA821": Object {
+      "Properties": Object {
+        "UsagePlanName": "backend-usage-plan",
+      },
+      "Type": "AWS::ApiGateway::UsagePlan",
+    },
     "APIGatewayAPICloudWatchRole04468EC8": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
@@ -135,7 +169,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "APIGatewayAPIDeploymentCABB9A2Bcf93a207b42b24c27a70d2687223d29d": Object {
+    "APIGatewayAPIDeploymentCABB9A2B797d1b0a72554b47c3be4a6f9d08acb6": Object {
       "DependsOn": Array [
         "APIGatewayAPIproxyANYDB3CFBD0",
         "APIGatewayAPIproxy6CE33476",
@@ -164,7 +198,7 @@ Object {
           "Format": "{\\"stage\\":\\"$context.stage\\",\\"requestId\\":\\"$context.requestId\\",\\"integrationRequestId\\":\\"$context.integration.requestId\\",\\"status\\":\\"$context.status\\",\\"apiId\\":\\"$context.apiId\\",\\"resourcePath\\":\\"$context.resourcePath\\",\\"path\\":\\"$context.path\\",\\"resourceId\\":\\"$context.resourceId\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"userAgent\\":\\"$context.identity.userAgent\\"}",
         },
         "DeploymentId": Object {
-          "Ref": "APIGatewayAPIDeploymentCABB9A2Bcf93a207b42b24c27a70d2687223d29d",
+          "Ref": "APIGatewayAPIDeploymentCABB9A2B797d1b0a72554b47c3be4a6f9d08acb6",
         },
         "RestApiId": Object {
           "Ref": "APIGatewayAPI321F7D19",
@@ -305,62 +339,30 @@ Object {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "LiveAlias9B8FFEA9": Object {
-      "Properties": Object {
-        "FunctionName": Object {
-          "Ref": "deaapphandler5A2E0A8F",
-        },
-        "FunctionVersion": Object {
-          "Fn::GetAtt": Array [
-            "deaapphandlerCurrentVersion3921518A14155ec187373f9931cef63cab2e1331",
-            "Version",
-          ],
-        },
-        "Name": "live",
-        "ProvisionedConcurrencyConfig": Object {
-          "ProvisionedConcurrentExecutions": 1,
-        },
-      },
-      "Type": "AWS::Lambda::Alias",
-    },
-    "deaapphandler5A2E0A8F": Object {
+    "AWS679f53fac002430cb0da5b7982bd22872D164C4C": Object {
       "DependsOn": Array [
-        "deaapphandlerServiceRoleF4D7863A",
+        "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
       ],
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b06c041e17e970820416a547e4a17e621c794bc601d76365ac805aca8f822c92.zip",
-        },
-        "Environment": Object {
-          "Variables": Object {
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
-          },
+          "S3Key": "864aa5eb2d6ca4e0d4d65c940bc9e4d5a29db1e4f3f3a098ddb56f76b2129ac4.zip",
         },
         "Handler": "index.handler",
-        "MemorySize": 512,
         "Role": Object {
           "Fn::GetAtt": Array [
-            "deaapphandlerServiceRoleF4D7863A",
+            "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
             "Arn",
           ],
         },
-        "Runtime": "nodejs16.x",
-        "Timeout": 180,
+        "Runtime": "nodejs14.x",
+        "Timeout": 120,
       },
       "Type": "AWS::Lambda::Function",
     },
-    "deaapphandlerCurrentVersion3921518A14155ec187373f9931cef63cab2e1331": Object {
-      "Properties": Object {
-        "FunctionName": Object {
-          "Ref": "deaapphandler5A2E0A8F",
-        },
-      },
-      "Type": "AWS::Lambda::Version",
-    },
-    "deaapphandlerServiceRoleF4D7863A": Object {
+    "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -390,6 +392,531 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "DigitalEvidenceArchiveCognitoDescribeCognitoUserPoolClient6FD347DA": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DigitalEvidenceArchiveCognitoDescribeCognitoUserPoolClientCustomResourcePolicy2B5EE361",
+      ],
+      "Properties": Object {
+        "Create": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"service\\":\\"CognitoIdentityServiceProvider\\",\\"action\\":\\"describeUserPoolClient\\",\\"parameters\\":{\\"UserPoolId\\":\\"",
+              Object {
+                "Ref": "DigitalEvidenceArchiveCognitoWorkbenchUserPoolEC3F0768",
+              },
+              "\\",\\"ClientId\\":\\"",
+              Object {
+                "Ref": "DigitalEvidenceArchiveCognitoWorkbenchUserPoolClient36D1EB5A",
+              },
+              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Ref": "DigitalEvidenceArchiveCognitoWorkbenchUserPoolClient36D1EB5A",
+              },
+              "\\"}}",
+            ],
+          ],
+        },
+        "InstallLatestAwsSdk": true,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::DescribeCognitoUserPoolClient",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DigitalEvidenceArchiveCognitoDescribeCognitoUserPoolClientCustomResourcePolicy2B5EE361": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "cognito-idp:DescribeUserPoolClient",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DigitalEvidenceArchiveCognitoWorkbenchUserPoolEC3F0768",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DigitalEvidenceArchiveCognitoDescribeCognitoUserPoolClientCustomResourcePolicy2B5EE361",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DigitalEvidenceArchiveCognitoWorkbenchUserPoolClient36D1EB5A": Object {
+      "Properties": Object {
+        "AccessTokenValidity": 15,
+        "AllowedOAuthFlows": Array [
+          "code",
+        ],
+        "AllowedOAuthFlowsUserPoolClient": true,
+        "AllowedOAuthScopes": Array [
+          "openid",
+        ],
+        "CallbackURLs": Array [
+          "test",
+          "https://bogus.bogus",
+        ],
+        "ClientName": "dea-client-test-Testville",
+        "EnableTokenRevocation": true,
+        "ExplicitAuthFlows": Array [
+          "ALLOW_ADMIN_USER_PASSWORD_AUTH",
+          "ALLOW_CUSTOM_AUTH",
+          "ALLOW_USER_SRP_AUTH",
+          "ALLOW_REFRESH_TOKEN_AUTH",
+        ],
+        "GenerateSecret": true,
+        "IdTokenValidity": 15,
+        "LogoutURLs": Array [
+          "test",
+          "https://bogus.bogus",
+        ],
+        "PreventUserExistenceErrors": "ENABLED",
+        "RefreshTokenValidity": 43200,
+        "SupportedIdentityProviders": Array [
+          "COGNITO",
+        ],
+        "TokenValidityUnits": Object {
+          "AccessToken": "minutes",
+          "IdToken": "minutes",
+          "RefreshToken": "minutes",
+        },
+        "UserPoolId": Object {
+          "Ref": "DigitalEvidenceArchiveCognitoWorkbenchUserPoolEC3F0768",
+        },
+      },
+      "Type": "AWS::Cognito::UserPoolClient",
+    },
+    "DigitalEvidenceArchiveCognitoWorkbenchUserPoolDomain2E16F07A": Object {
+      "Properties": Object {
+        "Domain": "cogtest",
+        "UserPoolId": Object {
+          "Ref": "DigitalEvidenceArchiveCognitoWorkbenchUserPoolEC3F0768",
+        },
+      },
+      "Type": "AWS::Cognito::UserPoolDomain",
+    },
+    "DigitalEvidenceArchiveCognitoWorkbenchUserPoolEC3F0768": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AccountRecoverySetting": Object {
+          "RecoveryMechanisms": Array [
+            Object {
+              "Name": "verified_email",
+              "Priority": 1,
+            },
+          ],
+        },
+        "AdminCreateUserConfig": Object {
+          "AllowAdminCreateUserOnly": true,
+        },
+        "AutoVerifiedAttributes": Array [
+          "email",
+        ],
+        "EmailVerificationMessage": "The verification code to your new account is {####}",
+        "EmailVerificationSubject": "Verify your new account",
+        "MfaConfiguration": "OFF",
+        "Schema": Array [
+          Object {
+            "Mutable": true,
+            "Name": "given_name",
+            "Required": true,
+          },
+          Object {
+            "Mutable": true,
+            "Name": "family_name",
+            "Required": true,
+          },
+          Object {
+            "Mutable": true,
+            "Name": "email",
+            "Required": true,
+          },
+        ],
+        "SmsVerificationMessage": "The verification code to your new account is {####}",
+        "UserPoolName": "dea-userpool-test-Testville",
+        "UsernameAttributes": Array [
+          "email",
+        ],
+        "UsernameConfiguration": Object {
+          "CaseSensitive": false,
+        },
+        "VerificationMessageTemplate": Object {
+          "DefaultEmailOption": "CONFIRM_WITH_CODE",
+          "EmailMessage": "The verification code to your new account is {####}",
+          "EmailSubject": "Verify your new account",
+          "SmsMessage": "The verification code to your new account is {####}",
+        },
+      },
+      "Type": "AWS::Cognito::UserPool",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "FlowLog3CB084E9": Object {
+      "Properties": Object {
+        "DeliverLogsPermissionArn": Object {
+          "Fn::GetAtt": Array [
+            "flowlogrole97E07705",
+            "Arn",
+          ],
+        },
+        "LogDestinationType": "cloud-watch-logs",
+        "LogGroupName": Object {
+          "Ref": "deavpcloggroup15482769",
+        },
+        "ResourceId": Object {
+          "Ref": "deavpc904D699F",
+        },
+        "ResourceType": "VPC",
+        "TrafficType": "ALL",
+      },
+      "Type": "AWS::EC2::FlowLog",
+    },
+    "LiveAlias9B8FFEA9": Object {
+      "Properties": Object {
+        "FunctionName": Object {
+          "Ref": "deaapphandler5A2E0A8F",
+        },
+        "FunctionVersion": Object {
+          "Fn::GetAtt": Array [
+            "deaapphandlerCurrentVersion3921518A6cf19fb371eabdb5d28b8c3d575ec863",
+            "Version",
+          ],
+        },
+        "Name": "live",
+        "ProvisionedConcurrencyConfig": Object {
+          "ProvisionedConcurrentExecutions": 1,
+        },
+      },
+      "Type": "AWS::Lambda::Alias",
+    },
+    "deaapphandler5A2E0A8F": Object {
+      "DependsOn": Array [
+        "deabaselambdarole86C6FF7A",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "0260d4f8947be917391f12b4573076bcc87d9eb4f2156b3f7f7d4543cfc7a895.zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "deabaselambdarole86C6FF7A",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs16.x",
+        "Timeout": 180,
+        "VpcConfig": Object {
+          "SecurityGroupIds": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "deaapphandlerSecurityGroup9058D096",
+                "GroupId",
+              ],
+            },
+          ],
+          "SubnetIds": Array [
+            Object {
+              "Ref": "deavpcIngressSubnet1Subnet18DEBB64",
+            },
+            Object {
+              "Ref": "deavpcIngressSubnet2Subnet93350CD8",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "deaapphandlerCurrentVersion3921518A6cf19fb371eabdb5d28b8c3d575ec863": Object {
+      "Properties": Object {
+        "FunctionName": Object {
+          "Ref": "deaapphandler5A2E0A8F",
+        },
+      },
+      "Type": "AWS::Lambda::Version",
+    },
+    "deaapphandlerSecurityGroup9058D096": Object {
+      "Properties": Object {
+        "GroupDescription": "Automatic security group for Lambda Function DeaBackendStackdeaapphandlerEF00DCA7",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "deavpc904D699F",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "deabaselambdarole86C6FF7A": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "deavpc904D699F": Object {
+      "Properties": Object {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsHostnames": true,
+        "EnableDnsSupport": true,
+        "InstanceTenancy": "default",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "DeaBackendStack/dea-vpc",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::VPC",
+    },
+    "deavpcIngressSubnet1RouteTable899FEE3E": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "DeaBackendStack/dea-vpc/IngressSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "deavpc904D699F",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "deavpcIngressSubnet1RouteTableAssociationACF6F084": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "deavpcIngressSubnet1RouteTable899FEE3E",
+        },
+        "SubnetId": Object {
+          "Ref": "deavpcIngressSubnet1Subnet18DEBB64",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "deavpcIngressSubnet1Subnet18DEBB64": Object {
+      "Properties": Object {
+        "AvailabilityZone": Object {
+          "Fn::Select": Array [
+            0,
+            Object {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.0.0/24",
+        "MapPublicIpOnLaunch": false,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Ingress",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Isolated",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "DeaBackendStack/dea-vpc/IngressSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "deavpc904D699F",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "deavpcIngressSubnet2RouteTable3EB65955": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "DeaBackendStack/dea-vpc/IngressSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "deavpc904D699F",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "deavpcIngressSubnet2RouteTableAssociationCF07F874": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "deavpcIngressSubnet2RouteTable3EB65955",
+        },
+        "SubnetId": Object {
+          "Ref": "deavpcIngressSubnet2Subnet93350CD8",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "deavpcIngressSubnet2Subnet93350CD8": Object {
+      "Properties": Object {
+        "AvailabilityZone": Object {
+          "Fn::Select": Array [
+            1,
+            Object {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.1.0/24",
+        "MapPublicIpOnLaunch": false,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Ingress",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Isolated",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "DeaBackendStack/dea-vpc/IngressSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "deavpc904D699F",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "deavpcloggroup15482769": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "flowlogrole97E07705": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "vpc-flow-logs.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "flowlogroleDefaultPolicy50B2239C": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "deavpcloggroup15482769",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "flowlogrole97E07705",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "flowlogroleDefaultPolicy50B2239C",
+        "Roles": Array [
+          Object {
+            "Ref": "flowlogrole97E07705",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "vpcsg90F3EB1C": Object {
+      "Properties": Object {
+        "GroupDescription": "DeaBackendStack/vpc-sg",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "deavpc904D699F",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
     },
   },
   "Rules": Object {

--- a/source/dea-backend/src/dea-backend-stack.ts
+++ b/source/dea-backend/src/dea-backend-stack.ts
@@ -1,16 +1,24 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable no-new */
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
-import { join } from 'path';
 import * as path from 'path';
 import { WorkbenchCognito, WorkbenchCognitoProps } from '@aws/workbench-core-infrastructure';
-import { Stack, CfnOutput, StackProps, Duration } from 'aws-cdk-lib';
+import { CfnOutput, Duration, Stack, StackProps } from 'aws-cdk-lib';
 import {
   AccessLogFormat,
   LambdaIntegration,
   LogGroupLogDestination,
   RestApi
 } from 'aws-cdk-lib/aws-apigateway';
+import {
+  FlowLog,
+  FlowLogDestination,
+  FlowLogResourceType,
+  SecurityGroup,
+  SubnetType,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Alias, Runtime } from 'aws-cdk-lib/aws-lambda';
 import * as nodejsLambda from 'aws-cdk-lib/aws-lambda-nodejs';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
@@ -24,33 +32,74 @@ export class DeaBackendStack extends Stack {
 
     super(scope, id, props);
 
-    const apiLambda: NodejsFunction = this._createAPILambda();
+    //take a optional VPC from config, if not provided create one
+    const vpc = this._createVpc();
+    const apiLambda = this._createAPILambda(vpc);
     this._createRestApi(apiLambda);
     this._createCognitoResources(COGNITO_DOMAIN, WEBSITE_URLS, USER_POOL_NAME, USER_POOL_CLIENT_NAME);
   }
 
+  private _createVpc = (): Vpc => {
+    const vpc = new Vpc(this, 'dea-vpc', {
+      natGateways: 0,
+      subnetConfiguration: [
+        {
+          cidrMask: 24,
+          name: 'Ingress',
+          subnetType: SubnetType.PRIVATE_ISOLATED
+        }
+      ]
+    });
+
+    new SecurityGroup(this, 'vpc-sg', {
+      vpc
+    });
+
+    const logGroup = new LogGroup(this, 'dea-vpc-log-group');
+
+    const role = new Role(this, 'flow-log-role', {
+      assumedBy: new ServicePrincipal('vpc-flow-logs.amazonaws.com')
+    });
+
+    new FlowLog(this, 'FlowLog', {
+      resourceType: FlowLogResourceType.fromVpc(vpc),
+      destination: FlowLogDestination.toCloudWatchLogs(logGroup, role)
+    });
+
+    return vpc;
+  };
+
   // Create Lambda
-  private _createAPILambda(): NodejsFunction {
+  private _createAPILambda = (vpc: Vpc): NodejsFunction => {
+    const basicExecutionPolicy = ManagedPolicy.fromAwsManagedPolicyName(
+      'service-role/AWSLambdaBasicExecutionRole'
+    );
+    const role = new Role(this, 'dea-base-lambda-role', {
+      assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+      managedPolicies: [basicExecutionPolicy]
+    });
+
     const lambdaService = new nodejsLambda.NodejsFunction(this, 'dea-app-handler', {
       memorySize: 512,
+      vpc,
+      role: role,
       timeout: Duration.minutes(3),
       runtime: Runtime.NODEJS_16_X,
       handler: 'handler',
       entry: path.join(__dirname, '/../src/backendAPILambda.ts'),
-      depsLockFilePath: join(__dirname, '/../../common/config/rush/pnpm-lock.yaml'),
+      depsLockFilePath: path.join(__dirname, '/../../common/config/rush/pnpm-lock.yaml'),
       bundling: {
         externalModules: ['aws-sdk']
       }
     });
 
     return lambdaService;
-  }
+  };
 
   // API Gateway
-  private _createRestApi(apiLambda: NodejsFunction): void {
+  private _createRestApi = (apiLambda: NodejsFunction): void => {
     const logGroup = new LogGroup(this, 'APIGatewayAccessLogs');
     const API: RestApi = new RestApi(this, `API-Gateway API`, {
-      restApiName: 'Backend API Name',
       description: 'Backend API',
       deployOptions: {
         stageName: 'dev',
@@ -74,6 +123,10 @@ export class DeaBackendStack extends Stack {
       // TODO: Add CORS Preflight
     });
 
+    API.addUsagePlan('Backend Usage Plan', {
+      name: 'backend-usage-plan'
+    });
+
     new CfnOutput(this, 'apiUrlOutput', {
       value: API.url
     });
@@ -87,13 +140,13 @@ export class DeaBackendStack extends Stack {
     API.root.addProxy({
       defaultIntegration: new LambdaIntegration(alias)
     });
-  }
-  private _createCognitoResources(
+  };
+  private _createCognitoResources = (
     domainPrefix: string,
     websiteUrls: string[],
     userPoolName: string,
     userPoolClientName: string
-  ): WorkbenchCognito {
+  ): WorkbenchCognito => {
     const props: WorkbenchCognitoProps = {
       domainPrefix: domainPrefix,
       websiteUrls: websiteUrls,
@@ -117,5 +170,5 @@ export class DeaBackendStack extends Stack {
     });
 
     return workbenchCognito;
-  }
+  };
 }

--- a/source/dea-backend/src/dea-backend-stack.unit.test.ts
+++ b/source/dea-backend/src/dea-backend-stack.unit.test.ts
@@ -16,7 +16,7 @@ describe('DeaBackendStack', () => {
 
     // Assert it creates the function with the correct properties...
     template.hasResourceProperties('AWS::ApiGateway::RestApi', {
-      Name: 'Backend API Name'
+      Description: 'Backend API'
     });
 
     template.hasResourceProperties('AWS::Lambda::Function', {


### PR DESCRIPTION
*V727819919*

*Add cfn-nag npm task*

- Usage: `npm run nag`
- The cfn-nag task is currently not enforced in githooks, we'll need some conversation around which, if any, rules we want to disable.
- To generate templates prior to running cfn-nag `STAGE=test npm run cdk synth`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
