### PR TITLE
fix: include a lint rule to prevent floating promises and fix existin…

### DIFF
--- a/source/dea-app/.eslintrc.js
+++ b/source/dea-app/.eslintrc.js
@@ -32,8 +32,10 @@ module.exports = {
     ],
     'import/newline-after-import': ['error'],
     curly: ['error'],
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/await-thenable': 'error',
   },
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'security', 'import'],
-  parserOptions: { tsconfigRootDir: __dirname },
+  parserOptions: { tsconfigRootDir: __dirname, project: './tsconfig.json' },
 };

--- a/source/dea-app/src/app/services/case-service.ts
+++ b/source/dea-app/src/app/services/case-service.ts
@@ -60,7 +60,7 @@ export const listCasesForUser = async (
   // Build a batch object of get requests for the case in each membership
   const batch = {};
   for (const caseMembership of caseMemberships) {
-    CasePersistence.getCase(caseMembership.caseUlid, batch, repositoryProvider);
+    await CasePersistence.getCase(caseMembership.caseUlid, batch, repositoryProvider);
   }
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const caseEntities = (await repositoryProvider.table.batchGet(batch, {

--- a/source/dea-app/src/test-e2e/auth/auth.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/auth/auth.e2e.test.ts
@@ -36,7 +36,7 @@ describe('API authentication', () => {
     const client = axios.create();
     const url = `${deaApiUrl}hi`;
 
-    expect(client.get(url)).rejects.toThrow('Request failed with status code 403');
+    await expect(client.get(url)).rejects.toThrow('Request failed with status code 403');
   });
 
   it('should disallow calls without id token in the header', async () => {
@@ -54,7 +54,7 @@ describe('API authentication', () => {
 
     const url = `${deaApiUrl}hi`;
 
-    expect(client.get(url)).rejects.toThrow('Request failed with status code 400');
+    await expect(client.get(url)).rejects.toThrow('Request failed with status code 400');
     // const response = await client.get(url);
 
     // expect(response.status).toEqual(400);

--- a/source/dea-app/src/test/app/resources/case-file-upload.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/case-file-upload.integration.test.ts
@@ -62,10 +62,10 @@ describe('Test case file upload', () => {
     await expect(initiateCaseFileUploadAndValidate(CASE_ULID, '/food/ramen.jpg')).rejects.toThrow();
 
     // allowed fileNames
-    await expect(initiateCaseFileUploadAndValidate(CASE_ULID, 'ramen.jpg'));
-    await expect(initiateCaseFileUploadAndValidate(CASE_ULID, 'ramen-jpg'));
-    await expect(initiateCaseFileUploadAndValidate(CASE_ULID, 'ramen_jpg'));
-    await expect(initiateCaseFileUploadAndValidate(CASE_ULID, 'ramen jpg'));
+    expect(await initiateCaseFileUploadAndValidate(CASE_ULID, 'ramen.jpg')).toBeDefined();
+    expect(await initiateCaseFileUploadAndValidate(CASE_ULID, 'ramen-jpg')).toBeDefined();
+    expect(await initiateCaseFileUploadAndValidate(CASE_ULID, 'ramen_jpg')).toBeDefined();
+    expect(await initiateCaseFileUploadAndValidate(CASE_ULID, 'ramen jpg')).toBeDefined();
 
     // validate filePath
     await expect(initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, 'foo')).rejects.toThrow();
@@ -74,9 +74,9 @@ describe('Test case file upload', () => {
     await expect(initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, 'foo&&')).rejects.toThrow();
 
     // allowed filePaths
-    await expect(initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, '/'));
-    await expect(initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, '/foo/'));
-    await expect(initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, '/foo/bar/'));
+    expect(await initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, '/')).toBeDefined();
+    expect(await initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, '/foo/')).toBeDefined();
+    expect(await initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, '/foo/bar/')).toBeDefined();
 
     // validate fileSizeMb
     await expect(
@@ -90,8 +90,12 @@ describe('Test case file upload', () => {
     ).rejects.toThrow();
 
     // allowed fileSizeMb
-    await expect(initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, FILE_PATH, FILE_TYPE, 4_999_999));
-    await expect(initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, FILE_PATH, FILE_TYPE, 1));
+    expect(
+      await initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, FILE_PATH, FILE_TYPE, 4_999_999)
+    ).toBeDefined();
+    expect(
+      await initiateCaseFileUploadAndValidate(CASE_ULID, FILE_NAME, FILE_PATH, FILE_TYPE, 1)
+    ).toBeDefined();
   });
 });
 

--- a/source/dea-app/src/test/app/resources/create-case-membership.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/create-case-membership.integration.test.ts
@@ -115,12 +115,12 @@ describe('create case membership resource', () => {
       }
     );
 
-    expect(createCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
+    await expect(createCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'CaseUser payload missing.'
     );
   });
 
-  it('should error if the resource and path ids do not match', () => {
+  it('should error if the resource and path ids do not match', async () => {
     const ulid1 = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
     const ulid2 = '02ARZ3NDEKTSV4RRFFQ69G5FAV';
     const ulid3 = '03ARZ3NDEKTSV4RRFFQ69G5FAV';
@@ -139,7 +139,7 @@ describe('create case membership resource', () => {
       }
     );
 
-    expect(createCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
+    await expect(createCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'Requested Case Ulid does not match resource'
     );
   });

--- a/source/dea-app/src/test/app/resources/lambda-preexecution-checks.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/lambda-preexecution-checks.integration.test.ts
@@ -71,7 +71,7 @@ describe('lambda pre-execution checks', () => {
     // make sure not added twice (in the getByToken code, we assert only 1 exists)
 
     const idToken2 = await cognitoHelper.getIdTokenForUser(testUser);
-    const tokenId2 = await (await getTokenPayload(idToken, region)).sub;
+    const tokenId2 = (await getTokenPayload(idToken, region)).sub;
     expect(tokenId2).toStrictEqual(tokenId);
 
     const event2 = Object.assign(

--- a/source/dea-app/src/test/app/resources/update-cases.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/update-cases.integration.test.ts
@@ -107,7 +107,7 @@ describe('update cases resource', () => {
       }
     );
 
-    expect(updateCases(event, dummyContext, repositoryProvider)).rejects.toThrow(
+    await expect(updateCases(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'Requested Case Ulid does not match resource'
     );
   });
@@ -124,7 +124,7 @@ describe('update cases resource', () => {
       }
     );
 
-    expect(updateCases(event, dummyContext, repositoryProvider)).rejects.toThrow(
+    await expect(updateCases(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'Update cases payload missing.'
     );
   });

--- a/source/dea-app/src/test/cognito-token-helpers.integration.test.ts
+++ b/source/dea-app/src/test/cognito-token-helpers.integration.test.ts
@@ -39,7 +39,7 @@ describe('cognito helpers integration test', () => {
 
     const fakeRegion = region === 'us-east-1' ? 'us-east-2' : 'us-east-1';
 
-    expect(getTokenPayload(idToken, fakeRegion)).rejects.toThrow(
+    await expect(getTokenPayload(idToken, fakeRegion)).rejects.toThrow(
       'Unable to grab the parameters in SSM needed for token verification.'
     );
   });
@@ -52,7 +52,7 @@ describe('cognito helpers integration test', () => {
     const modifiedToken =
       token.substring(0, replacementIndex) + replacementChar + token.substring(replacementIndex + 1);
 
-    expect(getTokenPayload(modifiedToken, region)).rejects.toThrow('Unable to verify id token: ');
+    await expect(getTokenPayload(modifiedToken, region)).rejects.toThrow('Unable to verify id token: ');
   });
 
   it('should decode and return a DeaUser from the token', async () => {
@@ -73,13 +73,13 @@ describe('cognito helpers integration test', () => {
     const tokenPayload = await getTokenPayload(token, region);
 
     delete tokenPayload['given_name'];
-    expect(getDeaUserFromToken(tokenPayload)).rejects.toThrow(
+    await expect(getDeaUserFromToken(tokenPayload)).rejects.toThrow(
       'First and/or last name not given in id token.'
     );
 
     tokenPayload['given_name'] = firstName;
     delete tokenPayload['family_name'];
-    expect(getDeaUserFromToken(tokenPayload)).rejects.toThrow(
+    await expect(getDeaUserFromToken(tokenPayload)).rejects.toThrow(
       'First and/or last name not given in id token.'
     );
   });

--- a/source/dea-backend/.eslintrc.js
+++ b/source/dea-backend/.eslintrc.js
@@ -39,8 +39,10 @@ module.exports = {
     ],
     'import/newline-after-import': ['error'],
     curly: ['error'],
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/await-thenable': 'error',
   },
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'security', 'import'],
-  parserOptions: { tsconfigRootDir: __dirname },
+  parserOptions: { tsconfigRootDir: __dirname, project: './tsconfig.json' },
 };

--- a/source/dea-main/.eslintrc.js
+++ b/source/dea-main/.eslintrc.js
@@ -39,8 +39,10 @@ module.exports = {
     ],
     'import/newline-after-import': ['error'],
     curly: ['error'],
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/await-thenable': 'error',
   },
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'security', 'import'],
-  parserOptions: { tsconfigRootDir: __dirname },
+  parserOptions: { tsconfigRootDir: __dirname, project: './tsconfig.json' },
 };

--- a/source/dea-main/src/dea-main-stack.ts
+++ b/source/dea-main/src/dea-main-stack.ts
@@ -83,7 +83,7 @@ export class DeaMainStack extends cdk.Stack {
     this._apiGwAuthNagSuppresions();
   }
 
-  private async _uiStackConstructNagSuppress(): Promise<void> {
+  private _uiStackConstructNagSuppress(): void {
     const cdkLambda = this.node.findChild('Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C').node
       .defaultChild;
     if (cdkLambda instanceof CfnFunction) {

--- a/source/dea-ui/infrastructure/.eslintrc.js
+++ b/source/dea-ui/infrastructure/.eslintrc.js
@@ -37,8 +37,10 @@ module.exports = {
     ],
     'import/newline-after-import': ['error'],
     curly: ['error'],
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/await-thenable': 'error',
   },
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'security', 'import'],
-  parserOptions: { tsconfigRootDir: __dirname },
+  parserOptions: { tsconfigRootDir: __dirname, project: './tsconfig.json' },
 };

--- a/source/dea-ui/ui/.eslintrc.js
+++ b/source/dea-ui/ui/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'next/core-web-vitals',
   ],
-  parserOptions: { tsconfigRootDir: __dirname },
+  parserOptions: { tsconfigRootDir: __dirname, project: './tsconfig.json' },
   plugins: ['testing-library', '@typescript-eslint', 'security', 'import'],
   parser: '@typescript-eslint/parser',
   rules: {
@@ -32,6 +32,8 @@ module.exports = {
     ],
     'import/newline-after-import': ['error'],
     curly: ['error'],
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/await-thenable': 'error',
   },
   overrides: [
     // Only uses Testing Library lint rules in test files

--- a/source/dea-ui/ui/src/components/Header.tsx
+++ b/source/dea-ui/ui/src/components/Header.tsx
@@ -29,7 +29,7 @@ export default function Header(): JSX.Element {
           type: 'menu-dropdown',
           text: `Sherlock Holmes`,
           items: profileActions,
-          onItemClick: async () => await signOut(),
+          onItemClick: async () => signOut(),
         },
       ]}
     />

--- a/source/dea-ui/ui/src/components/case-list-table/CaseTable.tsx
+++ b/source/dea-ui/ui/src/components/case-list-table/CaseTable.tsx
@@ -45,6 +45,7 @@ function CaseTable(): JSX.Element {
     selection: {},
   });
   function createNewCaseHandler() {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     router.push('/create-cases');
   }
 
@@ -83,6 +84,7 @@ function CaseTable(): JSX.Element {
               href={`/${e.ulid}`}
               onFollow={(e) => {
                 e.preventDefault();
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
                 router.push(`${e.detail.href}`);
               }}
             >

--- a/source/dea-ui/ui/src/components/create-case/CreateCasesForm.tsx
+++ b/source/dea-ui/ui/src/components/create-case/CreateCasesForm.tsx
@@ -35,11 +35,13 @@ function CreateCasesForm(): JSX.Element {
       await createCase(formData);
     } finally {
       setIsSubmitLoading(false);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       router.push('/');
     }
   }
 
   function onCancelHandler() {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     router.push('/');
   }
 


### PR DESCRIPTION
- introduce `@typescript-eslint/no-floating-promises` rule
  - this ensures we await calls to async functions, preventing async errors
- introduce `@typescript-eslint/await-thenable` rule
  - this prevents await on non-async functions, which can hide errors from the above rule
- fix, or ignore existing exceptions to no-floating-promises


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
