### PR TITLE
chore: remove git submodule commands from the READMEs. Fix PR command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,14 @@ cd ./$WORKSPACE_NAME
 git checkout --track origin/develop
 ```
 
-5. Be sure to ingest MAF Workbench core submodule
-Use the following command to checkout solution spark
-
-```
-git submodule update --init --recursive --remote
-```
-
-6. Run Rush Install
+5. Run Rush Install
 
 ```
 cd ./source
 rush cupdate
 ```
 
-7. Setup Git Defender
+6. Setup Git Defender
 
 ```
 git defender --setup
@@ -46,7 +39,7 @@ git defender --setup
 ## Creating a PR from a Commit(s)
 
 ```
-git pull upstream develop --rebase
+git pull origin develop --rebase
 ```
 
 ```

--- a/source/README.md
+++ b/source/README.md
@@ -20,12 +20,6 @@
 
 To install for the first time, run the following commands:
 
-Install git submodules
-
-```
-git submodule update --init --recursive --remote
-```
-
 Update & build rush
 
 ```


### PR DESCRIPTION
We removed MAF from the codebase, we do not need to run these commands anymore


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
