### PR TITLE
test: use local dynamodb instance for persistence tests

### DIFF
--- a/source/common/config/rush/browser-approved-packages.json
+++ b/source/common/config/rush/browser-approved-packages.json
@@ -4,539 +4,547 @@
   "packages": [
     {
       "name": "@aws-cdk/assert",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-cdk/aws-apigatewayv2-alpha",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-cdk/aws-apigatewayv2-authorizers-alpha",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-cdk/aws-apigatewayv2-integrations-alpha",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-cdk/aws-dynamodb",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws-cdk/aws-iam",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-sdk/client-cloudformation",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-sdk/client-cognito-identity-provider",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws-sdk/client-dynamodb",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws-sdk/client-ec2",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws-sdk/client-eventbridge",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws-sdk/client-iam",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws-sdk/client-kms",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws-sdk/client-lambda",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws-sdk/client-s3",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-sdk/client-s3-control",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-sdk/client-sagemaker",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-sdk/client-service-catalog",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-sdk/client-ssm",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-sdk/client-sts",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-sdk/types",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@aws-sdk/util-dynamodb",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws/dea-app",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws/dea-backend",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws/dea-main",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws/dea-ui",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws/dea-ui-infrastructure",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@aws/workbench-core-logging",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@awsui/collection-hooks",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@awsui/components-react",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@awsui/design-tokens",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@awsui/global-styles",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@awsui/test-utils-core",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@babel/core",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@babel/plugin-syntax-dynamic-import",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@babel/plugin-syntax-flow",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@babel/plugin-transform-react-jsx",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@babel/preset-env",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@babel/preset-next",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@babel/preset-react",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@babel/preset-typescript",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@babel/runtime",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@casl/ability",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@cloudscape-design/collection-hooks",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@cloudscape-design/components",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@cloudscape-design/design-tokens",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@cloudscape-design/global-styles",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@cloudscape-design/jest-preset",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@hapi/boom",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@microsoft/rush-lib",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@rushstack/eslint-config",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@rushstack/heft",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@rushstack/heft-jest-plugin",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@rushstack/heft-node-rig",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@rushstack/heft-web-rig",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@rushstack/heft-webpack5-plugin",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@rushstack/node-core-library",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@rushstack/ts-command-line",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "@testing-library/dom",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@testing-library/jest-dom",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@testing-library/react",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "@testing-library/user-event",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "aws-cdk",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "aws-cdk-lib",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "aws-jwt-verify",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "aws-lambda",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "aws-sdk-client-mock",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "axios",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "babel-jest",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "babel-loader",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "babel-preset-next",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "cdk-ssm-document",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "concurrently",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "constructs",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "cookie-parser",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "cors",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "csrf",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "csurf",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "cypress",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "date-fns",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "depcheck",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "diff",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
+    },
+    {
+      "name": "dynamo-db-local",
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "dynamodb-onetable",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "esbuild",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "eslint",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "eslint-config-next",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "eslint-plugin-import",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "eslint-plugin-security",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "eslint-plugin-testing-library",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "fast-check",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "generate-password",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "i18next",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "istanbul-badges-readme",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "jest",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "jest-circus",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "jest-fast-check",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "joi",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "js-yaml",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "jwt-decode",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "license-check-and-add",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "license-checker",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "lodash",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "lodash.kebabcase",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "md5-file",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "next",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "next-compose-plugins",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "next-global-css",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "next-i18next",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "next-transpile-modules",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "nodemon",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "npm-package-json-lint",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "npm-package-json-lint-config-default",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "pkce-challenge",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "react",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "react-dom",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "react-i18next",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "react-scripts",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "sass",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "sharp",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "sort-package-json",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "source-map-support",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "swr",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "triple-beam",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "ts-jest",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "ts-mockito",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "ts-node",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "tslib",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "typescript",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
     },
     {
       "name": "uuid",
-      "allowedCategories": ["production", "prototypes"]
+      "allowedCategories": [ "production", "prototypes" ]
+    },
+    {
+      "name": "wait-port",
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "web-vitals",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "webpack",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "winston",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "winston-transport",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "zod",
-      "allowedCategories": ["production"]
+      "allowedCategories": [ "production" ]
     }
   ]
 }

--- a/source/common/config/rush/pnpm-lock.yaml
+++ b/source/common/config/rush/pnpm-lock.yaml
@@ -33,6 +33,7 @@ importers:
       cookie-parser: ^1.4.6
       cors: ^2.8.5
       depcheck: ^1.4.3
+      dynamo-db-local: ~4.1.4
       dynamodb-onetable: ~2.5.1
       eslint: ^8.7.0
       eslint-plugin-import: ^2.26.0
@@ -51,6 +52,7 @@ importers:
       ts-mockito: ~2.6.1
       typescript: ^4.5.2
       uuid: ^8.3.2
+      wait-port: ~1.0.4
     dependencies:
       '@aws-sdk/client-dynamodb': 3.204.0
       '@aws-sdk/client-s3': 3.204.0
@@ -81,6 +83,7 @@ importers:
       concurrently: 7.5.0
       constructs: 10.0.5
       depcheck: 1.4.3
+      dynamo-db-local: 4.1.4
       dynamodb-onetable: 2.5.1
       eslint: 8.27.0
       eslint-plugin-import: 2.26.0_eslint@8.27.0
@@ -97,6 +100,7 @@ importers:
       ts-jest: 27.1.5_3e98952c91d0ad38e7beba6fb8181295
       ts-mockito: 2.6.1
       typescript: 4.8.4
+      wait-port: 1.0.4
 
   ../../dea-backend:
     specifiers:
@@ -5410,6 +5414,11 @@ packages:
     resolution: {integrity: sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==}
     dev: false
 
+  /commander/9.4.1:
+    resolution: {integrity: sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==}
+    engines: {node: ^12.20.0 || >=14}
+    dev: true
+
   /concat-map/0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
@@ -5801,6 +5810,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       webidl-conversions: 5.0.0
+    dev: true
+
+  /dynamo-db-local/4.1.4:
+    resolution: {integrity: sha512-5UU3VLJSiaFeM7VzRbhzenLFeKApkCFd6fh13sl3NBSVJ71QmmC1AjWZ0/Zfe5cFK+DTqv2RAxw15A7TnJCqAw==}
+    engines: {node: '>=12.20.1'}
     dev: true
 
   /dynamodb-onetable/2.5.1:
@@ -10639,6 +10653,18 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       xml-name-validator: 3.0.0
+    dev: true
+
+  /wait-port/1.0.4:
+    resolution: {integrity: sha512-w8Ftna3h6XSFWWc2JC5gZEgp64nz8bnaTp5cvzbJSZ53j+omktWTDdwXxEF0jM8YveviLgFWvNGrSvRHnkyHyw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      commander: 9.4.1
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /walker/1.0.8:

--- a/source/dea-app/README.md
+++ b/source/dea-app/README.md
@@ -5,6 +5,6 @@
 # Code Coverage
 | Statements                  | Branches                | Functions                 | Lines             |
 | --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://img.shields.io/badge/statements-51.43%25-red.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-33.87%25-red.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-52.83%25-red.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-48.92%25-red.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-53.91%25-red.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-32.3%25-red.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-58.18%25-red.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-51.4%25-red.svg?style=flat) |
 
 This project is the routing package for `dea-backend`. It is used by `dea-backend` to generate routes for DEA API. Please refer  [here](../dea-backend/README.md) for more information on how to use this project.

--- a/source/dea-app/config/jest.config.json
+++ b/source/dea-app/config/jest.config.json
@@ -9,5 +9,10 @@
       "statements": 70
     }
   },
-  "coverageReporters": ["json-summary", "json"]
+  "coverageReporters": [
+    "json-summary",
+    "json"
+  ],
+  "globalSetup": "<rootDir>/src/test/local-dynamo/setup.ts",
+  "globalTeardown": "<rootDir>/src/test/local-dynamo/teardown.ts"
 }

--- a/source/dea-app/package.json
+++ b/source/dea-app/package.json
@@ -63,6 +63,7 @@
     "concurrently": "^7.0.0",
     "constructs": "10.0.5",
     "depcheck": "^1.4.3",
+    "dynamo-db-local": "~4.1.4",
     "dynamodb-onetable": "~2.5.1",
     "eslint": "^8.7.0",
     "eslint-plugin-import": "^2.26.0",
@@ -78,6 +79,7 @@
     "sort-package-json": "^1.57.0",
     "ts-jest": "^27.1.3",
     "ts-mockito": "~2.6.1",
-    "typescript": "^4.5.2"
+    "typescript": "^4.5.2",
+    "wait-port": "~1.0.4"
   }
 }

--- a/source/dea-app/src/app/services/case-service.ts
+++ b/source/dea-app/src/app/services/case-service.ts
@@ -1,3 +1,8 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
 import { DeaCase } from '../../models/case';
 import { CaseStatus } from '../../models/case-status';
 import { createCase, updateCase } from '../../persistence/case';

--- a/source/dea-app/src/persistence/schema/dea-schema.ts
+++ b/source/dea-app/src/persistence/schema/dea-schema.ts
@@ -16,7 +16,7 @@ export const DeaSchema = {
   indexes: {
     primary: { hash: 'PK', sort: 'SK' },
     GSI1: { hash: 'GSI1PK', sort: 'GSI1SK', follow: false },
-    GSI2: { hash: 'GSI2PK', sort: 'GSI2PK', follow: false },
+    GSI2: { hash: 'GSI2PK', sort: 'GSI2SK', follow: false },
   },
   models: {
     Case: {
@@ -36,7 +36,7 @@ export const DeaSchema = {
       SK: { type: String, value: 'CASE#${caseUlid}#', required: true },
       // gsi1 enable list all users for a case, sorted by firstName, lastName
       GSI1PK: { type: String, value: 'CASE#${caseUlid}#' },
-      GSI1SK: { type: String, value: 'USER#${lowerFirstName}#${lowerLastName}#${userUlid}' },
+      GSI1SK: { type: String, value: 'USER#${userFirstNameLower}#${userLastNameLower}#${userUlid}#' },
       // gsi2 enable list all cases for a user, sorted by case name
       GSI2PK: { type: String, value: 'USER#${userUlid}#' },
       GSI2SK: { type: String, value: 'CASE#${lowerCaseName}#' },
@@ -44,6 +44,7 @@ export const DeaSchema = {
       userUlid: { type: String, validate: ulidMatch, required: true },
       actions: { type: Array, items: { type: String, enum: Object.keys(CaseAction), required: true } },
       caseName: { type: String, required: true },
+      lowerCaseName: { type: String, required: true },
       userFirstName: { type: String, required: true },
       userLastName: { type: String, required: true },
       userFirstNameLower: { type: String, required: true },

--- a/source/dea-app/src/persistence/user.ts
+++ b/source/dea-app/src/persistence/user.ts
@@ -84,3 +84,15 @@ export const updateUser = async (
 
     return userFromEntity(newEntity);
 };
+
+export const deleteUser = async (
+    ulid: string,
+    repositoryProvider: UserModelRepositoryProvider = {
+        UserModel: UserModel,
+    }
+): Promise<void> => {
+    await repositoryProvider.UserModel.remove({
+        PK: `USER#${ulid}#`,
+        SK: `USER#`,
+    });
+}

--- a/source/dea-app/src/test/custom-types/dynamo-db-local.d.ts
+++ b/source/dea-app/src/test/custom-types/dynamo-db-local.d.ts
@@ -1,0 +1,14 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ChildProcess } from "child_process";
+
+declare module 'dynamo-db-local';
+
+export declare class DbLocal {
+    spawn({port: number}): ChildProcess;
+}
+export declare const dbLocal: DbLocal
+export default dbLocal

--- a/source/dea-app/src/test/local-dynamo/setup.ts
+++ b/source/dea-app/src/test/local-dynamo/setup.ts
@@ -1,0 +1,43 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import DynamoDbLocal from 'dynamo-db-local';
+import { Dynamo } from 'dynamodb-onetable/Dynamo';
+import waitPort from "wait-port";
+
+const PORT = parseInt(process.env.PORT || '4567');
+export const dynamoTestClient = new Dynamo({
+    client: new DynamoDBClient({
+        endpoint: `http://localhost:${PORT}`,
+        region: 'local',
+        credentials: {
+            accessKeyId: 'test',
+            secretAccessKey: 'test',
+        },
+
+    })
+});
+
+const setup = async (): Promise<void> => {
+    const dynamodb = DynamoDbLocal.spawn({ port: PORT })
+    await waitPort({
+        host: '0.0.0.0',
+        port: PORT,
+        timeout: 10000,
+    });
+
+    process.env.DYNAMODB_PID = String(dynamodb.pid)
+    process.env.DYNAMODB_PORT = String(PORT)
+
+    process.on('unhandledRejection', () => {
+        if (process.env.DYNAMODB_PID) {
+            const pid = parseInt(process.env.DYNAMODB_PID)
+            process.kill(pid)
+        }
+    });
+};
+
+export default setup;

--- a/source/dea-app/src/test/local-dynamo/teardown.ts
+++ b/source/dea-app/src/test/local-dynamo/teardown.ts
@@ -1,0 +1,14 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+
+const teardown = (): void => {
+    if (process.env.DYNAMODB_PID) {
+        const pid = parseInt(process.env.DYNAMODB_PID)
+        process.kill(pid)
+    }
+}
+
+export default teardown;

--- a/source/dea-app/src/test/persistence/local-db-table.ts
+++ b/source/dea-app/src/test/persistence/local-db-table.ts
@@ -1,0 +1,22 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Table } from "dynamodb-onetable";
+import { DeaSchema } from "../../persistence/schema/dea-schema";
+import { dynamoTestClient } from "../local-dynamo/setup";
+
+export const initLocalDb = async (tableName: string): Promise<Table> => {
+
+    const testTable = new Table({
+        client: dynamoTestClient,
+        name: tableName,
+        schema: DeaSchema,
+        partial: false,
+    });
+
+    await testTable.createTable();
+
+    return testTable;
+}

--- a/source/dea-app/tsconfig.json
+++ b/source/dea-app/tsconfig.json
@@ -5,7 +5,11 @@
   "compilerOptions": {
     "strict": true,
     "types": ["heft-jest", "node"],
-    "lib": ["es2020", "dom"]
+    "lib": ["es2020", "dom"],
+    "baseUrl": "./",
+    "paths": {
+      "*": ["src/test/custom-types/*"]
+    }
   },
   "exclude": ["node_modules", "lib"]
 }


### PR DESCRIPTION
- add dynamo-db-local for persistence layer unit tests
- fix some schema errors
- refactor user and case user tests to utilize the new local database


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
