### PR TITLE
fix: add condition around nag that is not present for non-test stack

### DIFF
--- a/source/dea-main/src/dea-main-stack.ts
+++ b/source/dea-main/src/dea-main-stack.ts
@@ -90,11 +90,13 @@ export class DeaMainStack extends cdk.Stack {
       addLambdaSuppressions(cdkLambda);
     }
 
-    const autoDeleteLambda = this.node
-      .findChild('Custom::S3AutoDeleteObjectsCustomResourceProvider')
-      .node.findChild('Handler');
-    if (autoDeleteLambda instanceof CfnResource) {
-      addLambdaSuppressions(autoDeleteLambda);
+    // This will not exist in non-test deploys
+    const lambdaChild = this.node.tryFindChild('Custom::S3AutoDeleteObjectsCustomResourceProvider');
+    if (lambdaChild) {
+      const autoDeleteLambda = lambdaChild.node.findChild('Handler');
+      if (autoDeleteLambda instanceof CfnResource) {
+        addLambdaSuppressions(autoDeleteLambda);
+      }
     }
   }
 


### PR DESCRIPTION
- add a conditional around a nag that is not needed for non-test stacks


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
