### PR TITLE
feat: introduce audit service and writer implementation

### DIFF
--- a/.github/cdkCFExecutionPolicy.json
+++ b/.github/cdkCFExecutionPolicy.json
@@ -14,7 +14,8 @@
         "lambda:*",
         "logs:*",
         "s3:*",
-        "ssm:*"
+        "ssm:*",
+        "cloudtrail:*"
       ],
       "Resource": "*"
     },

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Digital Evidence Archive on AWS enables Law Enforcement organizations to ingest 
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-96.78%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-87.61%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-92.23%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-96.82%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-96.69%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-87.29%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-92.45%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-96.72%25-brightgreen.svg?style=flat) |
 
 
 ## Project Setup
@@ -40,6 +40,32 @@ rush cupdate
 
 ```
 git defender --setup
+```
+
+## CDK Policy Customization
+By default, the policies that CDK boostraps with are too permissive, so we recommend customizing the cdkCFExecutionPolicy. This is done using a policy document, ([cdkCFExecutionPolicy.json](.github/cdkCFExecutionPolicy.json))
+First, create the customized policy, via the aws cli:
+```
+aws iam create-policy \
+  --policy-name cdkCFExecutionPolicy \
+  --policy-document file://../../.github/cdkCFExecutionPolicy.json
+```
+Then boostrap your account, specifying the custom policy:
+```
+ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+cdk bootstrap aws://$ACCOUNT_ID/$AWS_REGION \
+  --cloudformation-execution-policies "arn:aws:iam::$ACCOUNT_ID:policy/cdkCFExecutionPolicy"
+```
+At this point your CDK deployments will use the customized policy!
+If you need to update the policy, simply modify the JSON file, and create a policy version, setting it as the default 
+> :warning: There is a limit to the number of policy versions.
+> Prior to creating a new version, you may need to list, and delete an existing version
+```
+ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+aws iam create-policy-version \
+  --policy-arn arn:aws:iam::$ACCOUNT_ID:policy/cdkCFExecutionPolicy \
+  --policy-document file://../../.github/cdkCFExecutionPolicy.json \
+  --set-as-default
 ```
 
 ## Local Environment Setup

--- a/source/common/config/rush/browser-approved-packages.json
+++ b/source/common/config/rush/browser-approved-packages.json
@@ -35,6 +35,10 @@
       "allowedCategories": ["production", "prototypes"]
     },
     {
+      "name": "@aws-sdk/client-cloudwatch-logs",
+      "allowedCategories": ["production"]
+    },
+    {
       "name": "@aws-sdk/client-cognito-identity",
       "allowedCategories": ["production"]
     },
@@ -120,6 +124,10 @@
     },
     {
       "name": "@aws/dea-ui-infrastructure",
+      "allowedCategories": ["production"]
+    },
+    {
+      "name": "@aws/workbench-core-audit",
       "allowedCategories": ["production"]
     },
     {

--- a/source/common/config/rush/pnpm-lock.yaml
+++ b/source/common/config/rush/pnpm-lock.yaml
@@ -7,12 +7,14 @@ importers:
 
   ../../dea-app:
     specifiers:
+      '@aws-sdk/client-cloudwatch-logs': ~3.272.0
       '@aws-sdk/client-cognito-identity': 3.264.0
       '@aws-sdk/client-cognito-identity-provider': 3.264.0
       '@aws-sdk/client-dynamodb': 3.264.0
       '@aws-sdk/client-s3': 3.264.0
       '@aws-sdk/client-ssm': 3.264.0
       '@aws-sdk/s3-request-presigner': 3.264.0
+      '@aws/workbench-core-audit': ~0.1.1
       '@casl/ability': ~6.3.3
       '@rushstack/eslint-config': ^3.0.0
       '@rushstack/heft': ^0.48.8
@@ -87,6 +89,8 @@ importers:
       puppeteer: 18.1.0
       uuid: 9.0.0
     devDependencies:
+      '@aws-sdk/client-cloudwatch-logs': 3.272.0
+      '@aws/workbench-core-audit': 0.1.1
       '@casl/ability': 6.3.3
       '@rushstack/eslint-config': 3.1.1_eslint@8.27.0+typescript@4.8.4
       '@rushstack/heft': 0.48.8
@@ -584,7 +588,7 @@ packages:
     resolution: {integrity: sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==}
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.257.0
+      '@aws-sdk/types': 3.272.0
       tslib: 1.14.1
     dev: false
 
@@ -592,7 +596,7 @@ packages:
     resolution: {integrity: sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==}
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.257.0
+      '@aws-sdk/types': 3.272.0
       tslib: 1.14.1
     dev: false
 
@@ -607,7 +611,7 @@ packages:
       '@aws-crypto/ie11-detection': 3.0.0
       '@aws-crypto/supports-web-crypto': 3.0.0
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.257.0
+      '@aws-sdk/types': 3.272.0
       '@aws-sdk/util-locate-window': 3.201.0
       '@aws-sdk/util-utf8-browser': 3.188.0
       tslib: 1.14.1
@@ -640,7 +644,7 @@ packages:
   /@aws-crypto/util/3.0.0:
     resolution: {integrity: sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==}
     dependencies:
-      '@aws-sdk/types': 3.257.0
+      '@aws-sdk/types': 3.272.0
       '@aws-sdk/util-utf8-browser': 3.188.0
       tslib: 1.14.1
 
@@ -650,6 +654,14 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/abort-controller/3.272.0:
+    resolution: {integrity: sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/chunked-blob-reader-native/3.208.0:
     resolution: {integrity: sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==}
@@ -709,6 +721,49 @@ packages:
     transitivePeerDependencies:
       - aws-crt
     dev: false
+
+  /@aws-sdk/client-cloudwatch-logs/3.272.0:
+    resolution: {integrity: sha512-0JaajIRb1FtYx4wS1IEqJEpHb7c8GotxRksiB6/LBXkCNFgN9+vxWO1E2kmEugw/1G3rRXE+f+rVem9SBEnXiA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.272.0
+      '@aws-sdk/config-resolver': 3.272.0
+      '@aws-sdk/credential-provider-node': 3.272.0
+      '@aws-sdk/fetch-http-handler': 3.272.0
+      '@aws-sdk/hash-node': 3.272.0
+      '@aws-sdk/invalid-dependency': 3.272.0
+      '@aws-sdk/middleware-content-length': 3.272.0
+      '@aws-sdk/middleware-endpoint': 3.272.0
+      '@aws-sdk/middleware-host-header': 3.272.0
+      '@aws-sdk/middleware-logger': 3.272.0
+      '@aws-sdk/middleware-recursion-detection': 3.272.0
+      '@aws-sdk/middleware-retry': 3.272.0
+      '@aws-sdk/middleware-serde': 3.272.0
+      '@aws-sdk/middleware-signing': 3.272.0
+      '@aws-sdk/middleware-stack': 3.272.0
+      '@aws-sdk/middleware-user-agent': 3.272.0
+      '@aws-sdk/node-config-provider': 3.272.0
+      '@aws-sdk/node-http-handler': 3.272.0
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/smithy-client': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/url-parser': 3.272.0
+      '@aws-sdk/util-base64': 3.208.0
+      '@aws-sdk/util-body-length-browser': 3.188.0
+      '@aws-sdk/util-body-length-node': 3.208.0
+      '@aws-sdk/util-defaults-mode-browser': 3.272.0
+      '@aws-sdk/util-defaults-mode-node': 3.272.0
+      '@aws-sdk/util-endpoints': 3.272.0
+      '@aws-sdk/util-retry': 3.272.0
+      '@aws-sdk/util-user-agent-browser': 3.272.0
+      '@aws-sdk/util-user-agent-node': 3.272.0
+      '@aws-sdk/util-utf8': 3.254.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: true
 
   /@aws-sdk/client-cognito-identity-provider/3.264.0:
     resolution: {integrity: sha512-XuQdH3I8HnVpkHpJtdhe7v3pqmv4uvcuBCQDp443WnK7K7EokjDZIb6xuCydU6xCswof+W2HRtWW46z91cKAHw==}
@@ -988,6 +1043,46 @@ packages:
     transitivePeerDependencies:
       - aws-crt
 
+  /@aws-sdk/client-sso-oidc/3.272.0:
+    resolution: {integrity: sha512-ECcXu3xoa1yggnGKMTh29eWNHiF/wC6r5Uqbla22eOOosyh0+Z6lkJ3JUSLOUKCkBXA4Cs/tJL9UDFBrKbSlvA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/config-resolver': 3.272.0
+      '@aws-sdk/fetch-http-handler': 3.272.0
+      '@aws-sdk/hash-node': 3.272.0
+      '@aws-sdk/invalid-dependency': 3.272.0
+      '@aws-sdk/middleware-content-length': 3.272.0
+      '@aws-sdk/middleware-endpoint': 3.272.0
+      '@aws-sdk/middleware-host-header': 3.272.0
+      '@aws-sdk/middleware-logger': 3.272.0
+      '@aws-sdk/middleware-recursion-detection': 3.272.0
+      '@aws-sdk/middleware-retry': 3.272.0
+      '@aws-sdk/middleware-serde': 3.272.0
+      '@aws-sdk/middleware-stack': 3.272.0
+      '@aws-sdk/middleware-user-agent': 3.272.0
+      '@aws-sdk/node-config-provider': 3.272.0
+      '@aws-sdk/node-http-handler': 3.272.0
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/smithy-client': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/url-parser': 3.272.0
+      '@aws-sdk/util-base64': 3.208.0
+      '@aws-sdk/util-body-length-browser': 3.188.0
+      '@aws-sdk/util-body-length-node': 3.208.0
+      '@aws-sdk/util-defaults-mode-browser': 3.272.0
+      '@aws-sdk/util-defaults-mode-node': 3.272.0
+      '@aws-sdk/util-endpoints': 3.272.0
+      '@aws-sdk/util-retry': 3.272.0
+      '@aws-sdk/util-user-agent-browser': 3.272.0
+      '@aws-sdk/util-user-agent-node': 3.272.0
+      '@aws-sdk/util-utf8': 3.254.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: true
+
   /@aws-sdk/client-sso/3.264.0:
     resolution: {integrity: sha512-p+7sYpRcdv9omnnsPhD/vOFuZ1SpfV62ZgistBK/RDsQg2W9SIWQRW1KPt7gOCQ0nwp4efntw4Sle0LjS7ykxg==}
     engines: {node: '>=14.0.0'}
@@ -1026,6 +1121,46 @@ packages:
       tslib: 2.4.1
     transitivePeerDependencies:
       - aws-crt
+
+  /@aws-sdk/client-sso/3.272.0:
+    resolution: {integrity: sha512-xn9a0IGONwQIARmngThoRhF1lLGjHAD67sUaShgIMaIMc6ipVYN6alWG1VuUpoUQ6iiwMEt0CHdfCyLyUV/fTA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/config-resolver': 3.272.0
+      '@aws-sdk/fetch-http-handler': 3.272.0
+      '@aws-sdk/hash-node': 3.272.0
+      '@aws-sdk/invalid-dependency': 3.272.0
+      '@aws-sdk/middleware-content-length': 3.272.0
+      '@aws-sdk/middleware-endpoint': 3.272.0
+      '@aws-sdk/middleware-host-header': 3.272.0
+      '@aws-sdk/middleware-logger': 3.272.0
+      '@aws-sdk/middleware-recursion-detection': 3.272.0
+      '@aws-sdk/middleware-retry': 3.272.0
+      '@aws-sdk/middleware-serde': 3.272.0
+      '@aws-sdk/middleware-stack': 3.272.0
+      '@aws-sdk/middleware-user-agent': 3.272.0
+      '@aws-sdk/node-config-provider': 3.272.0
+      '@aws-sdk/node-http-handler': 3.272.0
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/smithy-client': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/url-parser': 3.272.0
+      '@aws-sdk/util-base64': 3.208.0
+      '@aws-sdk/util-body-length-browser': 3.188.0
+      '@aws-sdk/util-body-length-node': 3.208.0
+      '@aws-sdk/util-defaults-mode-browser': 3.272.0
+      '@aws-sdk/util-defaults-mode-node': 3.272.0
+      '@aws-sdk/util-endpoints': 3.272.0
+      '@aws-sdk/util-retry': 3.272.0
+      '@aws-sdk/util-user-agent-browser': 3.272.0
+      '@aws-sdk/util-user-agent-node': 3.272.0
+      '@aws-sdk/util-utf8': 3.254.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: true
 
   /@aws-sdk/client-sts/3.264.0:
     resolution: {integrity: sha512-sco1jREkDdds4Z3V19Vlu/YpBHSzeEt1KFqOPnbjFw7pSakRNzpyWmLLxOwWjwgGKt6pSF3Aw0ZOMYsAUDc5qQ==}
@@ -1070,6 +1205,50 @@ packages:
     transitivePeerDependencies:
       - aws-crt
 
+  /@aws-sdk/client-sts/3.272.0:
+    resolution: {integrity: sha512-kigxCxURp3WupufGaL/LABMb7UQfzAQkKcj9royizL3ItJ0vw5kW/JFrPje5IW1mfLgdPF7PI9ShOjE0fCLTqA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/config-resolver': 3.272.0
+      '@aws-sdk/credential-provider-node': 3.272.0
+      '@aws-sdk/fetch-http-handler': 3.272.0
+      '@aws-sdk/hash-node': 3.272.0
+      '@aws-sdk/invalid-dependency': 3.272.0
+      '@aws-sdk/middleware-content-length': 3.272.0
+      '@aws-sdk/middleware-endpoint': 3.272.0
+      '@aws-sdk/middleware-host-header': 3.272.0
+      '@aws-sdk/middleware-logger': 3.272.0
+      '@aws-sdk/middleware-recursion-detection': 3.272.0
+      '@aws-sdk/middleware-retry': 3.272.0
+      '@aws-sdk/middleware-sdk-sts': 3.272.0
+      '@aws-sdk/middleware-serde': 3.272.0
+      '@aws-sdk/middleware-signing': 3.272.0
+      '@aws-sdk/middleware-stack': 3.272.0
+      '@aws-sdk/middleware-user-agent': 3.272.0
+      '@aws-sdk/node-config-provider': 3.272.0
+      '@aws-sdk/node-http-handler': 3.272.0
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/smithy-client': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/url-parser': 3.272.0
+      '@aws-sdk/util-base64': 3.208.0
+      '@aws-sdk/util-body-length-browser': 3.188.0
+      '@aws-sdk/util-body-length-node': 3.208.0
+      '@aws-sdk/util-defaults-mode-browser': 3.272.0
+      '@aws-sdk/util-defaults-mode-node': 3.272.0
+      '@aws-sdk/util-endpoints': 3.272.0
+      '@aws-sdk/util-retry': 3.272.0
+      '@aws-sdk/util-user-agent-browser': 3.272.0
+      '@aws-sdk/util-user-agent-node': 3.272.0
+      '@aws-sdk/util-utf8': 3.254.0
+      fast-xml-parser: 4.0.11
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: true
+
   /@aws-sdk/config-resolver/3.259.0:
     resolution: {integrity: sha512-gViMRsc4Ye6+nzJ0OYTZIT8m4glIAdtugN2Sr/t6P2iJW5X0bSL/EcbcHBgsve1lHjeGPeyzVkT7UnyGOZ5Z/A==}
     engines: {node: '>=14.0.0'}
@@ -1080,6 +1259,17 @@ packages:
       '@aws-sdk/util-middleware': 3.257.0
       tslib: 2.4.1
 
+  /@aws-sdk/config-resolver/3.272.0:
+    resolution: {integrity: sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/signature-v4': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/util-config-provider': 3.208.0
+      '@aws-sdk/util-middleware': 3.272.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/credential-provider-env/3.257.0:
     resolution: {integrity: sha512-GsmBi5Di6hk1JAi1iB6/LCY8o+GmlCvJoB7wuoVmXI3VxRVwptUVjuj8EtJbIrVGrF9dSuIRPCzUoSuzEzYGlg==}
     engines: {node: '>=14.0.0'}
@@ -1087,6 +1277,15 @@ packages:
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/credential-provider-env/3.272.0:
+    resolution: {integrity: sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/credential-provider-imds/3.259.0:
     resolution: {integrity: sha512-yCxoYWZAaDrCUEWxRfrpB0Mp1cFgJEMYW8T6GIb/+DQ5QLpZmorgaVD/j90QXupqFrR5tlxwuskBIkdD2E9YNg==}
@@ -1097,6 +1296,17 @@ packages:
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/url-parser': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/credential-provider-imds/3.272.0:
+    resolution: {integrity: sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/node-config-provider': 3.272.0
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/url-parser': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/credential-provider-ini/3.264.0:
     resolution: {integrity: sha512-UU5NNlfn+Go+5PLBzyTH1YE3r/pgykpE4QYFon87sCnEQnQH9xmlRTW1f1cBSQ9kivbFZd2/C2X3qhB3fe2JfA==}
@@ -1113,6 +1323,23 @@ packages:
       tslib: 2.4.1
     transitivePeerDependencies:
       - aws-crt
+
+  /@aws-sdk/credential-provider-ini/3.272.0:
+    resolution: {integrity: sha512-iE3CDzK5NcupHYjfYjBdY1JCy8NLEoRUsboEjG0i0gy3S3jVpDeVHX1dLVcL/slBFj6GiM7SoNV/UfKnJf3Gaw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.272.0
+      '@aws-sdk/credential-provider-imds': 3.272.0
+      '@aws-sdk/credential-provider-process': 3.272.0
+      '@aws-sdk/credential-provider-sso': 3.272.0
+      '@aws-sdk/credential-provider-web-identity': 3.272.0
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/shared-ini-file-loader': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: true
 
   /@aws-sdk/credential-provider-node/3.264.0:
     resolution: {integrity: sha512-DPzL7oawcILs5Mduim9Z8SVeJaUpaDRVbUIrBHsMBu+N7Zuqtzr+0ckHc1bEi3iYq2QUCk5pH5vpQaZYkMlbtw==}
@@ -1131,6 +1358,24 @@ packages:
     transitivePeerDependencies:
       - aws-crt
 
+  /@aws-sdk/credential-provider-node/3.272.0:
+    resolution: {integrity: sha512-FI8uvwM1IxiRSvbkdKv8DZG5vxU3ezaseTaB1fHWTxEUFb0pWIoHX9oeOKer9Fj31SOZTCNAaYFURbSRuZlm/w==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.272.0
+      '@aws-sdk/credential-provider-imds': 3.272.0
+      '@aws-sdk/credential-provider-ini': 3.272.0
+      '@aws-sdk/credential-provider-process': 3.272.0
+      '@aws-sdk/credential-provider-sso': 3.272.0
+      '@aws-sdk/credential-provider-web-identity': 3.272.0
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/shared-ini-file-loader': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: true
+
   /@aws-sdk/credential-provider-process/3.257.0:
     resolution: {integrity: sha512-xK8uYeNXaclaBCGrLi4z2pxPRngqLf5BM5jg2fn57zqvlL9V5gJF972FehrVBL0bfp1/laG0ZJtD2K2sapyWAw==}
     engines: {node: '>=14.0.0'}
@@ -1139,6 +1384,16 @@ packages:
       '@aws-sdk/shared-ini-file-loader': 3.257.0
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/credential-provider-process/3.272.0:
+    resolution: {integrity: sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/shared-ini-file-loader': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/credential-provider-sso/3.264.0:
     resolution: {integrity: sha512-CJuAlqIIJap6LXoqimvEAnYZ7Kb5pTbiS3e+aY+fajO3OPujmQpHuiY8kOmscjwZ4ErJdEskivcTGwXph0dPZQ==}
@@ -1153,6 +1408,20 @@ packages:
     transitivePeerDependencies:
       - aws-crt
 
+  /@aws-sdk/credential-provider-sso/3.272.0:
+    resolution: {integrity: sha512-hwYaulyiU/7chKKFecxCeo0ls6Dxs7h+5EtoYcJJGvfpvCncyOZF35t00OAsCd3Wo7HkhhgfpGdb6dmvCNQAZQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso': 3.272.0
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/shared-ini-file-loader': 3.272.0
+      '@aws-sdk/token-providers': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: true
+
   /@aws-sdk/credential-provider-web-identity/3.257.0:
     resolution: {integrity: sha512-Cm0uvRv4JuIbD0Kp3W0J/vwjADIyCx8HoZi5yg+QIi5nilocuTQ3ajvLeuPVSvFvdy+yaxSc5FxNXquWt7Mngw==}
     engines: {node: '>=14.0.0'}
@@ -1160,6 +1429,15 @@ packages:
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/credential-provider-web-identity/3.272.0:
+    resolution: {integrity: sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/endpoint-cache/3.208.0:
     resolution: {integrity: sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==}
@@ -1221,6 +1499,16 @@ packages:
       '@aws-sdk/util-base64': 3.208.0
       tslib: 2.4.1
 
+  /@aws-sdk/fetch-http-handler/3.272.0:
+    resolution: {integrity: sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/querystring-builder': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/util-base64': 3.208.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/hash-blob-browser/3.257.0:
     resolution: {integrity: sha512-3Nrcci3pCCc0ZILMGa/oUMq9le6nhvgCoVxFy5skYs/mQu4QnA8HcK0u4bTueW41rBj0ZW6BHLk/2SmigIkjCQ==}
     dependencies:
@@ -1239,6 +1527,16 @@ packages:
       '@aws-sdk/util-utf8': 3.254.0
       tslib: 2.4.1
 
+  /@aws-sdk/hash-node/3.272.0:
+    resolution: {integrity: sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/util-buffer-from': 3.208.0
+      '@aws-sdk/util-utf8': 3.254.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/hash-stream-node/3.257.0:
     resolution: {integrity: sha512-A24+EI0sO+IYO78sQPY4vVx7vzToc6XAobQqowmBJ6GXXILK72d3MR3NVbm0lmcS4Dh6MVZEFQD/DCyKvj2C7g==}
     engines: {node: '>=14.0.0'}
@@ -1253,6 +1551,13 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/invalid-dependency/3.272.0:
+    resolution: {integrity: sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/is-array-buffer/3.201.0:
     resolution: {integrity: sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==}
@@ -1287,6 +1592,15 @@ packages:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
 
+  /@aws-sdk/middleware-content-length/3.272.0:
+    resolution: {integrity: sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/middleware-endpoint-discovery/3.259.0:
     resolution: {integrity: sha512-1FeoJKD5wRZmxsHl+g+SOm1VfBZuwW8T/7rBHah63lWB2zOrvBiwJ2jfIalXEtlZYqPRYwsxiQYgR0J5w8Fk9Q==}
     engines: {node: '>=14.0.0'}
@@ -1309,6 +1623,20 @@ packages:
       '@aws-sdk/util-config-provider': 3.208.0
       '@aws-sdk/util-middleware': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/middleware-endpoint/3.272.0:
+    resolution: {integrity: sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-serde': 3.272.0
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/signature-v4': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/url-parser': 3.272.0
+      '@aws-sdk/util-config-provider': 3.208.0
+      '@aws-sdk/util-middleware': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/middleware-expect-continue/3.257.0:
     resolution: {integrity: sha512-7HSRA2Ta0fTq9Ewznp6fYG7CYOoqr5TeqEhKL1HyFb5i6YmsCiz88JKNJTllD5O7uFcd7Td/fJ66pK4JttfaaQ==}
@@ -1340,6 +1668,15 @@ packages:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
 
+  /@aws-sdk/middleware-host-header/3.272.0:
+    resolution: {integrity: sha512-Q8K7bMMFZnioUXpxn57HIt4p+I63XaNAawMLIZ5B4F2piyukbQeM9q2XVKMGwqLvijHR8CyP5nHrtKqVuINogQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/middleware-location-constraint/3.257.0:
     resolution: {integrity: sha512-pmm5rJR5aatXG0kC0KPBxkgoNn/ePcyVIYHGMEuJXRJm3ENy569QAH9UZeMFjprp3uuAbkqItQbY3MP8TYvuYA==}
     engines: {node: '>=14.0.0'}
@@ -1355,6 +1692,14 @@ packages:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
 
+  /@aws-sdk/middleware-logger/3.272.0:
+    resolution: {integrity: sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/middleware-recursion-detection/3.257.0:
     resolution: {integrity: sha512-rUCih6zHh8k9Edf5N5Er4s508FYbwLM0MWTD2axzlj9TjLqEQ9OKED3wHaLffXSDzodd3oTAfJCLPbWQyoZ3ZQ==}
     engines: {node: '>=14.0.0'}
@@ -1362,6 +1707,15 @@ packages:
       '@aws-sdk/protocol-http': 3.257.0
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/middleware-recursion-detection/3.272.0:
+    resolution: {integrity: sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/middleware-retry/3.259.0:
     resolution: {integrity: sha512-pVh1g8e84MAi7eVtWLiiiCtn82LzxOP7+LxTRHatmgIeN22yGQBZILliPDJypUPvDYlwxI1ekiK+oPTcte0Uww==}
@@ -1374,6 +1728,19 @@ packages:
       '@aws-sdk/util-retry': 3.257.0
       tslib: 2.4.1
       uuid: 8.3.2
+
+  /@aws-sdk/middleware-retry/3.272.0:
+    resolution: {integrity: sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/service-error-classification': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/util-middleware': 3.272.0
+      '@aws-sdk/util-retry': 3.272.0
+      tslib: 2.4.1
+      uuid: 8.3.2
+    dev: true
 
   /@aws-sdk/middleware-sdk-s3/3.257.0:
     resolution: {integrity: sha512-l9KRlUgsDKV1MB3zfttX/syhIBsG5Z3VVslz6EW09eSqZVreCudW3TMdyeLemup57xC2veEpkgVj8igiXd/LVQ==}
@@ -1396,12 +1763,32 @@ packages:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
 
+  /@aws-sdk/middleware-sdk-sts/3.272.0:
+    resolution: {integrity: sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-signing': 3.272.0
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/signature-v4': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/middleware-serde/3.257.0:
     resolution: {integrity: sha512-/JasfXPWFq24mnCrx9fxW/ISBSp07RJwhsF14qzm8Qy3Z0z470C+QRM6otTwAkYuuVt1wuLjja5agq3Jtzq7dQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/middleware-serde/3.272.0:
+    resolution: {integrity: sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/middleware-signing/3.257.0:
     resolution: {integrity: sha512-hCH3D83LHmm6nqmtNrGTWZCVjsQXrGHIXbd17/qrw7aPFvcAhsiiCncGFP+XsUXEKa2ZqcSNMUyPrx69ofNRZQ==}
@@ -1413,6 +1800,18 @@ packages:
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-middleware': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/middleware-signing/3.272.0:
+    resolution: {integrity: sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/signature-v4': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/util-middleware': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/middleware-ssec/3.257.0:
     resolution: {integrity: sha512-YcZrKeZk/0bsFvnTqp2rcF+6BSmeLTA65ZtyNNP2hh7Imaxg3kAQcueOJBeK4YP/5nU7a1mtt/4Q8BqbIjc41g==}
@@ -1428,6 +1827,13 @@ packages:
     dependencies:
       tslib: 2.4.1
 
+  /@aws-sdk/middleware-stack/3.272.0:
+    resolution: {integrity: sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/middleware-user-agent/3.257.0:
     resolution: {integrity: sha512-37rt75LZyD0UWpbcFuxEGqwF3DZKSixQPl7AsDe6q3KtrO5gGQB+diH5vbY0txNNYyv5IK9WMwvY73mVmoWRmw==}
     engines: {node: '>=14.0.0'}
@@ -1435,6 +1841,15 @@ packages:
       '@aws-sdk/protocol-http': 3.257.0
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/middleware-user-agent/3.272.0:
+    resolution: {integrity: sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/node-config-provider/3.259.0:
     resolution: {integrity: sha512-DUOqr71oonBvM6yKPdhDBmraqgXHCFrVWFw7hc5ZNxL2wS/EsbKfGPJp+C+SUgpn1upIWPNnh/bNoLAbBkcLsA==}
@@ -1444,6 +1859,16 @@ packages:
       '@aws-sdk/shared-ini-file-loader': 3.257.0
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/node-config-provider/3.272.0:
+    resolution: {integrity: sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/shared-ini-file-loader': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/node-http-handler/3.257.0:
     resolution: {integrity: sha512-8KnWHVVwaGKyTlkTU9BSOAiSovNDoagxemU2l10QqBbzUCVpljCUMUkABEGRJ1yoQCl6DJ7RtNkAyZ8Ne/E15A==}
@@ -1455,6 +1880,17 @@ packages:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
 
+  /@aws-sdk/node-http-handler/3.272.0:
+    resolution: {integrity: sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/abort-controller': 3.272.0
+      '@aws-sdk/protocol-http': 3.272.0
+      '@aws-sdk/querystring-builder': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/property-provider/3.257.0:
     resolution: {integrity: sha512-3rUbRAcF0GZ5PhDiXhS4yREfZ5hOEtvYEa9S/19OdM5eoypOaLU5XnFcCKfnccSP8SkdgpJujzxOMRWNWadlAQ==}
     engines: {node: '>=14.0.0'}
@@ -1462,12 +1898,28 @@ packages:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
 
+  /@aws-sdk/property-provider/3.272.0:
+    resolution: {integrity: sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/protocol-http/3.257.0:
     resolution: {integrity: sha512-xt7LGOgZIvbLS3418AYQLacOqx+mo5j4mPiIMz7f6AaUg+/fBUgESVsncKDqxbEJVwwCXSka8Ca0cntJmoeMSw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/protocol-http/3.272.0:
+    resolution: {integrity: sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/querystring-builder/3.257.0:
     resolution: {integrity: sha512-mZHWLP7XIkzx1GIXO5WfX/iJ+aY9TWs02RE9FkdL2+by0HEMR65L3brQTbU1mIBJ7BjaPwYH24dljUOSABX7yg==}
@@ -1477,12 +1929,29 @@ packages:
       '@aws-sdk/util-uri-escape': 3.201.0
       tslib: 2.4.1
 
+  /@aws-sdk/querystring-builder/3.272.0:
+    resolution: {integrity: sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/util-uri-escape': 3.201.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/querystring-parser/3.257.0:
     resolution: {integrity: sha512-UDrE1dEwWrWT8dG2VCrGYrPxCWOkZ1fPTPkjpkR4KZEdQDZBqU5gYZF2xPj8Nz7pjQVHFuW2wFm3XYEk56GEjg==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/querystring-parser/3.272.0:
+    resolution: {integrity: sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/s3-request-presigner/3.264.0:
     resolution: {integrity: sha512-8DNVV4tO6xkmoUA6n8iCgRC9adL8e3aphSXNykA2jWricTaR1/NtD9+5uYeklQbEh4EVisaQJJldOMlbB2GtXQ==}
@@ -1505,12 +1974,25 @@ packages:
     resolution: {integrity: sha512-FAyR0XsueGkkqDtkP03cTJQk52NdQ9sZelLynmmlGPUP75LApRPvFe1riKrou6+LsDbwVNVffj6mbDfIcOhaOw==}
     engines: {node: '>=14.0.0'}
 
+  /@aws-sdk/service-error-classification/3.272.0:
+    resolution: {integrity: sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /@aws-sdk/shared-ini-file-loader/3.257.0:
     resolution: {integrity: sha512-HNjC1+Wx3xHiJc+CP14GhIdVhfQGSjroAsWseRxAhONocA9Fl1ZX4hx7+sA5c9nOoMVOovi6ivJ/6lCRPTDRrQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/shared-ini-file-loader/3.272.0:
+    resolution: {integrity: sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/signature-v4-multi-region/3.264.0:
     resolution: {integrity: sha512-45rNJeC245g2HtDlxlcgNhB9YU0PcWXGNOLOiMWq3cSMNsaKJoTD1tLdBke2VjW7Hz7QBCWLCRAftHatnWcdyg==}
@@ -1540,6 +2022,19 @@ packages:
       '@aws-sdk/util-utf8': 3.254.0
       tslib: 2.4.1
 
+  /@aws-sdk/signature-v4/3.272.0:
+    resolution: {integrity: sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/is-array-buffer': 3.201.0
+      '@aws-sdk/types': 3.272.0
+      '@aws-sdk/util-hex-encoding': 3.201.0
+      '@aws-sdk/util-middleware': 3.272.0
+      '@aws-sdk/util-uri-escape': 3.201.0
+      '@aws-sdk/util-utf8': 3.254.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/smithy-client/3.261.0:
     resolution: {integrity: sha512-j8XQEa3caZUVFVZfhJjaskw80O/tB+IXu84HMN44N7UkXaCFHirUsNjTDztJhnVXf/gKXzIqUqprfRnOvwLtIg==}
     engines: {node: '>=14.0.0'}
@@ -1547,6 +2042,15 @@ packages:
       '@aws-sdk/middleware-stack': 3.257.0
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/smithy-client/3.272.0:
+    resolution: {integrity: sha512-pvdleJ3kaRvyRw2pIZnqL85ZlWBOZrPKmR9I69GCvlyrfdjRBhbSjIEZ+sdhZudw0vdHxq25AGoLUXhofVLf5Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-stack': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/token-providers/3.264.0:
     resolution: {integrity: sha512-1N54FCdBJRqrwFWHUoDpGI0rKhI29Or9ZwGjjcBzKzLhz5sEF/DEhuID7h1/KKEkXdQ0+lmXOFGMMrahrMpOow==}
@@ -1560,8 +2064,27 @@ packages:
     transitivePeerDependencies:
       - aws-crt
 
+  /@aws-sdk/token-providers/3.272.0:
+    resolution: {integrity: sha512-0GISJ4IKN2rXvbSddB775VjBGSKhYIGQnAdMqbvxi9LB6pSvVxcH9aIL28G0spiuL+dy3yGQZ8RlJPAyP9JW9A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso-oidc': 3.272.0
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/shared-ini-file-loader': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: true
+
   /@aws-sdk/types/3.257.0:
     resolution: {integrity: sha512-LmqXuBQBGeaGi/3Rp7XiEX1B5IPO2UUfBVvu0wwGqVsmstT0SbOVDZGPmxygACbm64n+PRx3uTSDefRfoiWYZg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.4.1
+
+  /@aws-sdk/types/3.272.0:
+    resolution: {integrity: sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.4.1
@@ -1572,6 +2095,14 @@ packages:
       '@aws-sdk/querystring-parser': 3.257.0
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/url-parser/3.272.0:
+    resolution: {integrity: sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==}
+    dependencies:
+      '@aws-sdk/querystring-parser': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/util-arn-parser/3.208.0:
     resolution: {integrity: sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==}
@@ -1630,6 +2161,16 @@ packages:
       bowser: 2.11.0
       tslib: 2.4.1
 
+  /@aws-sdk/util-defaults-mode-browser/3.272.0:
+    resolution: {integrity: sha512-W8ZVJSZRuUBg8l0JEZzUc+9fKlthVp/cdE+pFeF8ArhZelOLCiaeCrMaZAeJusaFzIpa6cmOYQAjtSMVyrwRtg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      bowser: 2.11.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/util-defaults-mode-node/3.261.0:
     resolution: {integrity: sha512-4AK6yu4bOmHSocUdbGoEHbNXB09UA58ON2HBHY4NxMBuFBAd9XB2tYiyhce+Cm+o+lHbS8oQnw0VZw16WMzzew==}
     engines: {node: '>= 10.0.0'}
@@ -1640,6 +2181,18 @@ packages:
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/util-defaults-mode-node/3.272.0:
+    resolution: {integrity: sha512-U0NTcbMw6KFk7uz/avBmfxQSTREEiX6JDMH68oN/3ux4AICd2I4jHyxnloSWGuiER1FxZf1dEJ8ZTwy8Ibl21Q==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/config-resolver': 3.272.0
+      '@aws-sdk/credential-provider-imds': 3.272.0
+      '@aws-sdk/node-config-provider': 3.272.0
+      '@aws-sdk/property-provider': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/util-dynamodb/3.218.0:
     resolution: {integrity: sha512-qe6G2omXXX9u05J3hU1XOdlxlQWkrMXzV06PVVa+QufD0YgxoNYGxS/jcoFqSzi49ELPIYKuVwsZjJNwkTx8PA==}
@@ -1654,6 +2207,14 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/util-endpoints/3.272.0:
+    resolution: {integrity: sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/util-format-url/3.257.0:
     resolution: {integrity: sha512-Q/c1BLoEZLvnjagAE0nQryhQlFoC/a8ZrXJn4XljWPeFcFAVLpCoSzcTbQM1N4oQvDIgMvl5gBeGzp0BiW30QA==}
@@ -1682,12 +2243,27 @@ packages:
     dependencies:
       tslib: 2.4.1
 
+  /@aws-sdk/util-middleware/3.272.0:
+    resolution: {integrity: sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/util-retry/3.257.0:
     resolution: {integrity: sha512-l9TOsOAYtZxwW3q5fQKW4rsD9t2HVaBfQ4zBamHkNTfB4vBVvCnz4oxkvSvA2MlxCA6am+K1K/oj917Tpqk53g==}
     engines: {node: '>= 14.0.0'}
     dependencies:
       '@aws-sdk/service-error-classification': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/util-retry/3.272.0:
+    resolution: {integrity: sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==}
+    engines: {node: '>= 14.0.0'}
+    dependencies:
+      '@aws-sdk/service-error-classification': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/util-stream-browser/3.258.0:
     resolution: {integrity: sha512-MCAxHL3Hz/+eU4LZk0ZbLWAIUueH/jHpSbrloxZ3Dil2RL3w6NSJd5gE8zS7gs1B/eMcE600Brf5xSDR8kA5HA==}
@@ -1723,6 +2299,14 @@ packages:
       bowser: 2.11.0
       tslib: 2.4.1
 
+  /@aws-sdk/util-user-agent-browser/3.272.0:
+    resolution: {integrity: sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==}
+    dependencies:
+      '@aws-sdk/types': 3.272.0
+      bowser: 2.11.0
+      tslib: 2.4.1
+    dev: true
+
   /@aws-sdk/util-user-agent-node/3.259.0:
     resolution: {integrity: sha512-R0VTmNs+ySDDebU98BUbsLyeIM5YmAEr9esPpy15XfSy3AWmAeru8nLlztdaLilHZzLIDzvM2t7NGk/FzZFCvA==}
     engines: {node: '>=14.0.0'}
@@ -1735,6 +2319,20 @@ packages:
       '@aws-sdk/node-config-provider': 3.259.0
       '@aws-sdk/types': 3.257.0
       tslib: 2.4.1
+
+  /@aws-sdk/util-user-agent-node/3.272.0:
+    resolution: {integrity: sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+    dependencies:
+      '@aws-sdk/node-config-provider': 3.272.0
+      '@aws-sdk/types': 3.272.0
+      tslib: 2.4.1
+    dev: true
 
   /@aws-sdk/util-utf8-browser/3.188.0:
     resolution: {integrity: sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==}
@@ -1762,6 +2360,30 @@ packages:
     dependencies:
       tslib: 2.4.1
     dev: false
+
+  /@aws/workbench-core-audit/0.1.1:
+    resolution: {integrity: sha512-rAqrXzQiZ1yz+gS7hJv6iLNrT5pj/hhdKIgVyAO0eCwO5hJMeMEhER37jo6p9BhXDlHrhX0/t1CIUpHlxYeI8g==}
+    dependencies:
+      '@aws/workbench-core-authorization': 0.1.1
+      lodash: 4.17.21
+    dev: true
+
+  /@aws/workbench-core-authorization/0.1.1:
+    resolution: {integrity: sha512-sDEMU9QdZS95GhHQULC2D8X0qu0YkSoX4b5UuqJebanb8MALqz2qw75KCvm+r/YCdbPAjr82XOXFWnpqVli5OA==}
+    dependencies:
+      '@aws/workbench-core-logging': 0.1.1
+      '@casl/ability': 5.4.4
+      lodash: 4.17.21
+    dev: true
+
+  /@aws/workbench-core-logging/0.1.1:
+    resolution: {integrity: sha512-y4o7HrR7x12EGFQ78RGmKiUJ+uoh/K+yCmD2aYJ9KvmdbBjPvtDeCM0wP7vQJ4yzce51NMYbdgoJ0iIUFjY7sg==}
+    dependencies:
+      '@types/triple-beam': 1.3.2
+      triple-beam: 1.3.0
+      winston: 3.8.2
+      winston-transport: 4.5.0
+    dev: true
 
   /@babel/code-frame/7.18.6:
     resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
@@ -3025,6 +3647,12 @@ packages:
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
+
+  /@casl/ability/5.4.4:
+    resolution: {integrity: sha512-7+GOnMUq6q4fqtDDesymBXTS9LSDVezYhFiSJ8Rn3f0aQLeRm7qHn66KWbej4niCOvm0XzNj9jzpkK0yz6hUww==}
+    dependencies:
+      '@ucast/mongo2js': 1.3.4
     dev: true
 
   /@casl/ability/6.3.3:

--- a/source/dea-app/README.md
+++ b/source/dea-app/README.md
@@ -5,6 +5,6 @@
 
 | Statements                                                                         | Branches                                                                      | Functions                                                                        | Lines                                                                   |
 | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-99.21%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-86.76%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-98.16%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-99.11%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-99.39%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-86.8%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-99.11%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-99.31%25-brightgreen.svg?style=flat) |
 
 This project is the routing package for `dea-backend`. It is used by `dea-backend` to generate routes for DEA API. Please refer [here](../dea-backend/README.md) for more information on how to use this project.

--- a/source/dea-app/package.json
+++ b/source/dea-app/package.json
@@ -59,6 +59,8 @@
     "@types/jsonwebtoken": "~9.0.1"
   },
   "devDependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "~3.272.0",
+    "@aws/workbench-core-audit": "~0.1.1",
     "@casl/ability": "~6.3.3",
     "@rushstack/eslint-config": "^3.0.0",
     "@rushstack/heft": "^0.48.8",

--- a/source/dea-app/src/app/audit/dea-audit-plugin.ts
+++ b/source/dea-app/src/app/audit/dea-audit-plugin.ts
@@ -1,0 +1,15 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CloudWatchLogsClient } from '@aws-sdk/client-cloudwatch-logs';
+import BaseAuditPlugin from '@aws/workbench-core-audit/lib/plugins/baseAuditPlugin';
+import DeaAuditWriter from './dea-audit-writer';
+
+const region = process.env.AWS_REGION ?? 'us-east-1';
+
+export const defaultCloudwatchClient = new CloudWatchLogsClient({ region });
+
+const theWriter = new DeaAuditWriter(defaultCloudwatchClient);
+export const deaAuditPlugin = new BaseAuditPlugin(theWriter);

--- a/source/dea-app/src/app/audit/dea-audit-writer.ts
+++ b/source/dea-app/src/app/audit/dea-audit-writer.ts
@@ -1,0 +1,45 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CloudWatchLogsClient,
+  CreateLogGroupCommandOutput,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+} from '@aws-sdk/client-cloudwatch-logs';
+import AuditEntry from '@aws/workbench-core-audit/lib/auditEntry';
+import Metadata from '@aws/workbench-core-audit/lib/metadata';
+import Writer from '@aws/workbench-core-audit/lib/plugins/writer';
+import { now } from 'lodash';
+import { getRequiredEnv } from '../../lambda-http-helpers';
+
+const auditLogGroup = getRequiredEnv('AUDIT_LOG_GROUP_NAME', 'AUDIT_LOG_GROUP_UNSPECIFIED');
+const lambdaName = getRequiredEnv('AWS_LAMBDA_FUNCTION_NAME', 'NO_LAMBDA_NAME_FOUND');
+
+export default class DeaAuditWriter implements Writer {
+  private _isLogStreamReady: Promise<CreateLogGroupCommandOutput>;
+  private _logStreamName: string;
+
+  public constructor(private cloudwatchClient: CloudWatchLogsClient) {
+    this._logStreamName = `${lambdaName}-${new Date().toISOString()}`.replaceAll(':', '');
+    const createLogStreamCommand = new CreateLogStreamCommand({
+      logGroupName: auditLogGroup,
+      logStreamName: this._logStreamName,
+    });
+    this._isLogStreamReady = cloudwatchClient.send(createLogStreamCommand);
+  }
+
+  public async write(metadata: Metadata, auditEntry: AuditEntry): Promise<void> {
+    // ensure logstream was created
+    await this._isLogStreamReady;
+    const putLogsCommand = new PutLogEventsCommand({
+      logGroupName: auditLogGroup,
+      logStreamName: this._logStreamName,
+      logEvents: [{ timestamp: now(), message: JSON.stringify(auditEntry) }],
+    });
+
+    void this.cloudwatchClient.send(putLogsCommand);
+  }
+}

--- a/source/dea-app/src/app/services/audit-service.ts
+++ b/source/dea-app/src/app/services/audit-service.ts
@@ -1,0 +1,17 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import AuditService from '@aws/workbench-core-audit/lib/auditService';
+import { deaAuditPlugin } from '../audit/dea-audit-plugin';
+
+const continueOnError = false;
+const requiredAuditValues = ['actor', 'source'];
+const fieldsToMask = ['password', 'accessKey', 'idToken', 'X-Amz-Security-Token'];
+export const auditService = new AuditService(
+  deaAuditPlugin,
+  continueOnError,
+  requiredAuditValues,
+  fieldsToMask
+);

--- a/source/dea-app/src/logger.ts
+++ b/source/dea-app/src/logger.ts
@@ -22,16 +22,16 @@ export const logLevel = (): LogLevel => {
 };
 
 export const logger = {
-  debug: (msg: string, obj: object) => {
+  debug: (msg: string, obj?: object) => {
     console.debug(`${msg}`, obj);
   },
-  error: (msg: string, obj: object) => {
+  error: (msg: string, obj?: object) => {
     console.error(`${msg}`, obj);
   },
-  info: (msg: string, obj: object) => {
+  info: (msg: string, obj?: object) => {
     console.info(`${msg}`, obj);
   },
-  warn: (msg: string, obj: object) => {
+  warn: (msg: string, obj?: object) => {
     console.warn(`${msg}`, obj);
   },
 };

--- a/source/dea-app/src/test/services/audit-service.unit.test.ts
+++ b/source/dea-app/src/test/services/audit-service.unit.test.ts
@@ -1,0 +1,30 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CloudWatchLogsClient,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+} from '@aws-sdk/client-cloudwatch-logs';
+import { anyOfClass, instance, mock, verify } from 'ts-mockito';
+import DeaAuditWriter from '../../app/audit/dea-audit-writer';
+import { auditService } from '../../app/services/audit-service';
+
+describe('audit service', () => {
+  it('writes', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    const writer = new DeaAuditWriter(clientMockInstance);
+
+    await writer.write({ tag: 'youre it' }, { action: 'create', actor: { name: 'Mickey' } });
+    verify(clientMock.send(anyOfClass(CreateLogStreamCommand)));
+    verify(clientMock.send(anyOfClass(PutLogEventsCommand)));
+  });
+
+  it('exists', () => {
+    expect(auditService).toBeDefined();
+    expect('write' in auditService).toBeTruthy();
+  });
+});

--- a/source/dea-app/tsconfig.json
+++ b/source/dea-app/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "target": "ES2020",
+  "target": "ES2022",
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
     "strict": true,
     "types": ["heft-jest", "node"],
-    "lib": ["es2020", "dom"],
+    "lib": ["es2022", "dom"],
     "baseUrl": "./",
     "paths": {
       "*": ["src/test/custom-types/*"]

--- a/source/dea-backend/README.md
+++ b/source/dea-backend/README.md
@@ -6,7 +6,7 @@
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-95.03%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-93.87%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-94.64%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-94.92%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-93.91%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-92.15%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-93.44%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.78%25-brightgreen.svg?style=flat) |
 
 
 ## Useful commands

--- a/source/dea-backend/src/config.ts
+++ b/source/dea-backend/src/config.ts
@@ -5,6 +5,7 @@
 
 import path from 'path';
 import { RemovalPolicy } from 'aws-cdk-lib';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import convict from 'convict';
 // https://www.npmjs.com/package/convict
 
@@ -151,6 +152,7 @@ interface DEAConfig {
   isTestStack(): boolean;
   userGroups(): DEAUserPoolGroupDefinition[];
   retainPolicy(): RemovalPolicy;
+  retentionDays(): RetentionDays;
 }
 
 export const convictConfig = convict(convictSchema);
@@ -164,6 +166,7 @@ export const deaConfig: DEAConfig = {
   isTestStack: () => convictConfig.get('testStack'),
   userGroups: () => convictConfig.get('userGroups'),
   retainPolicy: () => (convictConfig.get('testStack') ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN),
+  retentionDays: () => (convictConfig.get('testStack') ? RetentionDays.TWO_WEEKS : RetentionDays.INFINITE),
 };
 
 export const loadConfig = (stage: string): void => {

--- a/source/dea-backend/src/constructs/dea-audit-trail.ts
+++ b/source/dea-backend/src/constructs/dea-audit-trail.ts
@@ -1,0 +1,59 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { StackProps } from 'aws-cdk-lib';
+import * as CloudTrail from 'aws-cdk-lib/aws-cloudtrail';
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { BlockPublicAccess, Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+import { deaConfig } from '../config';
+
+interface DeaAuditProps extends StackProps {
+  readonly kmsKey: Key;
+}
+
+export class DeaAuditTrail extends Construct {
+  public auditTrail: CloudTrail.Trail;
+  public auditLogGroup: LogGroup;
+  public trailLogGroup: LogGroup;
+
+  public constructor(scope: Construct, stackName: string, props: DeaAuditProps) {
+    super(scope, stackName);
+
+    this.auditLogGroup = this._createLogGroup(scope, 'deaAuditLogs', props.kmsKey);
+    this.trailLogGroup = this._createLogGroup(scope, 'deaTrailLogs', props.kmsKey);
+    this.auditTrail = this._createAuditTrail(scope, this.trailLogGroup, props.kmsKey);
+    props.kmsKey.grantEncrypt(new ServicePrincipal('cloudtrail.amazonaws.com'));
+  }
+
+  private _createAuditTrail(scope: Construct, trailLogGroup: LogGroup, kmsKey: Key) {
+    const trailBucket = new Bucket(this, 'deaTrailBucket', {
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      encryption: BucketEncryption.KMS,
+      encryptionKey: kmsKey,
+      enforceSSL: true,
+      publicReadAccess: false,
+      removalPolicy: deaConfig.retainPolicy(),
+      autoDeleteObjects: deaConfig.isTestStack(),
+    });
+
+    return new CloudTrail.Trail(scope, 'deaTrail', {
+      bucket: trailBucket,
+      sendToCloudWatchLogs: true,
+      cloudWatchLogGroup: trailLogGroup,
+      encryptionKey: kmsKey,
+    });
+  }
+
+  private _createLogGroup(scope: Construct, id: string, kmsKey: Key) {
+    return new LogGroup(scope, id, {
+      encryptionKey: kmsKey,
+      retention: deaConfig.retentionDays(),
+      removalPolicy: deaConfig.retainPolicy(),
+    });
+  }
+}

--- a/source/dea-backend/src/index.ts
+++ b/source/dea-backend/src/index.ts
@@ -7,6 +7,7 @@
 import 'source-map-support/register';
 import { deaConfig } from './config';
 import { createCfnOutput } from './constructs/construct-support';
+import { DeaAuditTrail } from './constructs/dea-audit-trail';
 import { DeaAuthConstruct } from './constructs/dea-auth';
 import { DeaBackendConstruct } from './constructs/dea-backend-stack';
 import { DeaRestApiConstruct } from './constructs/dea-rest-api';
@@ -14,6 +15,7 @@ import { addSnapshotSerializers } from './test/infra/dea-snapshot-serializers';
 import { validateBackendConstruct } from './test/infra/validate-backend-construct';
 
 export {
+  DeaAuditTrail,
   DeaAuthConstruct,
   DeaBackendConstruct,
   DeaRestApiConstruct,

--- a/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
+++ b/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
@@ -141,6 +141,187 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "DeaAuditdeaTrailBucket4819FF43": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "KMSMasterKeyID": Object {
+                  "Fn::GetAtt": Array [
+                    "testKey1CDDDD5E",
+                    "Arn",
+                  ],
+                },
+                "SSEAlgorithm": "aws:kms",
+              },
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeaAuditdeaTrailBucketAutoDeleteObjectsCustomResourceA4FC66B6": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DeaAuditdeaTrailBucketPolicyA68DF945",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DeaAuditdeaTrailBucket4819FF43",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeaAuditdeaTrailBucketPolicyA68DF945": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "DeaAuditdeaTrailBucket4819FF43",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaAuditdeaTrailBucket4819FF43",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaAuditdeaTrailBucket4819FF43",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaAuditdeaTrailBucket4819FF43",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaAuditdeaTrailBucket4819FF43",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:GetBucketAcl",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "cloudtrail.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DeaAuditdeaTrailBucket4819FF43",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "s3:x-amz-acl": "bucket-owner-full-control",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "cloudtrail.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DeaAuditdeaTrailBucket4819FF43",
+                        "Arn",
+                      ],
+                    },
+                    "/AWSLogs/",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "DeaBackendConstructDeaTableB48721A0": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
@@ -625,6 +806,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -681,6 +865,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -737,6 +924,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -793,6 +983,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -849,6 +1042,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -905,6 +1101,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -961,6 +1160,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -1017,6 +1219,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -1073,6 +1278,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -1129,6 +1337,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -1185,6 +1396,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -1241,6 +1455,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -1297,6 +1514,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -1353,6 +1573,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -1409,6 +1632,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -1465,6 +1691,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
@@ -4633,6 +4862,116 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "deaAuditLogs7B75D3F1": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "KmsKeyId": Object {
+          "Fn::GetAtt": Array [
+            "testKey1CDDDD5E",
+            "Arn",
+          ],
+        },
+        "RetentionInDays": 14,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "deaTrail2681791A": Object {
+      "DependsOn": Array [
+        "DeaAuditdeaTrailBucketPolicyA68DF945",
+        "deaTrailLogsRoleDefaultPolicyA1D73827",
+        "deaTrailLogsRole13472204",
+      ],
+      "Properties": Object {
+        "CloudWatchLogsLogGroupArn": Object {
+          "Fn::GetAtt": Array [
+            "deaTrailLogs0A0531F5",
+            "Arn",
+          ],
+        },
+        "CloudWatchLogsRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "deaTrailLogsRole13472204",
+            "Arn",
+          ],
+        },
+        "EnableLogFileValidation": true,
+        "EventSelectors": Array [],
+        "IncludeGlobalServiceEvents": true,
+        "IsLogging": true,
+        "IsMultiRegionTrail": true,
+        "KMSKeyId": Object {
+          "Fn::GetAtt": Array [
+            "testKey1CDDDD5E",
+            "Arn",
+          ],
+        },
+        "S3BucketName": Object {
+          "Ref": "DeaAuditdeaTrailBucket4819FF43",
+        },
+      },
+      "Type": "AWS::CloudTrail::Trail",
+    },
+    "deaTrailLogs0A0531F5": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "KmsKeyId": Object {
+          "Fn::GetAtt": Array [
+            "testKey1CDDDD5E",
+            "Arn",
+          ],
+        },
+        "RetentionInDays": 14,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "deaTrailLogsRole13472204": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "cloudtrail.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "deaTrailLogsRoleDefaultPolicyA1D73827": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:PutLogEvents",
+                "logs:CreateLogStream",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "deaTrailLogs0A0531F5",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "deaTrailLogsRoleDefaultPolicyA1D73827",
+        "Roles": Array [
+          Object {
+            "Ref": "deaTrailLogsRole13472204",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "testKey1CDDDD5E": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
@@ -4659,6 +4998,18 @@ Object {
                     ],
                   ],
                 },
+              },
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "cloudtrail.amazonaws.com",
               },
               "Resource": "*",
             },

--- a/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
+++ b/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
@@ -9,6 +9,7 @@ import { Template } from 'aws-cdk-lib/assertions';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import 'source-map-support/register';
 import { convictConfig } from '../../config';
+import { DeaAuditTrail } from '../../constructs/dea-audit-trail';
 import { DeaAuthConstruct } from '../../constructs/dea-auth';
 import { DeaBackendConstruct } from '../../constructs/dea-backend-stack';
 import { DeaRestApiConstruct } from '../../constructs/dea-rest-api';
@@ -44,6 +45,9 @@ describe('DeaBackend constructs', () => {
       kmsKey: key,
       accessLogsPrefixes: ['dea-ui-access-log'],
     });
+    const auditTrail = new DeaAuditTrail(stack, 'DeaAudit', {
+      kmsKey: key,
+    });
     const restApi = new DeaRestApiConstruct(stack, 'DeaRestApiConstruct', {
       deaTableArn: backend.deaTable.tableArn,
       deaTableName: backend.deaTable.tableName,
@@ -52,6 +56,11 @@ describe('DeaBackend constructs', () => {
       kmsKey: key,
       region: stack.region,
       accountId: stack.account,
+      lambdaEnv: {
+        AUDIT_LOG_GROUP_NAME: auditTrail.auditLogGroup.logGroupName,
+        TABLE_NAME: backend.deaTable.tableName,
+        DATASETS_BUCKET_NAME: backend.datasetsBucket.bucketName,
+      },
     });
 
     // Prepare the stack for assertions.
@@ -102,6 +111,9 @@ describe('DeaBackend constructs', () => {
       kmsKey: key,
       accessLogsPrefixes: ['dea-ui-access-log'],
     });
+    const auditTrail = new DeaAuditTrail(stack, 'DeaAudit', {
+      kmsKey: key,
+    });
     const restApi = new DeaRestApiConstruct(stack, 'DeaRestApiConstruct', {
       deaTableArn: backend.deaTable.tableArn,
       deaTableName: backend.deaTable.tableName,
@@ -110,6 +122,11 @@ describe('DeaBackend constructs', () => {
       kmsKey: key,
       region: stack.region,
       accountId: stack.account,
+      lambdaEnv: {
+        AUDIT_LOG_GROUP_NAME: auditTrail.auditLogGroup.logGroupName,
+        TABLE_NAME: backend.deaTable.tableName,
+        DATASETS_BUCKET_NAME: backend.datasetsBucket.bucketName,
+      },
     });
 
     const apiEndpointArns = new Map([

--- a/source/dea-backend/src/test/infra/validate-backend-construct.ts
+++ b/source/dea-backend/src/test/infra/validate-backend-construct.ts
@@ -46,19 +46,23 @@ export const validateBackendConstruct = (template: Template): void => {
   // validate datasets S3 bucket properties
   template.hasResourceProperties('AWS::S3::Bucket', {
     VersioningConfiguration: Match.objectLike({
-      Status: "Enabled"
+      Status: 'Enabled',
     }),
     ObjectLockEnabled: true,
     LifecycleConfiguration: Match.objectLike({
       Rules: Match.arrayWith([
         Match.objectLike({
           AbortIncompleteMultipartUpload: {
-            DaysAfterInitiation: 1
+            DaysAfterInitiation: 1,
           },
-          Id: "DeaDatasetsDeleteIncompleteUploadsLifecyclePolicy",
-          Status: "Enabled"
-        })
-      ])
-    })
+          Id: 'DeaDatasetsDeleteIncompleteUploadsLifecyclePolicy',
+          Status: 'Enabled',
+        }),
+      ]),
+    }),
+  });
+
+  template.hasResourceProperties('AWS::CloudTrail::Trail', {
+    IsLogging: true,
   });
 };

--- a/source/dea-backend/tsconfig.json
+++ b/source/dea-backend/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "target": "ES2020",
+  "target": "ES2022",
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
     "strict": true,
     "types": ["heft-jest", "node"],
-    "lib": ["es2020", "dom"],
+    "lib": ["es2022", "dom"],
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],

--- a/source/dea-main/src/dea-main-stack.ts
+++ b/source/dea-main/src/dea-main-stack.ts
@@ -6,6 +6,7 @@
 /* eslint-disable no-new */
 import {
   createCfnOutput,
+  DeaAuditTrail,
   DeaAuthConstruct,
   DeaBackendConstruct,
   deaConfig,
@@ -45,6 +46,11 @@ export class DeaMainStack extends cdk.Stack {
 
     const region = this.region;
     const accountId = this.account;
+
+    const auditTrail = new DeaAuditTrail(this, 'DeaAudit', {
+      kmsKey,
+    });
+
     const deaApi = new DeaRestApiConstruct(this, 'DeaApiGateway', {
       deaTableArn: backendConstruct.deaTable.tableArn,
       deaTableName: backendConstruct.deaTable.tableName,
@@ -53,6 +59,11 @@ export class DeaMainStack extends cdk.Stack {
       kmsKey,
       region,
       accountId,
+      lambdaEnv: {
+        AUDIT_LOG_GROUP_NAME: auditTrail.auditLogGroup.logGroupName,
+        TABLE_NAME: backendConstruct.deaTable.tableName,
+        DATASETS_BUCKET_NAME: backendConstruct.datasetsBucket.bucketName,
+      },
     });
 
     new DeaAuthConstruct(this, 'DeaAuth', {

--- a/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
+++ b/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
@@ -423,6 +423,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -479,6 +482,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -535,6 +541,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -591,6 +600,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -647,6 +659,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -703,6 +718,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -759,6 +777,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -815,6 +836,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -871,6 +895,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -927,6 +954,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -983,6 +1013,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -1039,6 +1072,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -1095,6 +1131,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -1151,6 +1190,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -1207,6 +1249,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -1263,6 +1308,9 @@ Object {
         },
         "Environment": Object {
           "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DATASETS_BUCKET_NAME": Object {
               "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
@@ -4716,6 +4764,187 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "DeaAuditdeaTrailBucket4819FF43": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "KMSMasterKeyID": Object {
+                  "Fn::GetAtt": Array [
+                    "primaryCustomerKey87EC2263",
+                    "Arn",
+                  ],
+                },
+                "SSEAlgorithm": "aws:kms",
+              },
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeaAuditdeaTrailBucketAutoDeleteObjectsCustomResourceA4FC66B6": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DeaAuditdeaTrailBucketPolicyA68DF945",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DeaAuditdeaTrailBucket4819FF43",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeaAuditdeaTrailBucketPolicyA68DF945": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "DeaAuditdeaTrailBucket4819FF43",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaAuditdeaTrailBucket4819FF43",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaAuditdeaTrailBucket4819FF43",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaAuditdeaTrailBucket4819FF43",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DeaAuditdeaTrailBucket4819FF43",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:GetBucketAcl",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "cloudtrail.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DeaAuditdeaTrailBucket4819FF43",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "s3:x-amz-acl": "bucket-owner-full-control",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "cloudtrail.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DeaAuditdeaTrailBucket4819FF43",
+                        "Arn",
+                      ],
+                    },
+                    "/AWSLogs/",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "DeaAuthAuthTestGroup72A5E3A7": Object {
       "Properties": Object {
         "Description": "Group used for auth e2e testing",
@@ -7129,6 +7358,116 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "deaAuditLogs7B75D3F1": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "KmsKeyId": Object {
+          "Fn::GetAtt": Array [
+            "primaryCustomerKey87EC2263",
+            "Arn",
+          ],
+        },
+        "RetentionInDays": 14,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "deaTrail2681791A": Object {
+      "DependsOn": Array [
+        "DeaAuditdeaTrailBucketPolicyA68DF945",
+        "deaTrailLogsRoleDefaultPolicyA1D73827",
+        "deaTrailLogsRole13472204",
+      ],
+      "Properties": Object {
+        "CloudWatchLogsLogGroupArn": Object {
+          "Fn::GetAtt": Array [
+            "deaTrailLogs0A0531F5",
+            "Arn",
+          ],
+        },
+        "CloudWatchLogsRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "deaTrailLogsRole13472204",
+            "Arn",
+          ],
+        },
+        "EnableLogFileValidation": true,
+        "EventSelectors": Array [],
+        "IncludeGlobalServiceEvents": true,
+        "IsLogging": true,
+        "IsMultiRegionTrail": true,
+        "KMSKeyId": Object {
+          "Fn::GetAtt": Array [
+            "primaryCustomerKey87EC2263",
+            "Arn",
+          ],
+        },
+        "S3BucketName": Object {
+          "Ref": "DeaAuditdeaTrailBucket4819FF43",
+        },
+      },
+      "Type": "AWS::CloudTrail::Trail",
+    },
+    "deaTrailLogs0A0531F5": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "KmsKeyId": Object {
+          "Fn::GetAtt": Array [
+            "primaryCustomerKey87EC2263",
+            "Arn",
+          ],
+        },
+        "RetentionInDays": 14,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "deaTrailLogsRole13472204": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "cloudtrail.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "deaTrailLogsRoleDefaultPolicyA1D73827": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:PutLogEvents",
+                "logs:CreateLogStream",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "deaTrailLogs0A0531F5",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "deaTrailLogsRoleDefaultPolicyA1D73827",
+        "Roles": Array [
+          Object {
+            "Ref": "deaTrailLogsRole13472204",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "primaryCustomerKey87EC2263": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
@@ -7184,6 +7523,18 @@ Object {
               },
               "Resource": "*",
               "Sid": "main-key-share-statement",
+            },
+            Object {
+              "Action": Array [
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "cloudtrail.amazonaws.com",
+              },
+              "Resource": "*",
             },
             Object {
               "Action": Array [

--- a/source/dea-main/tsconfig.json
+++ b/source/dea-main/tsconfig.json
@@ -1,12 +1,12 @@
 {
-  "target": "ES2020",
+  "target": "ES2022",
   "preserveSymlinks": true,
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
     "strict": true,
     "types": ["heft-jest", "node"],
-    "lib": ["es2020", "dom"],
+    "lib": ["es2022", "dom"],
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],

--- a/source/dea-ui/infrastructure/tsconfig.json
+++ b/source/dea-ui/infrastructure/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "target": "ES2020",
+  "target": "ES2022",
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
     "strict": true,
     "types": ["heft-jest", "node"],
-    "lib": ["es2020", "dom"],
+    "lib": ["es2022", "dom"],
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],

--- a/source/dea-ui/ui/cypress/tsconfig.json
+++ b/source/dea-ui/ui/cypress/tsconfig.json
@@ -1,13 +1,11 @@
 {
-    "compilerOptions": {
-      "target": "es5",
-      "lib": ["es5", "dom"],
-      "types": ["jest", "cypress", "node"],
-      "isolatedModules": false,
-    },
-    "include": ["**/*.ts", "e2e/pages/dashboard.cy.tsx"],
-    "files": ["../cypress.config.ts"],
-    "exclude": [
-        "../cypress.config.ts"
-    ]
-  }
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["es2022", "dom"],
+    "types": ["jest", "cypress", "node"],
+    "isolatedModules": false
+  },
+  "include": ["**/*.ts", "e2e/pages/dashboard.cy.tsx"],
+  "files": ["../cypress.config.ts"],
+  "exclude": ["../cypress.config.ts"]
+}

--- a/source/dea-ui/ui/tsconfig.json
+++ b/source/dea-ui/ui/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,28 +15,12 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "paths": {
-      "^@/components/(.*)$": [
-        "/components/*"
-      ],
-      "^@/pages/(.*)$": [
-        "/pages/*"
-      ]
+      "^@/components/(.*)$": ["/components/*"],
+      "^@/pages/(.*)$": ["/pages/*"]
     },
-    "types": [
-      "heft-jest",
-      "node"
-    ]
+    "types": ["heft-jest", "node"]
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    "jest-setup.ts"
-  ],
-  "exclude": [
-    "cypress.config.ts",
-    "node_modules",
-    "infrastructure"
-  ],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "jest-setup.ts"],
+  "exclude": ["cypress.config.ts", "node_modules", "infrastructure"],
   "rootDir": "."
 }


### PR DESCRIPTION
- target latest ES2022
- add audit stack which includes audit log group, cloudtrail trail with a trail log group and s3 bucket
- add audit-service and write functionality

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
