### PR TITLE
ci: add cdk steps to github actions

### DIFF
--- a/.github/cdkCFExecutionPolicy.json
+++ b/.github/cdkCFExecutionPolicy.json
@@ -1,0 +1,36 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "apigateway:*",
+        "cloudwatch:*",
+        "cognito-identity:*",
+        "cognito-idp:*",
+        "cognito-sync:*",
+        "dynamodb:*",
+        "kms:*",
+        "lambda:*",
+        "logs:*",
+        "s3:*",
+        "ssm:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:*Role*",
+        "iam:GetPolicy",
+        "iam:CreatePolicy",
+        "iam:DeletePolicy",
+        "iam:*PolicyVersion*"
+      ],
+      "NotResource": [
+        "arn:aws:iam::*:role/cdk-*",
+        "arn:aws:iam::*:policy/cdkCFExecutionPolicy"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -11,8 +11,12 @@ on:
       - reopened
       - synchronize
 
+permissions:
+      id-token: write   # This is required for requesting the JWT
+      contents: read    # This is required for actions/checkout
 jobs:
   verify:
+    environment: dea-test
     defaults:
       run:
         shell: bash
@@ -22,8 +26,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
       - name: Viperlight Scan
         run: node common/scripts/install-run-rush.js viperlight-scan
       - name: Install
@@ -50,6 +52,21 @@ jobs:
       - name: cfn_nag warning check
         run: |
           ! grep -C 3 'WARN\|FAIL' cfn_nag.out
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: GITHUBACTIONSESSION
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: cdk deploy
+        run: |
+          cd dea-main
+          STAGE=test npm run cdk deploy
       - name: Rush Test
         run: |
           node common/scripts/install-run-rush.js test:only
+      - name: cdk destroy
+        if: always()
+        run: |
+          cd dea-main
+          STAGE=test npm run cdk destroy

--- a/source/dea-main/cdk.json
+++ b/source/dea-main/cdk.json
@@ -1,4 +1,5 @@
 {
+  "requireApproval": "never",
   "app": "lib/index.js",
   "watch": {
     "include": ["**"],


### PR DESCRIPTION
- add cdk deploy and destroy to github actions
- included json for custom CDK execution policy (the default policy uses AdministratorAccess)
- Details:
  - CDK bootstrap is run manually once by a developer to create CDKToolkit stack
  - A role is created in the test account which github can assume, the only permissions on this role allows for sts:assume on the CDK generated roles. The role has a trust policy using the Github OIDC provider configured within the account, scoped to this repo


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
