### PR TITLE
feat: add cognito domain prefix to cdk deploy

### DIFF
--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -3,6 +3,7 @@ name: Pull Request Workflow
 env:
   CONFIGNAME: 'chewbacca'
   STAGE: RUN${{github.run_number}}
+  DOMAIN_PREFIX: deatestenv
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Digital Evidence Archive on AWS enables Law Enforcement organizations to ingest 
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-97.41%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-86.78%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-92.75%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.6%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-97.51%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-87.43%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-92.83%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.71%25-brightgreen.svg?style=flat) |
 
 
 ## Project Setup

--- a/source/common/config/chewbacca.json
+++ b/source/common/config/chewbacca.json
@@ -1,5 +1,6 @@
 {
   "stage": "chewbacca",
+  "testStack": true,
   "userGroups": [
     {
       "name": "CaseWorkerGroup",

--- a/source/common/config/rush/pnpm-lock.yaml
+++ b/source/common/config/rush/pnpm-lock.yaml
@@ -306,6 +306,7 @@ importers:
 
   ../../dea-ui/infrastructure:
     specifiers:
+      '@aws/dea-backend': workspace:*
       '@rushstack/eslint-config': ^3.0.0
       '@rushstack/heft': ^0.48.8
       '@rushstack/heft-jest-plugin': ^0.3.28
@@ -332,6 +333,7 @@ importers:
       ts-node: ^10.4.0
       typescript: ^4.5.2
     dependencies:
+      '@aws/dea-backend': link:../../dea-backend
       js-yaml: 4.1.0
     devDependencies:
       '@rushstack/eslint-config': 3.1.1_eslint@8.27.0+typescript@4.8.4

--- a/source/dea-app/README.md
+++ b/source/dea-app/README.md
@@ -5,7 +5,7 @@
 
 | Statements                                                                         | Branches                                                                      | Functions                                                                        | Lines                                                                   |
 | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-99.23%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.55%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-99.13%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-99.23%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-84.44%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-99.13%25-brightgreen.svg?style=flat) |
 
 
 This project is the routing package for `dea-backend`. It is used by `dea-backend` to generate routes for DEA API. Please refer [here](../dea-backend/README.md) for more information on how to use this project.

--- a/source/dea-app/setEnv.sh
+++ b/source/dea-app/setEnv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-PREFIX="${STAGE:-chewbacca}"
-export DEA_API_URL=$(aws cloudformation list-exports --region us-east-1 --query """Exports[?Name == '${PREFIX}-deaApiUrl'].Value | [0]""" | sed -e 's/^"//' -e 's/"$//') 
-export IDENTITY_POOL_ID=$(aws cloudformation list-exports --region us-east-1 --query """Exports[?Name == '${PREFIX}-identityPoolId'].Value | [0]""" | sed -e 's/^"//' -e 's/"$//') 
-export USER_POOL_ID=$(aws cloudformation list-exports --region us-east-1 --query """Exports[?Name == '${PREFIX}-userPoolId'].Value | [0]""" | sed -e 's/^"//' -e 's/"$//') 
-export USER_POOL_CLIENT_ID=$(aws cloudformation list-exports --region us-east-1 --query """Exports[?Name == '${PREFIX}-userPoolClientId'].Value | [0]""" | sed -e 's/^"//' -e 's/"$//')
+STACKPREFIX="${STAGE:-chewbacca}"
+export DEA_API_URL=$(aws cloudformation list-exports --region us-east-1 --query """Exports[?Name == '${STACKPREFIX}-deaApiUrl'].Value | [0]""" | sed -e 's/^"//' -e 's/"$//') 
+export IDENTITY_POOL_ID=$(aws cloudformation list-exports --region us-east-1 --query """Exports[?Name == '${STACKPREFIX}-identityPoolId'].Value | [0]""" | sed -e 's/^"//' -e 's/"$//') 
+export USER_POOL_ID=$(aws cloudformation list-exports --region us-east-1 --query """Exports[?Name == '${STACKPREFIX}-userPoolId'].Value | [0]""" | sed -e 's/^"//' -e 's/"$//') 
+export USER_POOL_CLIENT_ID=$(aws cloudformation list-exports --region us-east-1 --query """Exports[?Name == '${STACKPREFIX}-userPoolClientId'].Value | [0]""" | sed -e 's/^"//' -e 's/"$//')

--- a/source/dea-app/src/test-e2e/auth/auth.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/auth/auth.e2e.test.ts
@@ -5,15 +5,15 @@
 import { aws4Interceptor } from 'aws4-axios';
 import axios from 'axios';
 import CognitoHelper from '../helpers/cognito-helper';
-import { envSettings } from '../helpers/settings';
+import { testEnv } from '../helpers/settings';
 import { callDeaAPI } from '../resources/test-helpers';
 
 describe('API authentication', () => {
   const cognitoHelper: CognitoHelper = new CognitoHelper();
 
   const testUser = 'authE2ETestUser';
-  const deaApiUrl = envSettings.apiUrlOutput;
-  const region = envSettings.awsRegion;
+  const deaApiUrl = testEnv.apiUrlOutput;
+  const region = testEnv.awsRegion;
 
   beforeAll(async () => {
     // Create user in test group

--- a/source/dea-app/src/test-e2e/helpers/cognito-helper.ts
+++ b/source/dea-app/src/test-e2e/helpers/cognito-helper.ts
@@ -24,7 +24,7 @@ import { Credentials } from 'aws4-axios';
 import { getTokenPayload } from '../../cognito-token-helpers';
 import { ModelRepositoryProvider } from '../../persistence/schema/entities';
 import { deleteUser, getUserByTokenId } from '../../persistence/user';
-import { envSettings } from './settings';
+import { testEnv } from './settings';
 
 export default class CognitoHelper {
   private _identityPoolClient: CognitoIdentityClient;
@@ -39,10 +39,10 @@ export default class CognitoHelper {
   private _testPassword: string;
 
   public constructor() {
-    this._region = envSettings.awsRegion;
-    this._userPoolId = envSettings.userPoolId;
-    this._userPoolClientId = envSettings.clientId;
-    this._identityPoolId = envSettings.identityPoolId;
+    this._region = testEnv.awsRegion;
+    this._userPoolId = testEnv.userPoolId;
+    this._userPoolClientId = testEnv.clientId;
+    this._identityPoolId = testEnv.identityPoolId;
 
     this._idpUrl = `cognito-idp.${this._region}.amazonaws.com/${this._userPoolId}`;
 

--- a/source/dea-app/src/test-e2e/helpers/settings.ts
+++ b/source/dea-app/src/test-e2e/helpers/settings.ts
@@ -7,9 +7,10 @@ const throwUnset = (varName: string) => {
   throw new Error(`Required ENV ${varName} is not set.`);
 };
 
-export const envSettings = {
+export const testEnv = {
   stage: process.env.STAGE ?? 'chewbacca',
   awsRegion: process.env.AWS_REGION ?? 'us-east-1',
+  domainName: process.env.DOMAIN_PREFIX ?? throwUnset('DOMAIN_PREFIX'),
   apiUrlOutput: process.env.DEA_API_URL ?? throwUnset('DEA_API_URL'),
   identityPoolId: process.env.IDENTITY_POOL_ID ?? throwUnset('IDENTITY_POOL_ID'),
   userPoolId: process.env.USER_POOL_ID ?? throwUnset('USER_POOL_ID'),

--- a/source/dea-app/src/test-e2e/resources/create-cases.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/create-cases.e2e.test.ts
@@ -6,20 +6,20 @@
 import { fail } from 'assert';
 import { CaseStatus } from '../../models/case-status';
 import CognitoHelper from '../helpers/cognito-helper';
-import { envSettings } from '../helpers/settings';
+import { testEnv } from '../helpers/settings';
 import { callDeaAPI, callDeaAPIWithCreds, createCaseSuccess, deleteCase } from './test-helpers';
 
 describe('create cases api', () => {
   const cognitoHelper = new CognitoHelper();
 
   const testUser = 'createCaseTestUser';
-  const deaApiUrl = envSettings.apiUrlOutput;
+  const deaApiUrl = testEnv.apiUrlOutput;
 
   const caseIdsToDelete: string[] = [];
 
   beforeAll(async () => {
     // Create user in test group
-    await cognitoHelper.createUser(testUser, 'CreateCasesTestGroup', "CreateCases", "TestUser");
+    await cognitoHelper.createUser(testUser, 'CreateCasesTestGroup', 'CreateCases', 'TestUser');
   });
 
   afterAll(async () => {
@@ -31,7 +31,7 @@ describe('create cases api', () => {
   }, 30000);
 
   it('should create a new case', async () => {
-    const [creds, idToken]  = await cognitoHelper.getCredentialsForUser(testUser);
+    const [creds, idToken] = await cognitoHelper.getCredentialsForUser(testUser);
 
     const caseName = 'CASE B';
 
@@ -50,13 +50,13 @@ describe('create cases api', () => {
   }, 30000);
 
   it('should give an error when payload is missing', async () => {
-    const response = await callDeaAPI(testUser, `${deaApiUrl}cases`, cognitoHelper, "POST", undefined);
+    const response = await callDeaAPI(testUser, `${deaApiUrl}cases`, cognitoHelper, 'POST', undefined);
 
     expect(response.status).toEqual(400);
   });
 
   it('should give an error when the name is in use', async () => {
-    const [creds, idToken]  = await cognitoHelper.getCredentialsForUser(testUser);
+    const [creds, idToken] = await cognitoHelper.getCredentialsForUser(testUser);
 
     const caseName = 'CASE C';
     const createdCase = await createCaseSuccess(
@@ -72,12 +72,11 @@ describe('create cases api', () => {
 
     caseIdsToDelete.push(createdCase.ulid ?? fail());
 
-    const response = await callDeaAPIWithCreds(`${deaApiUrl}cases`, "POST", idToken, creds,
-      {
-        name: caseName,
-        status: 'ACTIVE',
-        description: 'any description',
-      });
+    const response = await callDeaAPIWithCreds(`${deaApiUrl}cases`, 'POST', idToken, creds, {
+      name: caseName,
+      status: 'ACTIVE',
+      description: 'any description',
+    });
 
     expect(response.status).toEqual(500);
   }, 30000);

--- a/source/dea-app/src/test-e2e/resources/get-all-cases.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/get-all-cases.e2e.test.ts
@@ -8,14 +8,14 @@ import { DeaCase } from '../../models/case';
 import { CaseStatus } from '../../models/case-status';
 import { caseResponseSchema } from '../../models/validation/case';
 import CognitoHelper from '../helpers/cognito-helper';
-import { envSettings } from '../helpers/settings';
+import { testEnv } from '../helpers/settings';
 import { callDeaAPIWithCreds, createCaseSuccess, deleteCase } from './test-helpers';
 
 describe('get all cases api', () => {
   const cognitoHelper = new CognitoHelper();
 
   const testUser = 'getAllCasesTestUser';
-  const deaApiUrl = envSettings.apiUrlOutput;
+  const deaApiUrl = testEnv.apiUrlOutput;
 
   const caseIdsToDelete: string[] = [];
 

--- a/source/dea-app/src/test-e2e/resources/get-case-details.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/get-case-details.e2e.test.ts
@@ -9,14 +9,14 @@ import { DeaCase } from '../../models/case';
 import { CaseStatus } from '../../models/case-status';
 import { caseResponseSchema } from '../../models/validation/case';
 import CognitoHelper from '../helpers/cognito-helper';
-import { envSettings } from '../helpers/settings';
+import { testEnv } from '../helpers/settings';
 import { callDeaAPIWithCreds, createCaseSuccess, deleteCase } from './test-helpers';
 
 describe('get case api', () => {
   const cognitoHelper: CognitoHelper = new CognitoHelper();
 
   const testUser = 'getCaseE2ETestUser';
-  const deaApiUrl = envSettings.apiUrlOutput;
+  const deaApiUrl = testEnv.apiUrlOutput;
 
   beforeAll(async () => {
     // Create user in test group

--- a/source/dea-app/src/test-e2e/resources/test-helpers.ts
+++ b/source/dea-app/src/test-e2e/resources/test-helpers.ts
@@ -8,7 +8,7 @@ import Joi from 'joi';
 import { DeaCase } from '../../models/case';
 import { caseResponseSchema } from '../../models/validation/case';
 import CognitoHelper from '../helpers/cognito-helper';
-import { envSettings } from '../helpers/settings';
+import { testEnv } from '../helpers/settings';
 
 // we don't want axios throwing an exception on non 200 codes
 export const validateStatus = () => true;
@@ -76,7 +76,7 @@ export async function callDeaAPIWithCreds(
   const interceptor = aws4Interceptor(
     {
       service: 'execute-api',
-      region: envSettings.awsRegion,
+      region: testEnv.awsRegion,
     },
     creds
   );

--- a/source/dea-app/src/test/app/resources/lambda-preexecution-checks.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/lambda-preexecution-checks.integration.test.ts
@@ -10,7 +10,7 @@ import { DeaUser } from '../../../models/user';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
 import { getUserByTokenId, listUsers } from '../../../persistence/user';
 import CognitoHelper from '../../../test-e2e/helpers/cognito-helper';
-import { envSettings } from '../../../test-e2e/helpers/settings';
+import { testEnv } from '../../../test-e2e/helpers/settings';
 import { dummyContext, dummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
@@ -22,7 +22,7 @@ describe('lambda pre-execution checks', () => {
   const testUser = 'lambdaPreExecutionChecksTestUser';
   const firstName = 'PreExecCheck';
   const lastName = 'TestUser';
-  const region = envSettings.awsRegion;
+  const region = testEnv.awsRegion;
 
   beforeAll(async () => {
     await cognitoHelper.createUser(testUser, 'AuthTestGroup', firstName, lastName);

--- a/source/dea-app/src/test/cognito-token-helpers.integration.test.ts
+++ b/source/dea-app/src/test/cognito-token-helpers.integration.test.ts
@@ -5,7 +5,7 @@
 
 import { getDeaUserFromToken, getTokenPayload } from '../cognito-token-helpers';
 import CognitoHelper from '../test-e2e/helpers/cognito-helper';
-import { envSettings } from '../test-e2e/helpers/settings';
+import { testEnv } from '../test-e2e/helpers/settings';
 
 describe('cognito helpers integration test', () => {
   const cognitoHelper: CognitoHelper = new CognitoHelper();
@@ -13,7 +13,7 @@ describe('cognito helpers integration test', () => {
   const testUser = 'cognitoHelpersIntegrationTestUser';
   const firstName = 'CognitoTokenHelper';
   const lastName = 'TestUser';
-  const region = envSettings.awsRegion;
+  const region = testEnv.awsRegion;
 
   beforeAll(async () => {
     // Create user in test group

--- a/source/dea-app/src/test/persistence/user.unit.test.ts
+++ b/source/dea-app/src/test/persistence/user.unit.test.ts
@@ -67,11 +67,9 @@ describe('user persistence', () => {
     const lastName = 'Machio';
     const tokenId = 'ralphamachio';
 
-
     const firstName2 = 'Randy';
     const lastName2 = 'Savage';
     const tokenId2 = 'randysavage';
-
 
     const user1 = await createUser({ tokenId, firstName, lastName }, modelProvider);
     const user2 = await createUser(
@@ -115,8 +113,8 @@ describe('user persistence', () => {
 
     expect(actual.values).toEqual(expectedUsers.values);
 
-    deleteAndVerifyUser(user1.ulid, modelProvider);
-    deleteAndVerifyUser(user2.ulid, modelProvider);
+    await deleteAndVerifyUser(user1.ulid, modelProvider);
+    await deleteAndVerifyUser(user2.ulid, modelProvider);
   });
 
   it('should update a user', async () => {
@@ -127,7 +125,7 @@ describe('user persistence', () => {
     const updatedLastName = 'Van Winkle';
 
     const deaUser: DeaUser = {
-    tokenId,
+      tokenId,
       firstName,
       lastName,
     };

--- a/source/dea-backend/README.md
+++ b/source/dea-backend/README.md
@@ -6,7 +6,7 @@
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-99.62%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-90.47%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-99.61%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-100%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-93.33%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-100%25-brightgreen.svg?style=flat) |
 
 
 ## Useful commands

--- a/source/dea-backend/src/index.ts
+++ b/source/dea-backend/src/index.ts
@@ -10,6 +10,15 @@ import { createCfnOutput } from './constructs/construct-support';
 import { DeaAuthConstruct } from './constructs/dea-auth';
 import { DeaBackendConstruct } from './constructs/dea-backend-stack';
 import { DeaRestApiConstruct } from './constructs/dea-rest-api';
+import { addSnapshotSerializers } from './test/infra/dea-snapshot-serializers';
 import { validateBackendConstruct } from './test/infra/validate-backend-construct';
 
-export { DeaAuthConstruct, DeaBackendConstruct, DeaRestApiConstruct, deaConfig, validateBackendConstruct, createCfnOutput };
+export {
+  DeaAuthConstruct,
+  DeaBackendConstruct,
+  DeaRestApiConstruct,
+  deaConfig,
+  validateBackendConstruct,
+  createCfnOutput,
+  addSnapshotSerializers,
+};

--- a/source/dea-backend/src/test/config.unit.test.ts
+++ b/source/dea-backend/src/test/config.unit.test.ts
@@ -3,12 +3,13 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { deaConfig, loadConfig } from '../config';
+import { RemovalPolicy } from 'aws-cdk-lib';
+import { convictConfig, deaConfig, loadConfig } from '../config';
 
 describe('convict based config', () => {
   it('loads configuration from the stage', () => {
-    expect(deaConfig.cognitoDomain()).toBeUndefined();
     expect(deaConfig.region()).toBeDefined();
+    expect(deaConfig.retainPolicy()).toEqual(RemovalPolicy.DESTROY);
 
     expect(deaConfig.userGroups()).toEqual(
       expect.arrayContaining([
@@ -68,5 +69,20 @@ describe('convict based config', () => {
     expect(() => {
       loadConfig('invalid2');
     }).toThrow('endpoints: must be of type Array: value was "InvalidEndpoints"');
+  });
+
+  it('throws an error for invalid domain config', () => {
+    expect(() => {
+      // need the any here because convict doesn't resolve the type properly -.-
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const badName: any = 'Domain_';
+      convictConfig.set('cognito.domain', badName);
+      convictConfig.validate({ allowed: 'strict' });
+    }).toThrow('Cognito domain may only contain lowercase alphanumerics and hyphens.');
+  });
+
+  it('returns a destroy policy when non-test', () => {
+    convictConfig.set('testStack', false);
+    expect(deaConfig.retainPolicy()).toEqual(RemovalPolicy.RETAIN);
   });
 });

--- a/source/dea-backend/src/test/infra/__snapshots__/dea-auth.unit.test.ts.snap
+++ b/source/dea-backend/src/test/infra/__snapshots__/dea-auth.unit.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DeaBackend constructs synthesizes the way we expect 1`] = `
+exports[`DeaAuth constructs synthesizes the way we expect 1`] = `
 Object {
   "Outputs": Object {
     "DeaAuthidentityPoolIdEBA0D0C1": Object {
@@ -317,6 +317,17 @@ Object {
       "Type": "AWS::Cognito::UserPool",
       "UpdateReplacePolicy": "Delete",
     },
+    "DeaAuthDEAUserPoolCognitoDomainAB9C904A": Object {
+      "Properties": Object {
+        "Domain": Object {
+          "Ref": "DeaAuth[DOMAIN-REMOVED][HASH REMOVED]",
+        },
+        "UserPoolId": Object {
+          "Ref": "DeaAuthDEAUserPool22DB2BAB",
+        },
+      },
+      "Type": "AWS::Cognito::UserPoolDomain",
+    },
     "DeaAuthDEAUserPooldeaappclient3742F9D7": Object {
       "Properties": Object {
         "AccessTokenValidity": 720,
@@ -568,6 +579,15 @@ Object {
         },
       },
       "Type": "AWS::Cognito::IdentityPoolRoleAttachment",
+    },
+    "DeaAuth[DOMAIN-REMOVED][HASH REMOVED]": Object {
+      "Properties": Object {
+        "Domain": "[DOMAIN-REMOVED]",
+        "UserPoolId": Object {
+          "Ref": "DeaAuthDEAUserPool22DB2BAB",
+        },
+      },
+      "Type": "AWS::Cognito::UserPoolDomain",
     },
     "DeaAuthuserpoolclientidssmparam605B45CC": Object {
       "Properties": Object {

--- a/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
+++ b/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
@@ -83,6 +83,64 @@ Object {
     },
   },
   "Resources": Object {
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
+      "DependsOn": Array [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Lambda function for auto-deleting objects in ",
+              Object {
+                "Ref": "DeaBackendConstructS3AccessLogsBucket2074272F",
+              },
+              " S3 bucket.",
+            ],
+          ],
+        },
+        "Handler": "__entrypoint__.handler",
+        "MemorySize": 128,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "DeaBackendConstructDeaTableB48721A0": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
@@ -175,7 +233,7 @@ Object {
       "UpdateReplacePolicy": "Delete",
     },
     "DeaBackendConstructS3AccessLogsBucket2074272F": Object {
-      "DeletionPolicy": "Retain",
+      "DeletionPolicy": "Delete",
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -203,9 +261,34 @@ Object {
           "IgnorePublicAcls": true,
           "RestrictPublicBuckets": true,
         },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
       },
       "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeaBackendConstructS3AccessLogsBucketAutoDeleteObjectsCustomResource6EDC2642": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DeaBackendConstructS3AccessLogsBucketPolicy55BD9984",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DeaBackendConstructS3AccessLogsBucket2074272F",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
     },
     "DeaBackendConstructS3AccessLogsBucketPolicy55BD9984": Object {
       "Properties": Object {
@@ -224,6 +307,44 @@ Object {
               "Effect": "Deny",
               "Principal": Object {
                 "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaBackendConstructS3AccessLogsBucket2074272F",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaBackendConstructS3AccessLogsBucket2074272F",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
               },
               "Resource": Array [
                 Object {
@@ -298,8 +419,27 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
+    "DeaBackendConstructS3DatasetsBucketAutoDeleteObjectsCustomResource5386F212": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DeaBackendConstructS3DatasetsBucketPolicyA1DF7E5A",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
     "DeaBackendConstructS3DatasetsBucketDDF4C58A": Object {
-      "DeletionPolicy": "Retain",
+      "DeletionPolicy": "Delete",
       "Properties": Object {
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
@@ -341,12 +481,18 @@ Object {
           "IgnorePublicAcls": true,
           "RestrictPublicBuckets": true,
         },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
         "VersioningConfiguration": Object {
           "Status": "Enabled",
         },
       },
       "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
     },
     "DeaBackendConstructS3DatasetsBucketPolicyA1DF7E5A": Object {
       "Properties": Object {
@@ -365,6 +511,44 @@ Object {
               "Effect": "Deny",
               "Principal": Object {
                 "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
               },
               "Resource": Array [
                 Object {

--- a/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
+++ b/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
@@ -8,9 +8,9 @@ import { Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import 'source-map-support/register';
-import { deaConfig } from '../../config';
 import { DeaBackendConstruct } from '../../constructs/dea-backend-stack';
 import { DeaRestApiConstruct } from '../../constructs/dea-rest-api';
+import { addSnapshotSerializers } from './dea-snapshot-serializers';
 import { validateBackendConstruct } from './validate-backend-construct';
 
 describe('DeaBackend constructs', () => {
@@ -57,27 +57,10 @@ describe('DeaBackend constructs', () => {
     });
 
     //handlers
-    template.resourceCountIs('AWS::Lambda::Function', 9);
+    template.resourceCountIs('AWS::Lambda::Function', 10);
     template.resourceCountIs('AWS::ApiGateway::Method', 17);
 
-    expect.addSnapshotSerializer({
-      test: (val) => typeof val === 'string' && val.includes('zip'),
-      print: (val) => {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const newVal = (val as string).replace(/([A-Fa-f0-9]{64})/, '[HASH REMOVED]');
-        return `"${newVal}"`;
-      },
-    });
-
-    expect.addSnapshotSerializer({
-      test: (val) => typeof val === 'string' && val.includes(deaConfig.stage()),
-      print: (val) => {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const newVal1 = (val as string).replace(deaConfig.stage(), '[STAGE-REMOVED]');
-        const newVal = newVal1.replace(/([A-Fa-f0-9]{8})/, '[HASH REMOVED]');
-        return `"${newVal}"`;
-      },
-    });
+    addSnapshotSerializers();
 
     expect(template).toMatchSnapshot();
   });

--- a/source/dea-backend/src/test/infra/dea-snapshot-serializers.ts
+++ b/source/dea-backend/src/test/infra/dea-snapshot-serializers.ts
@@ -1,0 +1,40 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { deaConfig } from '../../config';
+
+export const addSnapshotSerializers = (): void => {
+  expect.addSnapshotSerializer({
+    test: (val) => typeof val === 'string' && val.includes('zip'),
+    print: (val) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const newVal = (val as string).replace(/([A-Fa-f0-9]{64})/, '[HASH REMOVED]');
+      return `"${newVal}"`;
+    },
+  });
+
+  expect.addSnapshotSerializer({
+    test: (val) => typeof val === 'string' && val.includes(deaConfig.stage()),
+    print: (val) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const newVal1 = (val as string).replace(deaConfig.stage(), '[STAGE-REMOVED]');
+      const newVal = newVal1.replace(/([A-Fa-f0-9]{8})/, '[HASH REMOVED]');
+      return `"${newVal}"`;
+    },
+  });
+
+  const domain = deaConfig.cognitoDomain();
+  if (domain) {
+    expect.addSnapshotSerializer({
+      test: (val) => typeof val === 'string' && val.includes(domain),
+      print: (val) => {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const newVal1 = (val as string).replace(domain, '[DOMAIN-REMOVED]');
+        const newVal = newVal1.replace(/([A-Fa-f0-9]{8})/, '[HASH REMOVED]');
+        return `"${newVal}"`;
+      },
+    });
+  }
+};

--- a/source/dea-main/src/dea-main-stack.ts
+++ b/source/dea-main/src/dea-main-stack.ts
@@ -4,18 +4,24 @@
  */
 
 /* eslint-disable no-new */
-import { createCfnOutput, DeaAuthConstruct, DeaBackendConstruct, DeaRestApiConstruct } from '@aws/dea-backend';
+import {
+  createCfnOutput,
+  DeaAuthConstruct,
+  DeaBackendConstruct,
+  deaConfig,
+  DeaRestApiConstruct,
+} from '@aws/dea-backend';
 import { DeaUiConstruct } from '@aws/dea-ui-infrastructure';
 import * as cdk from 'aws-cdk-lib';
 
-import { CfnResource, Duration, RemovalPolicy } from 'aws-cdk-lib';
+import { CfnResource, Duration } from 'aws-cdk-lib';
 import { CfnMethod } from 'aws-cdk-lib/aws-apigateway';
 import {
   AccountPrincipal,
   Effect,
   PolicyDocument,
   PolicyStatement,
-  ServicePrincipal
+  ServicePrincipal,
 } from 'aws-cdk-lib/aws-iam';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { CfnFunction } from 'aws-cdk-lib/aws-lambda';
@@ -32,7 +38,10 @@ export class DeaMainStack extends cdk.Stack {
 
     const uiAccessLogPrefix = 'dea-ui-access-log';
     // DEA Backend Construct
-    const backendConstruct = new DeaBackendConstruct(this, 'DeaBackendStack', { kmsKey: kmsKey, accessLogsPrefixes: [uiAccessLogPrefix]});
+    const backendConstruct = new DeaBackendConstruct(this, 'DeaBackendStack', {
+      kmsKey: kmsKey,
+      accessLogsPrefixes: [uiAccessLogPrefix],
+    });
 
     const region = this.region;
     const accountId = this.account;
@@ -119,7 +128,7 @@ export class DeaMainStack extends cdk.Stack {
     const key = new Key(this, 'primaryCustomerKey', {
       enableKeyRotation: true,
       policy: mainKeyPolicy,
-      removalPolicy: RemovalPolicy.DESTROY,
+      removalPolicy: deaConfig.retainPolicy(),
       pendingWindow: Duration.days(7),
     });
 

--- a/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
+++ b/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
@@ -336,7 +336,7 @@ Object {
             Array [
               "Lambda function for auto-deleting objects in ",
               Object {
-                "Ref": "DeaUiStackartifactbucketFFC87A37",
+                "Ref": "DeaBackendStackS3AccessLogsBucket46FDD3E0",
               },
               " S3 bucket.",
             ],
@@ -3482,6 +3482,17 @@ Object {
       "Type": "AWS::Cognito::UserPool",
       "UpdateReplacePolicy": "Delete",
     },
+    "DeaAuthDEAUserPoolCognitoDomainAB9C904A": Object {
+      "Properties": Object {
+        "Domain": Object {
+          "Ref": "DeaAuth[DOMAIN-REMOVED][HASH REMOVED]",
+        },
+        "UserPoolId": Object {
+          "Ref": "DeaAuthDEAUserPool22DB2BAB",
+        },
+      },
+      "Type": "AWS::Cognito::UserPoolDomain",
+    },
     "DeaAuthDEAUserPooldeaappclient3742F9D7": Object {
       "Properties": Object {
         "AccessTokenValidity": 720,
@@ -3820,6 +3831,15 @@ Object {
       },
       "Type": "AWS::Cognito::IdentityPoolRoleAttachment",
     },
+    "DeaAuth[DOMAIN-REMOVED][HASH REMOVED]": Object {
+      "Properties": Object {
+        "Domain": "[DOMAIN-REMOVED]",
+        "UserPoolId": Object {
+          "Ref": "DeaAuthDEAUserPool22DB2BAB",
+        },
+      },
+      "Type": "AWS::Cognito::UserPoolDomain",
+    },
     "DeaAuthuserpoolclientidssmparam605B45CC": Object {
       "Properties": Object {
         "AllowedPattern": ".*",
@@ -3938,7 +3958,7 @@ Object {
       "UpdateReplacePolicy": "Delete",
     },
     "DeaBackendStackS3AccessLogsBucket46FDD3E0": Object {
-      "DeletionPolicy": "Retain",
+      "DeletionPolicy": "Delete",
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -3966,9 +3986,34 @@ Object {
           "IgnorePublicAcls": true,
           "RestrictPublicBuckets": true,
         },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
       },
       "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeaBackendStackS3AccessLogsBucketAutoDeleteObjectsCustomResource54474E78": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DeaBackendStackS3AccessLogsBucketPolicyCF6769D3",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DeaBackendStackS3AccessLogsBucket46FDD3E0",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
     },
     "DeaBackendStackS3AccessLogsBucketPolicyCF6769D3": Object {
       "Properties": Object {
@@ -3987,6 +4032,44 @@ Object {
               "Effect": "Deny",
               "Principal": Object {
                 "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaBackendStackS3AccessLogsBucket46FDD3E0",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaBackendStackS3AccessLogsBucket46FDD3E0",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
               },
               "Resource": Array [
                 Object {
@@ -4062,7 +4145,7 @@ Object {
       "Type": "AWS::S3::BucketPolicy",
     },
     "DeaBackendStackS3DatasetsBucket408FF954": Object {
-      "DeletionPolicy": "Retain",
+      "DeletionPolicy": "Delete",
       "Properties": Object {
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
@@ -4104,12 +4187,37 @@ Object {
           "IgnorePublicAcls": true,
           "RestrictPublicBuckets": true,
         },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
         "VersioningConfiguration": Object {
           "Status": "Enabled",
         },
       },
       "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeaBackendStackS3DatasetsBucketAutoDeleteObjectsCustomResource4F25360D": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DeaBackendStackS3DatasetsBucketPolicy328F21B8",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
     },
     "DeaBackendStackS3DatasetsBucketPolicy328F21B8": Object {
       "Properties": Object {
@@ -4128,6 +4236,44 @@ Object {
               "Effect": "Deny",
               "Principal": Object {
                 "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaBackendStackS3DatasetsBucket408FF954",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaBackendStackS3DatasetsBucket408FF954",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
               },
               "Resource": Array [
                 Object {

--- a/source/dea-main/src/test/dea-main-stack.unit.test.ts
+++ b/source/dea-main/src/test/dea-main-stack.unit.test.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { deaConfig, validateBackendConstruct } from '@aws/dea-backend';
+import { addSnapshotSerializers, validateBackendConstruct } from '@aws/dea-backend';
 import { validateDeaUiConstruct } from '@aws/dea-ui-infrastructure';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
@@ -11,22 +11,12 @@ import 'source-map-support/register';
 import { DeaMainStack } from '../dea-main-stack';
 
 describe('DeaMainStack', () => {
-  beforeAll(() => {
-    process.env.STAGE = 'chewbacca';
-  });
-
-  afterAll(() => {
-    delete process.env.STAGE;
-  });
-
   it('synthesizes the way we expect', () => {
     const app = new cdk.App();
 
     // Create the DeaMainStack
     const deaMainStack = new DeaMainStack(app, 'DeaMainStack', {});
 
-    // TODO
-    // Prepare the stack for assertions.
     const template = Template.fromStack(deaMainStack);
 
     validateBackendConstruct(template);
@@ -34,24 +24,7 @@ describe('DeaMainStack', () => {
     // Assert it creates the api with the correct properties...
     validateDeaUiConstruct(template);
 
-    expect.addSnapshotSerializer({
-      test: (val) => typeof val === 'string' && val.includes('zip'),
-      print: (val) => {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const newVal = (val as string).replace(/([A-Fa-f0-9]{64})/, '[HASH REMOVED]');
-        return `"${newVal}"`;
-      },
-    });
-
-    expect.addSnapshotSerializer({
-      test: (val) => typeof val === 'string' && val.includes(deaConfig.stage()),
-      print: (val) => {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const newVal1 = (val as string).replace(deaConfig.stage(), '[STAGE-REMOVED]');
-        const newVal = newVal1.replace(/([A-Fa-f0-9]{8})/, '[HASH REMOVED]');
-        return `"${newVal}"`;
-      },
-    });
+    addSnapshotSerializers();
 
     expect(template).toMatchSnapshot();
   });

--- a/source/dea-ui/infrastructure/package.json
+++ b/source/dea-ui/infrastructure/package.json
@@ -35,6 +35,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
+    "@aws/dea-backend": "workspace:*",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {

--- a/source/dea-ui/infrastructure/src/dea-ui-stack.ts
+++ b/source/dea-ui/infrastructure/src/dea-ui-stack.ts
@@ -4,22 +4,19 @@
  */
 /* eslint-disable no-new */
 import * as path from 'path';
-import { RemovalPolicy, StackProps } from 'aws-cdk-lib';
+import { deaConfig } from '@aws/dea-backend';
+import { StackProps } from 'aws-cdk-lib';
 import {
-  AwsIntegration, ContentHandling,
+  AwsIntegration,
+  ContentHandling,
   MethodOptions,
   Model,
   PassthroughBehavior,
-  RestApi
+  RestApi,
 } from 'aws-cdk-lib/aws-apigateway';
 import { AnyPrincipal, Effect, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Key } from 'aws-cdk-lib/aws-kms';
-import {
-  BlockPublicAccess,
-  Bucket,
-  BucketAccessControl,
-  BucketEncryption
-} from 'aws-cdk-lib/aws-s3';
+import { BlockPublicAccess, Bucket, BucketAccessControl, BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
 
@@ -31,7 +28,6 @@ interface IUiStackProps extends StackProps {
 }
 
 export class DeaUiConstruct extends Construct {
-
   public constructor(scope: Construct, id: string, props: IUiStackProps) {
     super(scope, 'DeaUiStack');
 
@@ -42,8 +38,8 @@ export class DeaUiConstruct extends Construct {
       encryption: BucketEncryption.S3_MANAGED,
       serverAccessLogsBucket: props.accessLogsBucket,
       serverAccessLogsPrefix: props.accessLogPrefix,
-      removalPolicy: RemovalPolicy.DESTROY,
-      autoDeleteObjects: true,
+      removalPolicy: deaConfig.retainPolicy(),
+      autoDeleteObjects: deaConfig.isTestStack(),
     });
 
     this._addS3TLSSigV4BucketPolicy(bucket);

--- a/source/dea-ui/infrastructure/src/test/infra/dea-ui-infra-construct.unit.test.ts
+++ b/source/dea-ui/infrastructure/src/test/infra/dea-ui-infra-construct.unit.test.ts
@@ -3,6 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
+import { addSnapshotSerializers } from '@aws/dea-backend';
 import * as cdk from 'aws-cdk-lib';
 import { Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
@@ -66,14 +67,7 @@ describe('DeaMainStack', () => {
     template.resourceCountIs('AWS::ApiGateway::Method', 2);
     template.resourceCountIs('AWS::Lambda::Function', 2);
 
-    expect.addSnapshotSerializer({
-      test: (val) => typeof val === 'string' && val.includes('zip'),
-      print: (val) => {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const newVal = (val as string).replace(/([A-Fa-f0-9]{64})/, '[HASH REMOVED]');
-        return `"${newVal}"`;
-      },
-    });
+    addSnapshotSerializers();
 
     expect(template).toMatchSnapshot();
   });

--- a/source/dea-ui/ui/README.md
+++ b/source/dea-ui/ui/README.md
@@ -8,7 +8,7 @@ This is a prototype app and you should expect to modify the source code to refle
 
 | Statements                                                                                   | Branches                                                                                 | Functions                                                                                  | Lines                                                                              |
 | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-92.26%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-84.61%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-85.82%25-yellow.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-92.8%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-92.26%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-86.48%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-85.82%25-yellow.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-92.8%25-brightgreen.svg?style=flat) |
 
 ## Creating a stage file
 


### PR DESCRIPTION
- add a new config parameter to indicate if a stack is intended for tests `testStack`
  - This currently only dictates the removal policy for our buckets
- renamed envSettings object to testEnv to be more clear about the intended use
- extended config for cognito domain
  - the domain is now required, for development set DOMAIN_PREFIX to a unique value, for one-click a parameter is added


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
