### PR TITLE
fix: add README to dea-app folder to fix test failure

### DIFF
--- a/source/dea-app/README.md
+++ b/source/dea-app/README.md
@@ -1,0 +1,10 @@
+# swb-app
+
+⚠️ $\textcolor{red}{\text{Experimental}}$ ⚠️ : Not for use in any critical, production, or otherwise important deployments
+
+# Code Coverage
+| Statements                  | Branches                | Functions                 | Lines             |
+| --------------------------- | ----------------------- | ------------------------- | ----------------- |
+| ![Statements](https://img.shields.io/badge/statements-Unknown%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-Unknown%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-Unknown%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-Unknown%25-brightgreen.svg?style=flat) |
+
+This project is the routing package for `dea-backend`. It is used by `dea-backend` to generate routes for DEA API. Please refer  [here](../dea-backend/README.md) for more information on how to use this project.


### PR DESCRIPTION
Fixes the following rush test error

```
==[ @aws/dea-app ]===============================================[ 17 of 21 ]==
Readme file does not exist
Please refer to the documentation
https://github.com/olavoparno/istanbul-badges-readme/blob/master/README.md
Returned error code: 1
"@aws/dea-app" failed to build.
"@aws/dea-backend" is blocked by "@aws/dea-app".
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
