### PR TITLE
refactor: set the cognito domain before we generate snapshots for consistent ordering

### DIFF
--- a/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
+++ b/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
@@ -17,7 +17,8 @@ import { validateBackendConstruct } from './validate-backend-construct';
 
 describe('DeaBackend constructs', () => {
   beforeAll(() => {
-    process.env.STAGE = 'chewbacca';
+    process.env.STAGE = 'RUN1';
+    process.env.CONFIGNAME = 'chewbacca';
   });
 
   afterAll(() => {
@@ -25,6 +26,10 @@ describe('DeaBackend constructs', () => {
   });
 
   it('synthesizes the way we expect', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const domain: any = 'deatestenv';
+    convictConfig.set('cognito.domain', domain);
+
     const app = new cdk.App();
     const stack = new Stack(app, 'test-stack');
 

--- a/source/dea-main/src/test/dea-main-stack.unit.test.ts
+++ b/source/dea-main/src/test/dea-main-stack.unit.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { addSnapshotSerializers, validateBackendConstruct } from '@aws/dea-backend';
+import { convictConfig } from '@aws/dea-backend/lib/config';
 import { validateDeaUiConstruct } from '@aws/dea-ui-infrastructure';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
@@ -12,6 +13,10 @@ import { DeaMainStack } from '../dea-main-stack';
 
 describe('DeaMainStack', () => {
   it('synthesizes the way we expect', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const domain: any = 'deatestenv';
+    convictConfig.set('cognito.domain', domain);
+
     const app = new cdk.App();
 
     // Create the DeaMainStack


### PR DESCRIPTION
- depending on the domain name you were using locally you might have seen snapshot failures due to ordering, this resolves that issue by using a consistent name in the snapshot generation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
