### PR TITLE
feat: add skeleton of a lambda authorizer with basic unit tests

### DIFF
--- a/source/dea-app/src/lambda-handlers/custom-lambda-authorizer.ts
+++ b/source/dea-app/src/lambda-handlers/custom-lambda-authorizer.ts
@@ -1,0 +1,65 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  APIGatewayAuthorizerCallback,
+  APIGatewayTokenAuthorizerEvent,
+  AuthResponse,
+  PolicyDocument,
+} from 'aws-lambda';
+
+// TODO: once Cognito it added, replace this function for one that takes
+// the cognito-group(s) from the Cognito AuthN response, and grabs the
+// corresponding policy(s) from IAM
+// For now: just allow or deny access to the desired function
+function getPolicy(principalId: string, allowAccess: string, resource: string): AuthResponse {
+  const policyDocument: PolicyDocument = {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Action: 'execute-api:Invoke',
+        Effect: allowAccess,
+        Resource: resource,
+      },
+    ],
+  };
+
+  const authResponse: AuthResponse = {
+    principalId: principalId,
+    policyDocument: policyDocument,
+  };
+
+  return authResponse;
+}
+
+// TODO: once Cognito is added, add token validation here, as well
+// as verifying with Cognito that the session is still valid
+function validateToken(token: string, methodArn: string, callback: APIGatewayAuthorizerCallback): void {
+  switch (token) {
+    case 'allow':
+      callback(null, getPolicy('user', 'Allow', methodArn));
+      break;
+    case 'deny':
+      callback(null, getPolicy('user', 'Deny', methodArn));
+      break;
+    case 'unauthorized':
+      callback('Unauthorized'); // Return a 401 Unauthorized response
+      break;
+    default:
+      callback('Error: Invalid token'); // Return a 500 Invalid token response
+  }
+}
+
+// TODO add session management checks
+
+export async function handler(
+  event: APIGatewayTokenAuthorizerEvent,
+  callback: APIGatewayAuthorizerCallback
+): Promise<void> {
+  const token = event.authorizationToken;
+  const methodArn = event.methodArn;
+
+  validateToken(token, methodArn, callback);
+}

--- a/source/dea-app/src/test/lambda-handlers/customLambdaAuthorizer.jest.unit.test.ts
+++ b/source/dea-app/src/test/lambda-handlers/customLambdaAuthorizer.jest.unit.test.ts
@@ -1,0 +1,159 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  APIGatewayAuthorizerCallback,
+  APIGatewayAuthorizerResult,
+  APIGatewayTokenAuthorizerEvent,
+  PolicyDocument,
+} from 'aws-lambda';
+import { handler } from '../../lambda-handlers/custom-lambda-authorizer';
+
+type LambdaResult = APIGatewayAuthorizerResult | Error | string | undefined;
+
+const METHOD_ARN = 'arn:aws:execute-api:us-east-1:account-id:api-id/*/GET/my-cases';
+// TODO: When Cognito is added, mock it to test the logic of the interactions,
+const ALLOW_TOKEN = 'allow';
+const DENY_TOKEN = 'deny';
+const UNAUTHORIZED_TOKEN = 'unauthorized';
+const INVALID_TOKEN = 'aaaabbbbccc';
+
+const ALLOW_POLICY_DOCUMENT: PolicyDocument = {
+  Version: '2012-10-17',
+  Statement: [
+    {
+      Action: 'execute-api:Invoke',
+      Effect: 'Allow',
+      Resource: METHOD_ARN,
+    },
+  ],
+};
+const ALLOW_POLICY_DOCUMENT_STRING = JSON.stringify(ALLOW_POLICY_DOCUMENT);
+
+const DENY_POLICY_DOCUMENT: PolicyDocument = {
+  Version: '2012-10-17',
+  Statement: [
+    {
+      Action: 'execute-api:Invoke',
+      Effect: 'Deny',
+      Resource: METHOD_ARN,
+    },
+  ],
+};
+const DENY_POLICY_DOCUMENT_STRING = JSON.stringify(DENY_POLICY_DOCUMENT);
+
+//this is covered already and provided as an example of jest import mocking
+describe('Unit tests for custom lambda authorizer', () => {
+  it('verifies successful response', async () => {
+    const event: APIGatewayTokenAuthorizerEvent = createEvent(ALLOW_TOKEN);
+
+    let lambdaResult: LambdaResult;
+    const callback: APIGatewayAuthorizerCallback = (
+      error?: Error | string | null,
+      result?: APIGatewayAuthorizerResult
+    ) => {
+      if (result) {
+        lambdaResult = result;
+      } else {
+        lambdaResult = error === null ? undefined : error;
+      }
+    };
+
+    await handler(event, callback);
+
+    expect(isAnAuthResult(lambdaResult)).toBe(true);
+
+    // eslint-disable-next-line
+    const authResult = lambdaResult as APIGatewayAuthorizerResult;
+    expect(authResult.principalId).toEqual('user');
+    expect(JSON.stringify(authResult.policyDocument)).toEqual(ALLOW_POLICY_DOCUMENT_STRING);
+  });
+
+  it('verifies deny response', async () => {
+    const event: APIGatewayTokenAuthorizerEvent = createEvent(DENY_TOKEN);
+
+    let lambdaResult: LambdaResult;
+    const callback: APIGatewayAuthorizerCallback = (
+      error?: Error | string | null,
+      result?: APIGatewayAuthorizerResult
+    ) => {
+      if (result) {
+        lambdaResult = result;
+      } else {
+        lambdaResult = error === null ? undefined : error;
+      }
+    };
+
+    await handler(event, callback);
+
+    expect(isAnAuthResult(lambdaResult)).toBe(true);
+
+    // eslint-disable-next-line
+    const authResult = lambdaResult as APIGatewayAuthorizerResult;
+    expect(authResult.principalId).toEqual('user');
+    expect(JSON.stringify(authResult.policyDocument)).toEqual(DENY_POLICY_DOCUMENT_STRING);
+  });
+
+  it('verifies unauthorized response', async () => {
+    const event: APIGatewayTokenAuthorizerEvent = createEvent(UNAUTHORIZED_TOKEN);
+
+    let lambdaResult: LambdaResult;
+    const callback: APIGatewayAuthorizerCallback = (
+      error?: Error | string | null,
+      result?: APIGatewayAuthorizerResult
+    ) => {
+      if (result) {
+        lambdaResult = result;
+      } else {
+        lambdaResult = error === null ? undefined : error;
+      }
+    };
+
+    await handler(event, callback);
+
+    expect(typeof lambdaResult).toBe('string');
+
+    // eslint-disable-next-line
+    const authResult = lambdaResult as string;
+    expect(lambdaResult).toEqual('Unauthorized');
+  });
+
+  it('verifies invalid token response', async () => {
+    const event: APIGatewayTokenAuthorizerEvent = createEvent(INVALID_TOKEN);
+
+    let lambdaResult: LambdaResult;
+    const callback: APIGatewayAuthorizerCallback = (
+      error?: Error | string | null,
+      result?: APIGatewayAuthorizerResult
+    ) => {
+      if (result) {
+        lambdaResult = result;
+      } else {
+        lambdaResult = error === null ? undefined : error;
+      }
+    };
+
+    await handler(event, callback);
+
+    expect(typeof lambdaResult).toBe('string');
+
+    // eslint-disable-next-line
+    const authResult = lambdaResult as string;
+    expect(lambdaResult).toEqual('Error: Invalid token');
+  });
+});
+
+function createEvent(token: string): APIGatewayTokenAuthorizerEvent {
+  return {
+    type: 'TOKEN',
+    methodArn: METHOD_ARN,
+    authorizationToken: token,
+  };
+}
+
+// eslint-disable-next-line
+function isAnAuthResult(lambdaResult: any): boolean {
+  return 'principalId' in lambdaResult && 'policyDocument' in lambdaResult;
+}

--- a/source/dea-main/src/dea-main-stack.ts
+++ b/source/dea-main/src/dea-main-stack.ts
@@ -54,11 +54,6 @@ export class DeaMainStack extends cdk.Stack {
               'AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs',
           },
           {
-            id: 'W59',
-            reason:
-              'AWSCustomResource Lambda Function does not yet have an AuthorizationType. In development for Custom Lambda Authorizers now.',
-          },
-          {
             id: 'W89',
             reason: 'VPCs are not used for this use case. Custom resource for serving UI',
           },
@@ -92,16 +87,6 @@ export class DeaMainStack extends cdk.Stack {
         .node.findChild('API-Gateway API')
         .node.findChild('Default')
         .node.findChild('ANY').node.defaultChild
-    );
-
-    // Hello API GET Method
-    apiGwMethodArray.push(
-      this.node
-        .findChild('DeaBackendStack')
-        .node.findChild('API-Gateway API')
-        .node.findChild('Default')
-        .node.findChild('hello')
-        .node.findChild('GET').node.defaultChild
     );
 
     // UI API GW

--- a/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
+++ b/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
@@ -125,10 +125,6 @@ Object {
               "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
             },
             Object {
-              "id": "W59",
-              "reason": "AWSCustomResource Lambda Function does not yet have an AuthorizationType. In development for Custom Lambda Authorizers now.",
-            },
-            Object {
               "id": "W89",
               "reason": "VPCs are not used for this use case. Custom resource for serving UI",
             },
@@ -394,7 +390,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "DeaBackendStackAPIGatewayAPIDeployment70A4DC51b1515dbaf4e561841cad390f43f11d3a": Object {
+    "DeaBackendStackAPIGatewayAPIDeployment70A4DC51e728cb017327ac792e04bcaa7a1795aa": Object {
       "DependsOn": Array [
         "DeaBackendStackAPIGatewayAPIproxyANY42138D59",
         "DeaBackendStackAPIGatewayAPIproxy637DBD20",
@@ -425,7 +421,7 @@ Object {
           "Format": "{\\"stage\\":\\"$context.stage\\",\\"requestId\\":\\"$context.requestId\\",\\"integrationRequestId\\":\\"$context.integration.requestId\\",\\"status\\":\\"$context.status\\",\\"apiId\\":\\"$context.apiId\\",\\"resourcePath\\":\\"$context.resourcePath\\",\\"path\\":\\"$context.path\\",\\"resourceId\\":\\"$context.resourceId\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"userAgent\\":\\"$context.identity.userAgent\\"}",
         },
         "DeploymentId": Object {
-          "Ref": "DeaBackendStackAPIGatewayAPIDeployment70A4DC51b1515dbaf4e561841cad390f43f11d3a",
+          "Ref": "DeaBackendStackAPIGatewayAPIDeployment70A4DC51e728cb017327ac792e04bcaa7a1795aa",
         },
         "RestApiId": Object {
           "Ref": "DeaBackendStackAPIGatewayAPI9C81C9B1",
@@ -450,18 +446,11 @@ Object {
       "Type": "AWS::ApiGateway::Resource",
     },
     "DeaBackendStackAPIGatewayAPIhelloGET8F9E5231": Object {
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W59",
-              "reason": "Auth not implemented yet, will revisit",
-            },
-          ],
-        },
-      },
       "Properties": Object {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": Object {
+          "Ref": "DeaBackendStackCustomTokenAuthorizer07087916",
+        },
         "HttpMethod": "GET",
         "Integration": Object {
           "IntegrationHttpMethod": "POST",
@@ -724,6 +713,216 @@ Object {
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
+    },
+    "DeaBackendStackCustomTokenAuthorizer07087916": Object {
+      "Properties": Object {
+        "AuthorizerUri": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Fn::Select": Array [
+                  1,
+                  Object {
+                    "Fn::Split": Array [
+                      ":",
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaBackendStackCustomTokenAuthorizerLambda49B18F02",
+                          "Arn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              ":apigateway:",
+              Object {
+                "Fn::Select": Array [
+                  3,
+                  Object {
+                    "Fn::Split": Array [
+                      ":",
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaBackendStackCustomTokenAuthorizerLambda49B18F02",
+                          "Arn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              ":lambda:path/2015-03-31/functions/",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DeaBackendStackCustomTokenAuthorizerLambda49B18F02",
+                  "Arn",
+                ],
+              },
+              "/invocations",
+            ],
+          ],
+        },
+        "IdentitySource": "method.request.header.Authorization",
+        "Name": "DeaMainStackDeaBackendStackCustomTokenAuthorizerCA94FF39",
+        "RestApiId": Object {
+          "Ref": "DeaBackendStackAPIGatewayAPI9C81C9B1",
+        },
+        "Type": "TOKEN",
+      },
+      "Type": "AWS::ApiGateway::Authorizer",
+    },
+    "DeaBackendStackCustomTokenAuthorizerLambda49B18F02": Object {
+      "DependsOn": Array [
+        "DeaBackendStackCustomTokenAuthorizerLambdalambdarole46C1B623",
+        "DeaBackendStackdeavpcIngressSubnet1RouteTableAssociation58064637",
+        "DeaBackendStackdeavpcIngressSubnet2RouteTableAssociation473345C0",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaBackendStackCustomTokenAuthorizerLambdalambdarole46C1B623",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs16.x",
+        "Timeout": 180,
+        "VpcConfig": Object {
+          "SecurityGroupIds": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "DeaBackendStacktestSecurityGroup29697845",
+                "GroupId",
+              ],
+            },
+          ],
+          "SubnetIds": Array [
+            Object {
+              "Ref": "DeaBackendStackdeavpcIngressSubnet1SubnetABD836F5",
+            },
+            Object {
+              "Ref": "DeaBackendStackdeavpcIngressSubnet2SubnetDD3E1464",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaBackendStackCustomTokenAuthorizerLambdaDeaMainStackDeaBackendStackCustomTokenAuthorizerCA94FF39PermissionsE9CD8833": Object {
+      "DependsOn": Array [
+        "DeaBackendStackdeavpcIngressSubnet1RouteTableAssociation58064637",
+        "DeaBackendStackdeavpcIngressSubnet2RouteTableAssociation473345C0",
+      ],
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaBackendStackCustomTokenAuthorizerLambda49B18F02",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaBackendStackAPIGatewayAPI9C81C9B1",
+              },
+              "/authorizers/",
+              Object {
+                "Ref": "DeaBackendStackCustomTokenAuthorizer07087916",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaBackendStackCustomTokenAuthorizerLambdalambdarole46C1B623": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
     "DeaBackendStackFlowLogB1F9C02F": Object {
       "Properties": Object {


### PR DESCRIPTION
Lambda Authorizer with Basic Authorization. When the Cognito User Pool is added, it will be used for authentication in the Authorizer, and the unit tests will be updated


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
