### PR TITLE
fix: do not cache custom auth policy

### DIFF
--- a/source/dea-backend/src/constructs/dea-rest-api.ts
+++ b/source/dea-backend/src/constructs/dea-rest-api.ts
@@ -214,6 +214,7 @@ export class DeaRestApiConstruct extends Construct {
 
     return new TokenAuthorizer(this, 'CustomTokenAuthorizer', {
       handler: authLambda,
+      resultsCacheTtl: Duration.seconds(0),
     });
   }
 }

--- a/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
+++ b/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
@@ -376,6 +376,7 @@ Object {
     },
     "DeaApiGatewayCustomTokenAuthorizerF6D5E61E": Object {
       "Properties": Object {
+        "AuthorizerResultTtlInSeconds": 0,
         "AuthorizerUri": Object {
           "Fn::Join": Array [
             "",


### PR DESCRIPTION
- currently the policy returned by the authorizer only allows access to the endpoint requested, and as this is cached subsequent requests to different endpoints will be denied as the cached policy is returned. For now don't cache the policy, the authorizer is due to be removed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
