### PR TITLE
refactor: remove unnecessary bucket name and prefix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Digital Evidence Archive on AWS enables Law Enforcement organizations to ingest 
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-97.32%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.71%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.77%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.54%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-97.32%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.71%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.8%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.54%25-brightgreen.svg?style=flat) |
 
 
 ## Project Setup

--- a/source/dea-backend/src/constants.ts
+++ b/source/dea-backend/src/constants.ts
@@ -14,9 +14,6 @@ function getConstants(): {
   AWS_REGION: string;
   SSM_DOC_OUTPUT_KEY_SUFFIX: string;
   S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY: string;
-  S3_ACCESS_BUCKET_PREFIX: string;
-  S3_UI_ACCESS_LOG_PREFIX: string;
-  S3_DATASETS_ACCESS_LOG_PREFIX: string;
   S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY: string;
   S3_DATASETS_BUCKET_ARN_OUTPUT_KEY: string;
   S3_ARTIFACT_BUCKET_SC_PREFIX: string;
@@ -51,9 +48,6 @@ function getConstants(): {
     const SC_PORTFOLIO_NAME = `dea-${config.stage}-${config.awsRegionShortName}`; // Service Catalog Portfolio Name
     const AWS_REGION = config.awsRegion;
     const AWS_REGION_SHORT_NAME = config.awsRegionShortName;
-    const S3_ACCESS_BUCKET_PREFIX = 'dea-access-log';
-    const S3_UI_ACCESS_LOG_PREFIX = 'dea-ui-access-log';
-    const S3_DATASETS_ACCESS_LOG_PREFIX = 'dea-datasets-access-log';
     const S3_ARTIFACT_BUCKET_SC_PREFIX = 'dea-catalog-cfn-templates/';
     const S3_ARTIFACT_BUCKET_BOOTSTRAP_PREFIX = 'environment-files/'; // Location of env bootstrap scripts in the artifacts bucket
     const ROOT_USER_EMAIL = config.rootUserEmail;
@@ -90,9 +84,6 @@ function getConstants(): {
       AWS_REGION,
       SSM_DOC_OUTPUT_KEY_SUFFIX,
       S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY,
-      S3_ACCESS_BUCKET_PREFIX,
-      S3_UI_ACCESS_LOG_PREFIX,
-      S3_DATASETS_ACCESS_LOG_PREFIX,
       S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY,
       S3_DATASETS_BUCKET_ARN_OUTPUT_KEY,
       S3_ARTIFACT_BUCKET_SC_PREFIX,

--- a/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
+++ b/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
@@ -32,7 +32,7 @@ describe('DeaBackend constructs', () => {
     });
 
     // Create the DeaBackendConstruct
-    const backend = new DeaBackendConstruct(stack, 'DeaBackendConstruct', { kmsKey: key });
+    const backend = new DeaBackendConstruct(stack, 'DeaBackendConstruct', { kmsKey: key, accessLogsPrefixes: ['dea-ui-access-log'] });
     new DeaRestApiConstruct(stack, 'DeaRestApiConstruct', {
       deaTableArn: backend.deaTable.tableArn,
       kmsKey: key,

--- a/source/dea-main/src/dea-main-stack.ts
+++ b/source/dea-main/src/dea-main-stack.ts
@@ -30,8 +30,9 @@ export class DeaMainStack extends cdk.Stack {
     // Create KMS key to pass into backend and UI
     const kmsKey = this._createEncryptionKey();
 
+    const uiAccessLogPrefix = 'dea-ui-access-log';
     // DEA Backend Construct
-    const backendConstruct = new DeaBackendConstruct(this, 'DeaBackendStack', { kmsKey: kmsKey });
+    const backendConstruct = new DeaBackendConstruct(this, 'DeaBackendStack', { kmsKey: kmsKey, accessLogsPrefixes: [uiAccessLogPrefix]});
 
     const region = this.region;
     const accountId = this.account;
@@ -58,6 +59,7 @@ export class DeaMainStack extends cdk.Stack {
       kmsKey: kmsKey,
       restApi: deaApi.deaRestApi,
       accessLogsBucket: backendConstruct.accessLogsBucket,
+      accessLogPrefix: uiAccessLogPrefix,
     });
 
     // Stack node resource handling

--- a/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
+++ b/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
@@ -156,7 +156,7 @@ Object {
         "Handler": "index.handler",
         "Layers": Array [
           Object {
-            "Ref": "DeaUiStackDeaUiStackdeploymentbucketAwsCliLayerE6B55D5A",
+            "Ref": "DeaUiStackartifactdeploymentbucketAwsCliLayer760BCEFB",
           },
         ],
         "Role": Object {
@@ -263,7 +263,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaUiStackDeaUiStackbucket2409F549",
+                    "DeaUiStackartifactbucketFFC87A37",
                     "Arn",
                   ],
                 },
@@ -273,7 +273,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "DeaUiStackDeaUiStackbucket2409F549",
+                          "DeaUiStackartifactbucketFFC87A37",
                           "Arn",
                         ],
                       },
@@ -330,7 +330,7 @@ Object {
             Array [
               "Lambda function for auto-deleting objects in ",
               Object {
-                "Ref": "DeaUiStackDeaUiStackbucket2409F549",
+                "Ref": "DeaUiStackartifactbucketFFC87A37",
               },
               " S3 bucket.",
             ],
@@ -903,7 +903,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::UsagePlan",
     },
-    "DeaApiGatewaydeaapiDeployment99E77629611b937b3689e4aca4f2810c24650f2e": Object {
+    "DeaApiGatewaydeaapiDeployment99E7762903ef90daea52e277dfc950661ebbf256": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeaapibyeGETD2EE08E8",
         "DeaApiGatewaydeaapibyeOPTIONSC9B258C6",
@@ -959,7 +959,7 @@ Object {
           "Format": "{\\"stage\\":\\"$context.stage\\",\\"requestId\\":\\"$context.requestId\\",\\"integrationRequestId\\":\\"$context.integration.requestId\\",\\"status\\":\\"$context.status\\",\\"apiId\\":\\"$context.apiId\\",\\"resourcePath\\":\\"$context.resourcePath\\",\\"path\\":\\"$context.path\\",\\"resourceId\\":\\"$context.resourceId\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"userAgent\\":\\"$context.identity.userAgent\\"}",
         },
         "DeploymentId": Object {
-          "Ref": "DeaApiGatewaydeaapiDeployment99E77629611b937b3689e4aca4f2810c24650f2e",
+          "Ref": "DeaApiGatewaydeaapiDeployment99E7762903ef90daea52e277dfc950661ebbf256",
         },
         "RestApiId": Object {
           "Ref": "DeaApiGatewaydeaapi822A9228",
@@ -2537,7 +2537,7 @@ Object {
                 },
                 ":s3:path/",
                 Object {
-                  "Ref": "DeaUiStackDeaUiStackbucket2409F549",
+                  "Ref": "DeaUiStackartifactbucketFFC87A37",
                 },
                 "/index.html",
               ],
@@ -2675,7 +2675,7 @@ Object {
                 },
                 ":s3:path/",
                 Object {
-                  "Ref": "DeaUiStackDeaUiStackbucket2409F549",
+                  "Ref": "DeaUiStackartifactbucketFFC87A37",
                 },
                 "/{proxy}",
               ],
@@ -4135,7 +4135,26 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "DeaUiStackDeaUiStackbucket2409F549": Object {
+    "DeaUiStackartifactbucketAutoDeleteObjectsCustomResource3D6F178A": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DeaUiStackartifactbucketPolicy4886C807",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DeaUiStackartifactbucketFFC87A37",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeaUiStackartifactbucketFFC87A37": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "AccessControl": "LogDeliveryWrite",
@@ -4166,7 +4185,7 @@ Object {
             "Value": "true",
           },
           Object {
-            "Key": "aws-cdk:cr-owned:debec8f9",
+            "Key": "aws-cdk:cr-owned:51fb81a3",
             "Value": "true",
           },
         ],
@@ -4177,29 +4196,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "DeaUiStackDeaUiStackbucketAutoDeleteObjectsCustomResource59A9A4D8": Object {
-      "DeletionPolicy": "Delete",
-      "DependsOn": Array [
-        "DeaUiStackDeaUiStackbucketPolicy3F40F0AF",
-      ],
-      "Properties": Object {
-        "BucketName": Object {
-          "Ref": "DeaUiStackDeaUiStackbucket2409F549",
-        },
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::S3AutoDeleteObjects",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "DeaUiStackDeaUiStackbucketPolicy3F40F0AF": Object {
+    "DeaUiStackartifactbucketPolicy4886C807": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "DeaUiStackDeaUiStackbucket2409F549",
+          "Ref": "DeaUiStackartifactbucketFFC87A37",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -4221,7 +4221,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaUiStackDeaUiStackbucket2409F549",
+                    "DeaUiStackartifactbucketFFC87A37",
                     "Arn",
                   ],
                 },
@@ -4231,7 +4231,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "DeaUiStackDeaUiStackbucket2409F549",
+                          "DeaUiStackartifactbucketFFC87A37",
                           "Arn",
                         ],
                       },
@@ -4255,7 +4255,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaUiStackDeaUiStackbucket2409F549",
+                    "DeaUiStackartifactbucketFFC87A37",
                     "Arn",
                   ],
                 },
@@ -4265,7 +4265,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "DeaUiStackDeaUiStackbucket2409F549",
+                          "DeaUiStackartifactbucketFFC87A37",
                           "Arn",
                         ],
                       },
@@ -4293,7 +4293,7 @@ Object {
                   Array [
                     Object {
                       "Fn::GetAtt": Array [
-                        "DeaUiStackDeaUiStackbucket2409F549",
+                        "DeaUiStackartifactbucketFFC87A37",
                         "Arn",
                       ],
                     },
@@ -4309,7 +4309,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "DeaUiStackDeaUiStackdeploymentbucketAwsCliLayerE6B55D5A": Object {
+    "DeaUiStackartifactdeploymentbucketAwsCliLayer760BCEFB": Object {
       "Properties": Object {
         "Content": Object {
           "S3Bucket": Object {
@@ -4321,11 +4321,11 @@ Object {
       },
       "Type": "AWS::Lambda::LayerVersion",
     },
-    "DeaUiStackDeaUiStackdeploymentbucketCustomResource5769B150": Object {
+    "DeaUiStackartifactdeploymentbucketCustomResourceC6B8B11C": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "DestinationBucketName": Object {
-          "Ref": "DeaUiStackDeaUiStackbucket2409F549",
+          "Ref": "DeaUiStackartifactbucketFFC87A37",
         },
         "Prune": true,
         "ServiceToken": Object {
@@ -4384,7 +4384,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaUiStackDeaUiStackbucket2409F549",
+                    "DeaUiStackartifactbucketFFC87A37",
                     "Arn",
                   ],
                 },
@@ -4394,7 +4394,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "DeaUiStackDeaUiStackbucket2409F549",
+                          "DeaUiStackartifactbucketFFC87A37",
                           "Arn",
                         ],
                       },

--- a/source/dea-ui/infrastructure/src/constants.ts
+++ b/source/dea-ui/infrastructure/src/constants.ts
@@ -12,12 +12,8 @@ function getConstants(): {
   API_BASE_URL: string;
   AWS_REGION: string;
   STACK_NAME: string;
-  S3_ACCESS_LOGS_BUCKET_PREFIX: string;
-  S3_UI_ACCESS_LOG_PREFIX: string;
   S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY: string;
   S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY: string;
-  S3_ARTIFACT_BUCKET_NAME: string;
-  S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME: string;
 } {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const config: any = yaml.load(
@@ -31,10 +27,7 @@ function getConstants(): {
   const API_BASE_URL = config.apiUrlOutput?.replace('/dev/', '') || '';
   const AWS_REGION = config.awsRegion;
   const STACK_NAME = namePrefix;
-  const S3_ARTIFACT_BUCKET_NAME = `${namePrefix}-bucket`;
-  const S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME = `${namePrefix}-deployment-bucket`;
-  const S3_ACCESS_LOGS_BUCKET_PREFIX = 'dea-access-log';
-  const S3_UI_ACCESS_LOG_PREFIX = 'dea-ui-access-log';
+
 
   // CloudFormation Output Keys
   const S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY = 'S3BucketArtifactsArnOutput';
@@ -45,12 +38,8 @@ function getConstants(): {
     API_BASE_URL,
     AWS_REGION,
     STACK_NAME,
-    S3_ACCESS_LOGS_BUCKET_PREFIX,
-    S3_UI_ACCESS_LOG_PREFIX,
     S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY,
     S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY,
-    S3_ARTIFACT_BUCKET_NAME,
-    S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME,
   };
 }
 

--- a/source/dea-ui/infrastructure/src/dea-ui-stack.ts
+++ b/source/dea-ui/infrastructure/src/dea-ui-stack.ts
@@ -25,53 +25,28 @@ import { Construct } from 'constructs';
 import { getConstants } from './constants';
 
 interface IUiStackProps extends StackProps {
-  kmsKey: Key;
-  restApi: RestApi;
-  accessLogsBucket: Bucket;
+  readonly kmsKey: Key;
+  readonly restApi: RestApi;
+  readonly accessLogsBucket: Bucket;
+  readonly accessLogPrefix: string;
 }
 
 export class DeaUiConstruct extends Construct {
-  public distributionEnvVars: {
-    STAGE: string;
-    STACK_NAME: string;
-    API_BASE_URL: string;
-    AWS_REGION: string;
-    S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY: string;
-    S3_ARTIFACT_BUCKET_NAME: string;
-    S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME: string;
-  };
 
   // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
   constructor(scope: Construct, id: string, props: IUiStackProps) {
     const {
-      STAGE,
       STACK_NAME,
-      API_BASE_URL,
-      AWS_REGION,
-      S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY,
-      S3_ARTIFACT_BUCKET_NAME,
-      S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME,
-      S3_UI_ACCESS_LOG_PREFIX,
     } = getConstants();
     super(scope, STACK_NAME);
 
-    this.distributionEnvVars = {
-      STAGE,
-      STACK_NAME,
-      API_BASE_URL,
-      AWS_REGION,
-      S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY,
-      S3_ARTIFACT_BUCKET_NAME,
-      S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME,
-    };
-
-    const bucket = new Bucket(this, S3_ARTIFACT_BUCKET_NAME, {
+    const bucket = new Bucket(this, 'artifact-bucket', {
       accessControl: BucketAccessControl.LOG_DELIVERY_WRITE,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       websiteIndexDocument: 'index.html',
       encryption: BucketEncryption.S3_MANAGED,
       serverAccessLogsBucket: props.accessLogsBucket,
-      serverAccessLogsPrefix: S3_UI_ACCESS_LOG_PREFIX,
+      serverAccessLogsPrefix: props.accessLogPrefix,
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
     });
@@ -79,7 +54,7 @@ export class DeaUiConstruct extends Construct {
     this._addS3TLSSigV4BucketPolicy(bucket);
 
     // eslint-disable-next-line no-new
-    new BucketDeployment(this, this.distributionEnvVars.S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME, {
+    new BucketDeployment(this, 'artifact-deployment-bucket', {
       destinationBucket: bucket,
       sources: [Source.asset(path.resolve(__dirname, '../../ui/out'))],
     });

--- a/source/dea-ui/infrastructure/src/test/infra/__snapshots__/dea-ui-infra-construct.unit.test.ts.snap
+++ b/source/dea-ui/infrastructure/src/test/infra/__snapshots__/dea-ui-infra-construct.unit.test.ts.snap
@@ -53,7 +53,7 @@ Object {
         "Handler": "index.handler",
         "Layers": Array [
           Object {
-            "Ref": "DeaUiStackDeaUiStackdeploymentbucketAwsCliLayerE6B55D5A",
+            "Ref": "DeaUiStackartifactdeploymentbucketAwsCliLayer760BCEFB",
           },
         ],
         "Role": Object {
@@ -160,7 +160,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaUiStackDeaUiStackbucket2409F549",
+                    "DeaUiStackartifactbucketFFC87A37",
                     "Arn",
                   ],
                 },
@@ -170,7 +170,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "DeaUiStackDeaUiStackbucket2409F549",
+                          "DeaUiStackartifactbucketFFC87A37",
                           "Arn",
                         ],
                       },
@@ -209,7 +209,7 @@ Object {
             Array [
               "Lambda function for auto-deleting objects in ",
               Object {
-                "Ref": "DeaUiStackDeaUiStackbucket2409F549",
+                "Ref": "DeaUiStackartifactbucketFFC87A37",
               },
               " S3 bucket.",
             ],
@@ -250,7 +250,26 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "DeaUiStackDeaUiStackbucket2409F549": Object {
+    "DeaUiStackartifactbucketAutoDeleteObjectsCustomResource3D6F178A": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DeaUiStackartifactbucketPolicy4886C807",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DeaUiStackartifactbucketFFC87A37",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeaUiStackartifactbucketFFC87A37": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "AccessControl": "LogDeliveryWrite",
@@ -281,7 +300,7 @@ Object {
             "Value": "true",
           },
           Object {
-            "Key": "aws-cdk:cr-owned:fb025039",
+            "Key": "aws-cdk:cr-owned:b197ded3",
             "Value": "true",
           },
         ],
@@ -292,29 +311,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "DeaUiStackDeaUiStackbucketAutoDeleteObjectsCustomResource59A9A4D8": Object {
-      "DeletionPolicy": "Delete",
-      "DependsOn": Array [
-        "DeaUiStackDeaUiStackbucketPolicy3F40F0AF",
-      ],
-      "Properties": Object {
-        "BucketName": Object {
-          "Ref": "DeaUiStackDeaUiStackbucket2409F549",
-        },
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::S3AutoDeleteObjects",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "DeaUiStackDeaUiStackbucketPolicy3F40F0AF": Object {
+    "DeaUiStackartifactbucketPolicy4886C807": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "DeaUiStackDeaUiStackbucket2409F549",
+          "Ref": "DeaUiStackartifactbucketFFC87A37",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -336,7 +336,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaUiStackDeaUiStackbucket2409F549",
+                    "DeaUiStackartifactbucketFFC87A37",
                     "Arn",
                   ],
                 },
@@ -346,7 +346,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "DeaUiStackDeaUiStackbucket2409F549",
+                          "DeaUiStackartifactbucketFFC87A37",
                           "Arn",
                         ],
                       },
@@ -370,7 +370,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaUiStackDeaUiStackbucket2409F549",
+                    "DeaUiStackartifactbucketFFC87A37",
                     "Arn",
                   ],
                 },
@@ -380,7 +380,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "DeaUiStackDeaUiStackbucket2409F549",
+                          "DeaUiStackartifactbucketFFC87A37",
                           "Arn",
                         ],
                       },
@@ -408,7 +408,7 @@ Object {
                   Array [
                     Object {
                       "Fn::GetAtt": Array [
-                        "DeaUiStackDeaUiStackbucket2409F549",
+                        "DeaUiStackartifactbucketFFC87A37",
                         "Arn",
                       ],
                     },
@@ -424,7 +424,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "DeaUiStackDeaUiStackdeploymentbucketAwsCliLayerE6B55D5A": Object {
+    "DeaUiStackartifactdeploymentbucketAwsCliLayer760BCEFB": Object {
       "Properties": Object {
         "Content": Object {
           "S3Bucket": Object {
@@ -436,11 +436,11 @@ Object {
       },
       "Type": "AWS::Lambda::LayerVersion",
     },
-    "DeaUiStackDeaUiStackdeploymentbucketCustomResource5769B150": Object {
+    "DeaUiStackartifactdeploymentbucketCustomResourceC6B8B11C": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "DestinationBucketName": Object {
-          "Ref": "DeaUiStackDeaUiStackbucket2409F549",
+          "Ref": "DeaUiStackartifactbucketFFC87A37",
         },
         "Prune": true,
         "ServiceToken": Object {
@@ -499,7 +499,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaUiStackDeaUiStackbucket2409F549",
+                    "DeaUiStackartifactbucketFFC87A37",
                     "Arn",
                   ],
                 },
@@ -509,7 +509,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "DeaUiStackDeaUiStackbucket2409F549",
+                          "DeaUiStackartifactbucketFFC87A37",
                           "Arn",
                         ],
                       },
@@ -587,7 +587,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "testApiDeployment3727A0B911a3d6f3089853cb0ac40dd95a583e66": Object {
+    "testApiDeployment3727A0B9fad01d0f612a090752eb1a8cd3905bfc": Object {
       "DependsOn": Array [
         "testApiuiproxyGET92230E90",
         "testApiuiproxyDDF9EC1E",
@@ -608,7 +608,7 @@ Object {
       ],
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "testApiDeployment3727A0B911a3d6f3089853cb0ac40dd95a583e66",
+          "Ref": "testApiDeployment3727A0B9fad01d0f612a090752eb1a8cd3905bfc",
         },
         "RestApiId": Object {
           "Ref": "testApiD6ECAB50",
@@ -674,7 +674,7 @@ Object {
                 },
                 ":s3:path/",
                 Object {
-                  "Ref": "DeaUiStackDeaUiStackbucket2409F549",
+                  "Ref": "DeaUiStackartifactbucketFFC87A37",
                 },
                 "/index.html",
               ],
@@ -761,7 +761,7 @@ Object {
                 },
                 ":s3:path/",
                 Object {
-                  "Ref": "DeaUiStackDeaUiStackbucket2409F549",
+                  "Ref": "DeaUiStackartifactbucketFFC87A37",
                 },
                 "/{proxy}",
               ],

--- a/source/dea-ui/infrastructure/src/test/infra/dea-ui-infra-construct.unit.test.ts
+++ b/source/dea-ui/infrastructure/src/test/infra/dea-ui-infra-construct.unit.test.ts
@@ -38,7 +38,7 @@ describe('DeaMainStack', () => {
 
     const restApi = new RestApi(stack, 'testApi', { description: 'Backend API' });
 
-    new DeaUiConstruct(stack, 'DeaUiConstruct', { kmsKey: key, accessLogsBucket: accessLogsBucket, restApi });
+    new DeaUiConstruct(stack, 'DeaUiConstruct', { kmsKey: key, accessLogsBucket: accessLogsBucket, restApi, accessLogPrefix: 'dea-ui-access-log' });
 
     // Prepare the stack for assertions.
     const template = Template.fromStack(stack);


### PR DESCRIPTION
Context: Incrementally remove constants.ts config uses where they can be better served with an alternate approach

- remove unnecessary config:
  - bucket names
  - access log prefixes
- remove duplicated stack prefix 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
