### PR TITLE
chore: fix UI Bucket config

### DIFF
--- a/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
+++ b/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
@@ -55,6 +55,14 @@ Object {
         ],
       },
     },
+    "DeaUiStackDeaUIS3BucketAccessLogsOutputDCD456F0": Object {
+      "Export": Object {
+        "Name": "DeaUIS3BucketAccessLogsOutput",
+      },
+      "Value": Object {
+        "Ref": "DeaUiStackuiS3AccessLogsBucketF45A3215",
+      },
+    },
     "DeaUiStackdeauigatewayEndpointFE9A0DB0": Object {
       "Value": Object {
         "Fn::Join": Array [
@@ -243,6 +251,64 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
+      "DependsOn": Array [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Lambda function for auto-deleting objects in ",
+              Object {
+                "Ref": "DeaUiStackuiS3AccessLogsBucketF45A3215",
+              },
+              " S3 bucket.",
+            ],
+          ],
+        },
+        "Handler": "__entrypoint__.handler",
+        "MemorySize": 128,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
     "DeaBackendStackAPIGatewayAPI9C81C9B1": Object {
       "Properties": Object {
@@ -877,7 +943,22 @@ Object {
     "DeaUiStackDeaUiStackbucket2409F549": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
-        "AccessControl": "Private",
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": Object {
+          "DestinationBucketName": Object {
+            "Ref": "DeaUiStackuiS3AccessLogsBucketF45A3215",
+          },
+          "LogFilePrefix": "dea-ui-access-log",
+        },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
           "BlockPublicPolicy": true,
@@ -896,6 +977,81 @@ Object {
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
+    },
+    "DeaUiStackDeaUiStackbucketPolicy3F40F0AF": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "DeaUiStackDeaUiStackbucket2409F549",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaUiStackDeaUiStackbucket2409F549",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaUiStackDeaUiStackbucket2409F549",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Deny requests that do not use TLS/HTTPS",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "StringNotEquals": Object {
+                  "s3:signatureversion": "AWS4-HMAC-SHA256",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DeaUiStackDeaUiStackbucket2409F549",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+              "Sid": "Deny requests that do not use SigV4",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
     },
     "DeaUiStackDeaUiStackdeploymentbucketAwsCliLayerE6B55D5A": Object {
       "Properties": Object {
@@ -1256,6 +1412,177 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "DeaUiStackuiS3AccessLogsBucketAutoDeleteObjectsCustomResource26BB732F": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DeaUiStackuiS3AccessLogsBucketPolicyBA876991",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DeaUiStackuiS3AccessLogsBucketF45A3215",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeaUiStackuiS3AccessLogsBucketF45A3215": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W35",
+              "reason": "This is an access log bucket, we don't need to configure access logging for access log buckets",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeaUiStackuiS3AccessLogsBucketPolicyBA876991": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "DeaUiStackuiS3AccessLogsBucketF45A3215",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaUiStackuiS3AccessLogsBucketF45A3215",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaUiStackuiS3AccessLogsBucketF45A3215",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaUiStackuiS3AccessLogsBucketF45A3215",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaUiStackuiS3AccessLogsBucketF45A3215",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DeaUiStackuiS3AccessLogsBucketF45A3215",
+                        "Arn",
+                      ],
+                    },
+                    "/dea-ui-access-log*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
     },
   },
   "Rules": Object {

--- a/source/dea-main/src/test/dea-main-stack.unit.test.ts
+++ b/source/dea-main/src/test/dea-main-stack.unit.test.ts
@@ -7,7 +7,6 @@ import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
-import { BucketAccessControl } from 'aws-cdk-lib/aws-s3';
 import { DeaMainStack } from '../dea-main-stack';
 
 describe('DeaMainStack', () => {
@@ -45,7 +44,7 @@ describe('DeaMainStack', () => {
     });
 
     template.hasResourceProperties('AWS::S3::Bucket', {
-      AccessControl: BucketAccessControl.PRIVATE,
+      AccessControl: 'LogDeliveryWrite',
       PublicAccessBlockConfiguration: {
         BlockPublicAcls: true,
         BlockPublicPolicy: true,
@@ -55,8 +54,8 @@ describe('DeaMainStack', () => {
     });
 
     expect.addSnapshotSerializer({
-      test: val => typeof val === 'string' && val.includes('zip'),
-      print: val => {
+      test: (val) => typeof val === 'string' && val.includes('zip'),
+      print: (val) => {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         const newVal = (val as string).replace(/([A-Fa-f0-9]{64})/, '[HASH REMOVED]');
         return `"${newVal}"`;


### PR DESCRIPTION
- Update UI Bucket config. Enable encryption and added bucket policy to disallow non-secure transport
- Create new access log bucket
- Add warning suppression for new log bucket

This resolves the following nag warnings:
| WARN W51
|
| Resource: ["DeaUiStackDeaUiStackbucket2409F549"]
| Line Numbers: [722]
|
| S3 bucket should likely have a bucket policy
------------------------------------------------------------
| WARN W35
|
| Resource: ["DeaUiStackDeaUiStackbucket2409F549"]
| Line Numbers: [722]
|
| S3 Bucket should have access logging configured
------------------------------------------------------------
| WARN W41
|
| Resource: ["DeaUiStackDeaUiStackbucket2409F549"]
| Line Numbers: [722]
|
| S3 Bucket should have encryption option set