### PR TITLE
ci: deploy to new stage on merge to main

### DIFF
--- a/.github/workflows/main-merge-workflow.yml
+++ b/.github/workflows/main-merge-workflow.yml
@@ -1,0 +1,40 @@
+name: Merge to Main Workflow
+
+env:
+  STAGE: palpatine
+  DOMAIN_PREFIX: deaplayground
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+      id-token: write   # This is required for requesting the JWT
+      contents: read    # This is required for actions/checkout
+jobs:
+  verify:
+    environment: dea-test
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./source
+    name: Deploy Playground
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install
+        uses: ./.github/actions/baseAction
+      - name: Rush Build
+        run: |
+          node common/scripts/install-run-rush.js build
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: GITHUBACTIONSESSION
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: cdk deploy
+        run: |
+          cd dea-main
+          npm run cdk deploy

--- a/source/common/config/palpatine.json
+++ b/source/common/config/palpatine.json
@@ -1,0 +1,43 @@
+{
+  "userGroups": [
+    {
+      "name": "CaseWorkerGroup",
+      "description": "containing users who need access to case APIs",
+      "precedence": 1,
+      "endpoints": [
+        {
+          "path": "/cases",
+          "method": "POST"
+        },
+        {
+          "path": "/cases/{caseId}",
+          "method": "GET"
+        },
+        {
+          "path": "/cases/{caseId}",
+          "method": "PUT"
+        },
+        {
+          "path": "/cases/{caseId}",
+          "method": "DELETE"
+        },
+        {
+          "path": "/cases/{caseId}/userMemberships",
+          "method": "POST"
+        },
+        {
+          "path": "/users",
+          "method": "GET"
+        },
+        {
+          "path": "/cases/all-cases",
+          "method": "GET"
+        },
+        {
+          "path": "/cases/my-cases",
+          "method": "GET"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Resolves https://sim.amazon.com/issues/ea1314bf-69fd-4e01-8442-002d9cce6fb5
- add github actions workflow to run on merge to main
  - deploys to a new stage "palpatine" on the DEA test account


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
