### PR TITLE
refactor: use a provider for our dummy event to keep it safe

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -25,4 +25,4 @@ source/dea-backend/config/test.json:5
 source/dea-backend/src/config/test.yaml:5
 source/dea-ui/ui/src/models/User.ts:19
 source/dea-backend/src/config/demo.yaml:5
-source/dea-app/src/test/integration-objects.ts:83
+source/dea-app/src/test/integration-objects.ts:84

--- a/source/dea-app/src/index.ts
+++ b/source/dea-app/src/index.ts
@@ -31,7 +31,7 @@ import { getCaseUser } from './app/services/case-user-service';
 import { getRequiredPathParam, getUserUlid } from './lambda-http-helpers';
 import { DeaCase } from './models/case';
 import { CaseAction } from './models/case-action';
-import { dummyContext, dummyEvent, getDummyEvent } from './test/integration-objects';
+import { dummyContext, getDummyEvent } from './test/integration-objects';
 import { getTestAuditService } from './test/services/test-audit-service-provider';
 
 export {
@@ -70,6 +70,5 @@ export {
   NOT_FOUND_ERROR_NAME,
   ValidationError,
   VALIDATION_ERROR_NAME,
-  dummyEvent,
   dummyContext,
 };

--- a/source/dea-app/src/test/app/resources/complete-case-file-upload.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/complete-case-file-upload.integration.test.ts
@@ -21,7 +21,7 @@ import { CaseFileStatus } from '../../../models/case-file-status';
 import { CaseStatus } from '../../../models/case-status';
 import { DeaUser } from '../../../models/user';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 import {
   callCompleteCaseFileUpload,
@@ -47,7 +47,7 @@ const DATASETS_PROVIDER = {
   presignedCommandExpirySeconds: 3600,
 };
 
-const EVENT = dummyEvent;
+const EVENT = getDummyEvent();
 
 jest.setTimeout(30000);
 

--- a/source/dea-app/src/test/app/resources/create-case-membership.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/create-case-membership.integration.test.ts
@@ -18,7 +18,7 @@ import { caseUserResponseSchema } from '../../../models/validation/case-user';
 import { jsonParseWithDates } from '../../../models/validation/json-parse-with-dates';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
 import { createUser } from '../../../persistence/user';
-import { dummyContext, dummyEvent, getDummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 let repositoryProvider: ModelRepositoryProvider;
@@ -88,22 +88,18 @@ describe('create case membership resource', () => {
   });
 
   it('should error if the path param is not provided', async () => {
-    await expect(createCaseMembership(dummyEvent, dummyContext, repositoryProvider)).rejects.toThrow(
+    await expect(createCaseMembership(getDummyEvent(), dummyContext, repositoryProvider)).rejects.toThrow(
       ValidationError
     );
   });
 
   it('should error if no payload is provided', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
-        },
-        body: null,
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      },
+      body: null,
+    });
 
     await expect(createCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'CaseUser payload missing.'
@@ -114,20 +110,16 @@ describe('create case membership resource', () => {
     const ulid1 = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
     const ulid2 = '02ARZ3NDEKTSV4RRFFQ69G5FAV';
     const ulid3 = '03ARZ3NDEKTSV4RRFFQ69G5FAV';
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: ulid1,
-        },
-        body: JSON.stringify({
-          userUlid: ulid3,
-          caseUlid: ulid2,
-          actions: [CaseAction.VIEW_CASE_DETAILS],
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: ulid1,
+      },
+      body: JSON.stringify({
+        userUlid: ulid3,
+        caseUlid: ulid2,
+        actions: [CaseAction.VIEW_CASE_DETAILS],
+      }),
+    });
 
     await expect(createCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'Requested Case Ulid does not match resource'
@@ -143,20 +135,16 @@ describe('create case membership resource', () => {
     const user = await UserService.createUser(deaUser, repositoryProvider);
 
     const bogusUlid = '02ARZ3NDEKTSV4RRFFQ69G5FDV';
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: bogusUlid,
-        },
-        body: JSON.stringify({
-          userUlid: user.ulid,
-          caseUlid: bogusUlid,
-          actions: [CaseAction.VIEW_CASE_DETAILS],
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: bogusUlid,
+      },
+      body: JSON.stringify({
+        userUlid: user.ulid,
+        caseUlid: bogusUlid,
+        actions: [CaseAction.VIEW_CASE_DETAILS],
+      }),
+    });
 
     await expect(createCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       NotFoundError
@@ -180,20 +168,16 @@ describe('create case membership resource', () => {
     const newCase = await CaseService.createCases(deaCase, user, repositoryProvider);
 
     const bogusUlid = '02ARZ3NDEKTSV4RRFFQ69G5FAV';
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: newCase.ulid,
-        },
-        body: JSON.stringify({
-          userUlid: bogusUlid,
-          caseUlid: newCase.ulid,
-          actions: [CaseAction.VIEW_CASE_DETAILS],
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: newCase.ulid,
+      },
+      body: JSON.stringify({
+        userUlid: bogusUlid,
+        caseUlid: newCase.ulid,
+        actions: [CaseAction.VIEW_CASE_DETAILS],
+      }),
+    });
 
     await expect(createCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       NotFoundError

--- a/source/dea-app/src/test/app/resources/delete-case-membership.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/delete-case-membership.integration.test.ts
@@ -14,7 +14,7 @@ import { DeaUser, DeaUserInput } from '../../../models/user';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
 import { createUser } from '../../../persistence/user';
 import { bogusUlid } from '../../../test-e2e/resources/test-helpers';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 let repositoryProvider: ModelRepositoryProvider;
@@ -65,16 +65,12 @@ describe('delete case membership resource', () => {
       repositoryProvider
     );
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: newCase.ulid,
-          userId: user.ulid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: newCase.ulid,
+        userId: user.ulid,
+      },
+    });
 
     // membership exists before delete
     expect(
@@ -91,44 +87,32 @@ describe('delete case membership resource', () => {
   });
 
   it('should make no alert for removing a membership that does not exist', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: bogusUlid,
-          userId: bogusUlid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: bogusUlid,
+        userId: bogusUlid,
+      },
+    });
 
     const response = await deleteCaseMembership(event, dummyContext, repositoryProvider);
     expect(response.statusCode).toEqual(204);
   });
 
   it('should error if path params are missing', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: bogusUlid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: bogusUlid,
+      },
+    });
 
     await expect(deleteCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       ValidationError
     );
-    const event2 = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          userId: bogusUlid,
-        },
-      }
-    );
+    const event2 = getDummyEvent({
+      pathParameters: {
+        userId: bogusUlid,
+      },
+    });
 
     await expect(deleteCaseMembership(event2, dummyContext, repositoryProvider)).rejects.toThrow(
       ValidationError

--- a/source/dea-app/src/test/app/resources/delete-cases.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/delete-cases.integration.test.ts
@@ -13,7 +13,7 @@ import { CaseAction } from '../../../models/case-action';
 import { createCase } from '../../../persistence/case';
 import { listCaseUsersByCase } from '../../../persistence/case-user';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 let repositoryProvider: ModelRepositoryProvider;
@@ -28,15 +28,11 @@ describe('delete cases resource', () => {
   });
 
   it('should respond with success if the target entity does not exist', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      },
+    });
 
     const response = await deleteCase(event, dummyContext, repositoryProvider);
 
@@ -59,15 +55,11 @@ describe('delete cases resource', () => {
     };
     const createdCase = await createCase(theCase, user, repositoryProvider);
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: createdCase.ulid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: createdCase.ulid,
+      },
+    });
 
     const response = await deleteCase(event, dummyContext, repositoryProvider);
 
@@ -121,15 +113,11 @@ describe('delete cases resource', () => {
     const usersOnCase = await listCaseUsersByCase(createdCase.ulid, 30, undefined, repositoryProvider);
     expect(usersOnCase.length).toEqual(29);
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: createdCase.ulid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: createdCase.ulid,
+      },
+    });
 
     const response = await deleteCase(event, dummyContext, repositoryProvider);
 
@@ -149,6 +137,8 @@ describe('delete cases resource', () => {
   }, 30000);
 
   it('should error if the path param is not provided', async () => {
-    await expect(deleteCase(dummyEvent, dummyContext, repositoryProvider)).rejects.toThrow(ValidationError);
+    await expect(deleteCase(getDummyEvent(), dummyContext, repositoryProvider)).rejects.toThrow(
+      ValidationError
+    );
   });
 });

--- a/source/dea-app/src/test/app/resources/download-case-file.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/download-case-file.integration.test.ts
@@ -12,7 +12,7 @@ import { DeaCaseFile } from '../../../models/case-file';
 import { CaseFileStatus } from '../../../models/case-file-status';
 import { DeaUser } from '../../../models/user';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 import {
   callCompleteCaseFileUpload,
@@ -37,7 +37,7 @@ const DATASETS_PROVIDER = {
   presignedCommandExpirySeconds: 3600,
 };
 
-const EVENT = dummyEvent;
+const EVENT = getDummyEvent();
 
 jest.setTimeout(20000);
 

--- a/source/dea-app/src/test/app/resources/get-all-cases.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/get-all-cases.integration.test.ts
@@ -9,7 +9,7 @@ import { createUser } from '../../../app/services/user-service';
 import { DeaCase } from '../../../models/case';
 import { createCase } from '../../../persistence/case';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 let repositoryProvider: ModelRepositoryProvider;
@@ -74,15 +74,11 @@ describe('get all cases resource', () => {
         repositoryProvider
       )) ?? fail();
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        queryStringParameters: {
-          limit: '1',
-        },
-      }
-    );
+    const event = getDummyEvent({
+      queryStringParameters: {
+        limit: '1',
+      },
+    });
     const response = await getAllCases(event, dummyContext, repositoryProvider);
 
     if (!response.body) {
@@ -93,15 +89,11 @@ describe('get all cases resource', () => {
     expect(casesPage.cases.length).toEqual(1);
     expect(casesPage.next).toBeTruthy();
 
-    const event2 = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        queryStringParameters: {
-          next: casesPage.next,
-        },
-      }
-    );
+    const event2 = getDummyEvent({
+      queryStringParameters: {
+        next: casesPage.next,
+      },
+    });
     const response2 = await getAllCases(event2, dummyContext, repositoryProvider);
     if (!response2.body) {
       fail();

--- a/source/dea-app/src/test/app/resources/get-case-details.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/get-case-details.integration.test.ts
@@ -15,7 +15,7 @@ import { caseResponseSchema } from '../../../models/validation/case';
 import { jsonParseWithDates } from '../../../models/validation/json-parse-with-dates';
 import { createCase } from '../../../persistence/case';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 let repositoryProvider: ModelRepositoryProvider;
@@ -45,15 +45,11 @@ describe('get case details resource', () => {
     };
     const createdCase = await createCase(theCase, user, repositoryProvider);
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: createdCase.ulid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: createdCase.ulid,
+      },
+    });
 
     const response = await getCase(event, dummyContext, repositoryProvider);
 
@@ -74,20 +70,16 @@ describe('get case details resource', () => {
 
   it('should throw an error if the requested case does not exist', async () => {
     const ulid = '02ARZ3NDEKTSV4RRFFQ69G5FAV';
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: ulid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: ulid,
+      },
+    });
 
     await expect(getCase(event, dummyContext, repositoryProvider)).rejects.toThrow(NotFoundError);
   });
 
   it('should throw an error if the path param is missing', async () => {
-    await expect(getCase(dummyEvent, dummyContext, repositoryProvider)).rejects.toThrow(ValidationError);
+    await expect(getCase(getDummyEvent(), dummyContext, repositoryProvider)).rejects.toThrow(ValidationError);
   });
 });

--- a/source/dea-app/src/test/app/resources/get-case-file-details.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/get-case-file-details.integration.test.ts
@@ -13,7 +13,7 @@ import { DeaCaseFile } from '../../../models/case-file';
 import { CaseFileStatus } from '../../../models/case-file-status';
 import { DeaUser } from '../../../models/user';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 import {
   callCompleteCaseFileUpload,
@@ -32,7 +32,7 @@ let caseToDescribe = '';
 const FILE_ULID = 'ABCDEFGHHJKKMNNPQRSTTVWXY9';
 const UPLOAD_ID = '123456';
 const VERSION_ID = '543210';
-const EVENT = dummyEvent;
+const EVENT = getDummyEvent();
 
 jest.setTimeout(20000);
 

--- a/source/dea-app/src/test/app/resources/get-credentials.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/get-credentials.integration.test.ts
@@ -9,7 +9,7 @@ import { getToken } from '../../../app/resources/get-token';
 import { CognitoSsmParams, getCognitoSsmParams } from '../../../app/services/auth-service';
 
 import CognitoHelper from '../../../test-e2e/helpers/cognito-helper';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 
 let cognitoParams: CognitoSsmParams;
 
@@ -37,27 +37,19 @@ describe('get-credentials', () => {
       testUser
     );
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          authCode: authCode,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        authCode: authCode,
+      },
+    });
 
     const idToken = await getToken(event, dummyContext);
 
-    const credentialsEvent = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          idToken: idToken.body?.replace(/"/g, ''),
-        },
-      }
-    );
+    const credentialsEvent = getDummyEvent({
+      pathParameters: {
+        idToken: idToken.body?.replace(/"/g, ''),
+      },
+    });
 
     const response = await getCredentials(credentialsEvent, dummyContext);
     if (!response.body) {
@@ -70,20 +62,16 @@ describe('get-credentials', () => {
   }, 20000);
 
   it('should throw an error if the id token is not valid', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          idToken: 'fake.fake.fake',
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        idToken: 'fake.fake.fake',
+      },
+    });
 
     await expect(getCredentials(event, dummyContext)).rejects.toThrow(NotAuthorizedException);
   });
 
   it('should throw an error if the path param is missing', async () => {
-    await expect(getCredentials(dummyEvent, dummyContext)).rejects.toThrow(ValidationError);
+    await expect(getCredentials(getDummyEvent(), dummyContext)).rejects.toThrow(ValidationError);
   });
 });

--- a/source/dea-app/src/test/app/resources/get-token.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/get-token.integration.test.ts
@@ -7,7 +7,7 @@ import { getToken } from '../../../app/resources/get-token';
 import { CognitoSsmParams, getCognitoSsmParams } from '../../../app/services/auth-service';
 
 import CognitoHelper from '../../../test-e2e/helpers/cognito-helper';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 
 let cognitoParams: CognitoSsmParams;
 
@@ -35,15 +35,11 @@ describe('get-token', () => {
       testUser
     );
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          authCode: authCode,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        authCode: authCode,
+      },
+    });
 
     const response = await getToken(event, dummyContext);
     expect(response.statusCode).toEqual(200);
@@ -54,20 +50,16 @@ describe('get-token', () => {
   }, 20000);
 
   it('should throw an error if the authorization code is not valid', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          authCode: 'DUMMYAUTHCODE',
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        authCode: 'DUMMYAUTHCODE',
+      },
+    });
 
     await expect(getToken(event, dummyContext)).rejects.toThrow('Request failed with status code 400');
   });
 
   it('should throw an error if the path param is missing', async () => {
-    await expect(getToken(dummyEvent, dummyContext)).rejects.toThrow(ValidationError);
+    await expect(getToken(getDummyEvent(), dummyContext)).rejects.toThrow(ValidationError);
   });
 });

--- a/source/dea-app/src/test/app/resources/get-users.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/get-users.integration.test.ts
@@ -10,7 +10,7 @@ import { createUser } from '../../../app/services/user-service';
 import { DeaUser } from '../../../models/user';
 import { userResponseSchema } from '../../../models/validation/user';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 let repositoryProvider: ModelRepositoryProvider;
@@ -48,15 +48,11 @@ describe('get users resource', () => {
       repositoryProvider
     );
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        queryStringParameters: {
-          limit: '1',
-        },
-      }
-    );
+    const event = getDummyEvent({
+      queryStringParameters: {
+        limit: '1',
+      },
+    });
     const response = await getUsers(event, dummyContext, repositoryProvider);
 
     if (!response.body) {
@@ -67,15 +63,11 @@ describe('get users resource', () => {
     expect(casesPage.users.length).toEqual(1);
     expect(casesPage.next).toBeTruthy();
     Joi.assert(casesPage.users[0], userResponseSchema);
-    const event2 = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        queryStringParameters: {
-          next: casesPage.next,
-        },
-      }
-    );
+    const event2 = getDummyEvent({
+      queryStringParameters: {
+        next: casesPage.next,
+      },
+    });
     const response2 = await getUsers(event2, dummyContext, repositoryProvider);
     if (!response2.body) {
       fail();
@@ -117,15 +109,11 @@ describe('get users resource', () => {
       repositoryProvider
     );
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        queryStringParameters: {
-          nameBeginsWith: 'APRIL',
-        },
-      }
-    );
+    const event = getDummyEvent({
+      queryStringParameters: {
+        nameBeginsWith: 'APRIL',
+      },
+    });
     const response = await getUsers(event, dummyContext, repositoryProvider);
 
     if (!response.body) {

--- a/source/dea-app/src/test/app/resources/initiate-case-file-upload.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/initiate-case-file-upload.integration.test.ts
@@ -18,7 +18,7 @@ import { CaseFileStatus } from '../../../models/case-file-status';
 import { CaseStatus } from '../../../models/case-status';
 import { DeaUser } from '../../../models/user';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 import {
   callCompleteCaseFileUpload,
@@ -47,7 +47,7 @@ const DATASETS_PROVIDER = {
   presignedCommandExpirySeconds: 3600,
 };
 
-const EVENT = dummyEvent;
+const EVENT = getDummyEvent();
 
 jest.setTimeout(30000);
 

--- a/source/dea-app/src/test/app/resources/lambda-preexecution-checks.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/lambda-preexecution-checks.integration.test.ts
@@ -13,7 +13,7 @@ import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
 import { getUserByTokenId, listUsers } from '../../../persistence/user';
 import CognitoHelper from '../../../test-e2e/helpers/cognito-helper';
 import { testEnv } from '../../../test-e2e/helpers/settings';
-import { dummyContext, dummyEvent, getDummyAuditEvent } from '../../integration-objects';
+import { dummyContext, getDummyAuditEvent, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 let repositoryProvider: ModelRepositoryProvider;
@@ -40,12 +40,7 @@ describe('lambda pre-execution checks', () => {
     const idToken = await cognitoHelper.getIdTokenForUser(testUser);
 
     const tokenId = (await getTokenPayload(idToken, region)).sub;
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-      }
-    );
+    const event = getDummyEvent();
     event.headers['idToken'] = idToken;
 
     const auditEvent = getDummyAuditEvent();
@@ -80,12 +75,7 @@ describe('lambda pre-execution checks', () => {
     const tokenId2 = (await getTokenPayload(idToken, region)).sub;
     expect(tokenId2).toStrictEqual(tokenId);
 
-    const event2 = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-      }
-    );
+    const event2 = getDummyEvent();
     event2.headers['idToken'] = idToken2;
 
     const auditEvent2 = getDummyAuditEvent();
@@ -117,12 +107,7 @@ describe('lambda pre-execution checks', () => {
   }, 10000);
 
   it('should throw if no cognitoId is included in the request', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-      }
-    );
+    const event = getDummyEvent();
 
     event.requestContext.identity.cognitoIdentityId = null;
 

--- a/source/dea-app/src/test/app/resources/list-case-files.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/list-case-files.integration.test.ts
@@ -12,7 +12,7 @@ import { getCaseFileDetails } from '../../../app/resources/get-case-file-details
 import { CaseFileStatus } from '../../../models/case-file-status';
 import { DeaUser } from '../../../models/user';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 import {
   callCreateCase,
@@ -31,7 +31,7 @@ let caseToList = '';
 const FILE_ULID = 'ABCDEFGHHJKKMNNPQRSTTVWXY9';
 const UPLOAD_ID = '123456';
 const VERSION_ID = '543210';
-const EVENT = dummyEvent;
+const EVENT = getDummyEvent();
 
 jest.setTimeout(20000);
 

--- a/source/dea-app/src/test/app/resources/update-case-membership.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/update-case-membership.integration.test.ts
@@ -15,7 +15,7 @@ import { DeaUser, DeaUserInput } from '../../../models/user';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
 import { createUser } from '../../../persistence/user';
 import { bogusUlid } from '../../../test-e2e/resources/test-helpers';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 let repositoryProvider: ModelRepositoryProvider;
@@ -76,21 +76,17 @@ describe('delete case membership resource', () => {
   it('should update an existing membership', async () => {
     expect(targetMembership?.actions).toEqual(expect.arrayContaining([CaseAction.VIEW_CASE_DETAILS]));
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: targetMembership.caseUlid,
-          userId: targetMembership.userUlid,
-        },
-        body: JSON.stringify({
-          userUlid: targetMembership.userUlid,
-          caseUlid: targetMembership.caseUlid,
-          actions: [CaseAction.VIEW_CASE_DETAILS, CaseAction.DOWNLOAD],
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: targetMembership.caseUlid,
+        userId: targetMembership.userUlid,
+      },
+      body: JSON.stringify({
+        userUlid: targetMembership.userUlid,
+        caseUlid: targetMembership.caseUlid,
+        actions: [CaseAction.VIEW_CASE_DETAILS, CaseAction.DOWNLOAD],
+      }),
+    });
 
     const response = await updateCaseMembership(event, dummyContext, repositoryProvider);
     expect(response.statusCode).toEqual(200);
@@ -104,21 +100,17 @@ describe('delete case membership resource', () => {
   });
 
   it('should throw if the caseuser payload does not match the path caseid', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: targetMembership.caseUlid,
-          userId: targetMembership.userUlid,
-        },
-        body: JSON.stringify({
-          userUlid: targetMembership.userUlid,
-          caseUlid: bogusUlid,
-          actions: [CaseAction.VIEW_CASE_DETAILS, CaseAction.DOWNLOAD],
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: targetMembership.caseUlid,
+        userId: targetMembership.userUlid,
+      },
+      body: JSON.stringify({
+        userUlid: targetMembership.userUlid,
+        caseUlid: bogusUlid,
+        actions: [CaseAction.VIEW_CASE_DETAILS, CaseAction.DOWNLOAD],
+      }),
+    });
 
     await expect(updateCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'Requested Case id does not match resource'
@@ -126,21 +118,17 @@ describe('delete case membership resource', () => {
   });
 
   it('should throw if the caseuser payload does not match the path userid', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: targetMembership.caseUlid,
-          userId: targetMembership.userUlid,
-        },
-        body: JSON.stringify({
-          userUlid: bogusUlid,
-          caseUlid: targetMembership.caseUlid,
-          actions: [CaseAction.DOWNLOAD],
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: targetMembership.caseUlid,
+        userId: targetMembership.userUlid,
+      },
+      body: JSON.stringify({
+        userUlid: bogusUlid,
+        caseUlid: targetMembership.caseUlid,
+        actions: [CaseAction.DOWNLOAD],
+      }),
+    });
 
     await expect(updateCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'Requested User id does not match resource'
@@ -148,21 +136,17 @@ describe('delete case membership resource', () => {
   });
 
   it('should throw if the case membership does not exist', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: targetMembership.caseUlid,
-          userId: bogusUlid,
-        },
-        body: JSON.stringify({
-          userUlid: bogusUlid,
-          caseUlid: targetMembership.caseUlid,
-          actions: [CaseAction.DOWNLOAD],
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: targetMembership.caseUlid,
+        userId: bogusUlid,
+      },
+      body: JSON.stringify({
+        userUlid: bogusUlid,
+        caseUlid: targetMembership.caseUlid,
+        actions: [CaseAction.DOWNLOAD],
+      }),
+    });
 
     await expect(updateCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'Requested Case-User Membership not found'
@@ -170,16 +154,12 @@ describe('delete case membership resource', () => {
   });
 
   it('should throw if the payload is missing', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: targetMembership.caseUlid,
-          userId: bogusUlid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: targetMembership.caseUlid,
+        userId: bogusUlid,
+      },
+    });
 
     await expect(updateCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'CaseUser payload missing.'
@@ -187,29 +167,21 @@ describe('delete case membership resource', () => {
   });
 
   it('should error if path params are missing', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: bogusUlid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: bogusUlid,
+      },
+    });
 
     await expect(updateCaseMembership(event, dummyContext, repositoryProvider)).rejects.toThrow(
       ValidationError
     );
 
-    const event2 = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          userId: bogusUlid,
-        },
-      }
-    );
+    const event2 = getDummyEvent({
+      pathParameters: {
+        userId: bogusUlid,
+      },
+    });
 
     await expect(updateCaseMembership(event2, dummyContext, repositoryProvider)).rejects.toThrow(
       ValidationError

--- a/source/dea-app/src/test/app/resources/update-cases.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/update-cases.integration.test.ts
@@ -14,7 +14,7 @@ import { jsonParseWithDates } from '../../../models/validation/json-parse-with-d
 import { createCase } from '../../../persistence/case';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
 import { createUser } from '../../../persistence/user';
-import { dummyContext, dummyEvent } from '../../integration-objects';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 let repositoryProvider: ModelRepositoryProvider;
@@ -48,20 +48,16 @@ describe('update cases resource', () => {
     };
     const createdCase = await createCase(theCase, caseOwner, repositoryProvider);
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: createdCase.ulid,
-        },
-        body: JSON.stringify({
-          ulid: createdCase.ulid,
-          name: updatedName,
-          description: updatedDescription,
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: createdCase.ulid,
+      },
+      body: JSON.stringify({
+        ulid: createdCase.ulid,
+        name: updatedName,
+        description: updatedDescription,
+      }),
+    });
 
     const response = await updateCases(event, dummyContext, repositoryProvider);
 
@@ -90,20 +86,16 @@ describe('update cases resource', () => {
   it('should error if path and payload do not match', async () => {
     const ulid1 = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
     const ulid2 = '02ARZ3NDEKTSV4RRFFQ69G5FAV';
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: ulid1,
-        },
-        body: JSON.stringify({
-          ulid: ulid2,
-          name: 'ThisWillNotWork',
-          description: 'these are words',
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: ulid1,
+      },
+      body: JSON.stringify({
+        ulid: ulid2,
+        name: 'ThisWillNotWork',
+        description: 'these are words',
+      }),
+    });
 
     await expect(updateCases(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'Requested Case Ulid does not match resource'
@@ -111,16 +103,12 @@ describe('update cases resource', () => {
   });
 
   it('should error if no payload is provided', async () => {
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
-        },
-        body: null,
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      },
+      body: null,
+    });
 
     await expect(updateCases(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'Update cases payload missing.'
@@ -129,17 +117,13 @@ describe('update cases resource', () => {
 
   it('should error if a path parameter specifying caseId is not found', async () => {
     const ulid = '02ARZ3NDEKTSV4RRFFQ69G5FAV';
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        body: JSON.stringify({
-          ulid: ulid,
-          name: 'ThisWillNotWork',
-          description: 'these are words',
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      body: JSON.stringify({
+        ulid: ulid,
+        name: 'ThisWillNotWork',
+        description: 'these are words',
+      }),
+    });
 
     await expect(updateCases(event, dummyContext, repositoryProvider)).rejects.toThrow(
       "Required path param 'caseId' is missing."
@@ -153,21 +137,17 @@ describe('update cases resource', () => {
     };
     const createdCase = await createCase(theCase, caseOwner, repositoryProvider);
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: createdCase.ulid,
-        },
-        body: JSON.stringify({
-          ulid: createdCase.ulid,
-          name: 'CaseStatusCheck',
-          status: createdCase.status,
-          description: 'description',
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: createdCase.ulid,
+      },
+      body: JSON.stringify({
+        ulid: createdCase.ulid,
+        name: 'CaseStatusCheck',
+        status: createdCase.status,
+        description: 'description',
+      }),
+    });
 
     await expect(updateCases(event, dummyContext, repositoryProvider)).rejects.toThrow(
       '"status" is not allowed'
@@ -181,21 +161,17 @@ describe('update cases resource', () => {
     };
     const createdCase = await createCase(theCase, caseOwner, repositoryProvider);
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: createdCase.ulid,
-        },
-        body: JSON.stringify({
-          ulid: createdCase.ulid,
-          name: 'CaseCountCheck',
-          objectCount: 5,
-          description: 'description',
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: createdCase.ulid,
+      },
+      body: JSON.stringify({
+        ulid: createdCase.ulid,
+        name: 'CaseCountCheck',
+        objectCount: 5,
+        description: 'description',
+      }),
+    });
 
     await expect(updateCases(event, dummyContext, repositoryProvider)).rejects.toThrow(
       '"objectCount" is not allowed'
@@ -204,20 +180,16 @@ describe('update cases resource', () => {
 
   it('should error when updating a non-existant record', async () => {
     const ulid = '02ARZ3NDEKTSV4RRFFQ69G5FAV';
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: ulid,
-        },
-        body: JSON.stringify({
-          ulid: ulid,
-          name: 'ThisWillNotWork',
-          description: 'these are words',
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: ulid,
+      },
+      body: JSON.stringify({
+        ulid: ulid,
+        name: 'ThisWillNotWork',
+        description: 'these are words',
+      }),
+    });
 
     await expect(updateCases(event, dummyContext, repositoryProvider)).rejects.toThrow(OneTableError);
   });
@@ -234,20 +206,16 @@ describe('update cases resource', () => {
     const createdCase1 = await createCase(theCase1, caseOwner, repositoryProvider);
     const createdCase2 = await createCase(theCase2, caseOwner, repositoryProvider);
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: createdCase1.ulid,
-        },
-        body: JSON.stringify({
-          ulid: createdCase1.ulid,
-          name: createdCase2.name,
-          description: 'whatevs',
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: createdCase1.ulid,
+      },
+      body: JSON.stringify({
+        ulid: createdCase1.ulid,
+        name: createdCase2.name,
+        description: 'whatevs',
+      }),
+    });
 
     await expect(updateCases(event, dummyContext, repositoryProvider)).rejects.toThrow(
       'Cannot update unique attributes "name" for "Case". An item of the same name already exists.'
@@ -267,20 +235,16 @@ describe('update cases resource', () => {
     const createdCase1 = await createCase(theCase1, caseOwner, repositoryProvider);
     const createdCase2 = await createCase(theCase2, caseOwner, repositoryProvider);
 
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: createdCase1.ulid,
-        },
-        body: JSON.stringify({
-          ulid: createdCase1.ulid,
-          name: aNewNameForCase1,
-          description: 'whatevs',
-        }),
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: createdCase1.ulid,
+      },
+      body: JSON.stringify({
+        ulid: createdCase1.ulid,
+        name: aNewNameForCase1,
+        description: 'whatevs',
+      }),
+    });
 
     const response = await updateCases(event, dummyContext, repositoryProvider);
 
@@ -293,20 +257,16 @@ describe('update cases resource', () => {
     const updatedCase1: DeaCase = jsonParseWithDates(response.body);
     expect(updatedCase1.name).toEqual(aNewNameForCase1);
 
-    const event2 = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: createdCase2.ulid,
-        },
-        body: JSON.stringify({
-          ulid: createdCase2.ulid,
-          name: theCase1.name,
-          description: 'whatevs',
-        }),
-      }
-    );
+    const event2 = getDummyEvent({
+      pathParameters: {
+        caseId: createdCase2.ulid,
+      },
+      body: JSON.stringify({
+        ulid: createdCase2.ulid,
+        name: theCase1.name,
+        description: 'whatevs',
+      }),
+    });
 
     const response2 = await updateCases(event2, dummyContext, repositoryProvider);
 

--- a/source/dea-app/src/test/app/resources/verify-case-acls.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/verify-case-acls.integration.test.ts
@@ -12,7 +12,7 @@ import { DeaCase } from '../../../models/case';
 import { CaseAction } from '../../../models/case-action';
 import { DeaUser } from '../../../models/user';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
-import { dummyEvent } from '../../integration-objects';
+import { getDummyEvent } from '../../integration-objects';
 import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 let repositoryProvider: ModelRepositoryProvider;
@@ -121,52 +121,40 @@ describe('verify case ACLs', () => {
 
   it('should not throw if a user has all required acls', async () => {
     // GIVEN a user with membership and all acls
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: theCase.ulid,
-        },
-        headers: {
-          userUlid: userWithAllACLs.ulid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: theCase.ulid,
+      },
+      headers: {
+        userUlid: userWithAllACLs.ulid,
+      },
+    });
 
     // WHEN verifying ACLs, THEN sut doesn't throw
     await verifyCaseACLs(event, requiredActions, repositoryProvider);
 
     //try with the owner
-    const event2 = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: theCase.ulid,
-        },
-        headers: {
-          userUlid: owner.ulid,
-        },
-      }
-    );
+    const event2 = getDummyEvent({
+      pathParameters: {
+        caseId: theCase.ulid,
+      },
+      headers: {
+        userUlid: owner.ulid,
+      },
+    });
     await verifyCaseACLs(event2, requiredActions, repositoryProvider);
   });
 
   it('should not throw if there are no defined ACLs', async () => {
     // GIVEN a user
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: theCase.ulid,
-        },
-        headers: {
-          userUlid: userWithNoMembership.ulid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: theCase.ulid,
+      },
+      headers: {
+        userUlid: userWithNoMembership.ulid,
+      },
+    });
 
     // WHEN no ACLs are specified, THEN sut doesn't throw
     await verifyCaseACLs(event, []);
@@ -174,18 +162,14 @@ describe('verify case ACLs', () => {
 
   it('should throw if a user has no membership', async () => {
     // GIVEN a user with no membership
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: theCase.ulid,
-        },
-        headers: {
-          userUlid: userWithNoMembership.ulid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: theCase.ulid,
+      },
+      headers: {
+        userUlid: userWithNoMembership.ulid,
+      },
+    });
 
     // WHEN verifying ACLs, THEN sut throws forbidden error
     await expect(verifyCaseACLs(event, requiredActions, repositoryProvider)).rejects.toThrow(NotFoundError);
@@ -193,18 +177,14 @@ describe('verify case ACLs', () => {
 
   it('should throw if a user has no required acls', async () => {
     // GIVEN a user with membership but no ACLs
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: theCase.ulid,
-        },
-        headers: {
-          userUlid: userWithMembershipNoAcls.ulid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: theCase.ulid,
+      },
+      headers: {
+        userUlid: userWithMembershipNoAcls.ulid,
+      },
+    });
 
     // WHEN verifying ACLs, THEN sut throws forbidden error
     await expect(verifyCaseACLs(event, requiredActions, repositoryProvider)).rejects.toThrow(NotFoundError);
@@ -212,18 +192,14 @@ describe('verify case ACLs', () => {
 
   it('should throw if a user has partial required acls', async () => {
     // GIVEN a user with membership but partial ACLs
-    const event = Object.assign(
-      {},
-      {
-        ...dummyEvent,
-        pathParameters: {
-          caseId: theCase.ulid,
-        },
-        headers: {
-          userUlid: userWithMembershipPartialAcls.ulid,
-        },
-      }
-    );
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: theCase.ulid,
+      },
+      headers: {
+        userUlid: userWithMembershipPartialAcls.ulid,
+      },
+    });
 
     // WHEN verifying ACLs, THEN sut throws forbidden error
     await expect(verifyCaseACLs(event, requiredActions, repositoryProvider)).rejects.toThrow(NotFoundError);

--- a/source/dea-app/src/test/integration-objects.ts
+++ b/source/dea-app/src/test/integration-objects.ts
@@ -4,6 +4,7 @@
  */
 
 import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import _ from 'lodash';
 import {
   AuditEventResult,
   AuditEventSource,
@@ -12,7 +13,7 @@ import {
   IdentityType,
 } from '../app/services/audit-service';
 
-export const dummyEvent: APIGatewayProxyEvent = {
+const dummyEvent: APIGatewayProxyEvent = {
   resource: '/cases/{caseId}',
   path: '/cases/01GSX40H73JQ9Q2T2EERPYWN6C',
   httpMethod: 'GET',
@@ -133,21 +134,15 @@ const dummyAuditEvent: CJISAuditEventBody = {
   result: AuditEventResult.FAILURE,
 };
 
-export const getDummyEvent = (addedData?: object): APIGatewayProxyEvent => {
-  return Object.assign(
-    {},
-    {
-      ...dummyEvent,
-      ...addedData,
-    }
-  );
+export const getDummyEvent = (addedData: object = {}): APIGatewayProxyEvent => {
+  return _.cloneDeep({
+    ...dummyEvent,
+    ...addedData,
+  });
 };
 
 export const getDummyAuditEvent = (): CJISAuditEventBody => {
-  return Object.assign(
-    {},
-    {
-      ...dummyAuditEvent,
-    }
-  );
+  return _.cloneDeep({
+    ...dummyAuditEvent,
+  });
 };

--- a/source/dea-app/src/test/lambda-http-helpers.unit.test.ts
+++ b/source/dea-app/src/test/lambda-http-helpers.unit.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { getRequiredEnv, getRequiredHeader } from '../lambda-http-helpers';
-import { dummyEvent } from './integration-objects';
+import { getDummyEvent } from './integration-objects';
 
 describe('lambda http helper edge cases', () => {
   describe('getRequiredEnv', () => {
@@ -17,28 +17,20 @@ describe('lambda http helper edge cases', () => {
 
   describe('getRequiredHeader', () => {
     it('considers lower case values', () => {
-      const event = Object.assign(
-        {},
-        {
-          ...dummyEvent,
-          headers: {
-            alowercasevalue: 'somevalue',
-          },
-        }
-      );
+      const event = getDummyEvent({
+        headers: {
+          alowercasevalue: 'somevalue',
+        },
+      });
       const foundVal = getRequiredHeader(event, 'ALOWERCASEVALUE');
 
       expect(foundVal).toEqual('somevalue');
     });
 
     it('throws when a value is not found', () => {
-      const event = Object.assign(
-        {},
-        {
-          ...dummyEvent,
-          headers: {},
-        }
-      );
+      const event = getDummyEvent({
+        headers: {},
+      });
       expect(() => getRequiredHeader(event, 'idToken')).toThrow(`Required header 'idToken' is missing.`);
     });
   });

--- a/source/dea-backend/src/test/handlers/exception-handlers.unit.test.ts
+++ b/source/dea-backend/src/test/handlers/exception-handlers.unit.test.ts
@@ -5,7 +5,7 @@
 
 import {
   dummyContext,
-  dummyEvent,
+  getDummyEvent,
   ForbiddenError,
   getTestAuditService,
   NotFoundError,
@@ -19,9 +19,11 @@ import { createDeaHandler, NO_ACL } from '../../handlers/create-dea-handler';
 describe('exception handlers', () => {
   const OLD_ENV = process.env;
   let testAuditService: TestAuditService;
+  let dummyEvent: APIGatewayProxyEvent;
 
   beforeAll(() => {
     testAuditService = getTestAuditService();
+    dummyEvent = getDummyEvent();
   });
 
   beforeEach(() => {


### PR DESCRIPTION
- replace direct dummyEvent usage with a getter which provides a clone, keeping the original intact


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
