### PR TITLE
build: require opt in for git hooks

### DIFF
--- a/source/common/git-hooks/commit-msg
+++ b/source/common/git-hooks/commit-msg
@@ -24,6 +24,8 @@
 #   echo "Bad commit message, see example conventional commits: https://www.conventionalcommits.org/en/v1.0.0/"
 #   exit 1
 # fi
-INPUT_FILE=$1
-cd source
-node common/scripts/install-run-rush.js commitlint --edit "$INPUT_FILE"
+if [ "$RUN_HOOKS" == true ]; then
+    INPUT_FILE=$1
+    cd source
+    node common/scripts/install-run-rush.js commitlint --edit "$INPUT_FILE"
+fi

--- a/source/common/git-hooks/pre-commit
+++ b/source/common/git-hooks/pre-commit
@@ -7,13 +7,15 @@
 # are committed. The command is defined in common/config/rush/command-line.json
 # and uses the "rush-prettier" autoinstaller.
 
-cd source
-node common/scripts/install-run-rush.js git-secrets-scan || exit $?
-node common/scripts/install-run-rush.js prettier || exit $?
-node common/scripts/install-run-rush.js lint:fix || exit $?
-node common/scripts/install-run-rush.js add-license-header|| exit $?
-node common/scripts/install-run-rush.js sort-package-json && git add **/package.json || exit $?
-if ! node common/scripts/install-run-rush.js build:test; then
-    echo "\033[0;31mA Failure was encountered, please check the output above\033[0m"
-    exit 1
+if [ "$RUN_HOOKS" == true ]; then
+    cd source
+    node common/scripts/install-run-rush.js git-secrets-scan || exit $?
+    node common/scripts/install-run-rush.js prettier || exit $?
+    node common/scripts/install-run-rush.js lint:fix || exit $?
+    node common/scripts/install-run-rush.js add-license-header|| exit $?
+    node common/scripts/install-run-rush.js sort-package-json && git add **/package.json || exit $?
+    if ! node common/scripts/install-run-rush.js build:test; then
+        echo "\033[0;31mA Failure was encountered, please check the output above\033[0m"
+        exit 1
+    fi
 fi


### PR DESCRIPTION
- Make git hooks opt-in
- e.g. `RUN_HOOKS=true git commit -m "chore: this is a commit"` to run client side git hooks


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
