### PR TITLE
refactor: use response methods for resource response

### DIFF
--- a/source/dea-app/src/app/resources/complete-case-file-upload.ts
+++ b/source/dea-app/src/app/resources/complete-case-file-upload.ts
@@ -11,6 +11,7 @@ import { DatasetsProvider, defaultDatasetsProvider } from '../../storage/dataset
 import * as CaseFileService from '../services/case-file-service';
 import { validateCompleteCaseFileRequirements } from '../services/case-file-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const completeCaseFileUpload: DEAGatewayProxyHandler = async (
   event,
@@ -36,11 +37,5 @@ export const completeCaseFileUpload: DEAGatewayProxyHandler = async (
     datasetsProvider
   );
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify(completeUploadResponse),
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-    },
-  };
+  return responseOk(completeUploadResponse);
 };

--- a/source/dea-app/src/app/resources/create-case-membership.ts
+++ b/source/dea-app/src/app/resources/create-case-membership.ts
@@ -11,6 +11,7 @@ import { defaultProvider } from '../../persistence/schema/entities';
 import { ValidationError } from '../exceptions/validation-exception';
 import { createCaseUserMembershipFromDTO } from '../services/case-user-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const createCaseMembership: DEAGatewayProxyHandler = async (
   event,
@@ -28,8 +29,5 @@ export const createCaseMembership: DEAGatewayProxyHandler = async (
   }
 
   const caseUserResult = await createCaseUserMembershipFromDTO(caseUser, repositoryProvider);
-  return {
-    statusCode: 200,
-    body: JSON.stringify(caseUserResult),
-  };
+  return responseOk(caseUserResult);
 };

--- a/source/dea-app/src/app/resources/create-cases.ts
+++ b/source/dea-app/src/app/resources/create-cases.ts
@@ -10,6 +10,7 @@ import { defaultProvider } from '../../persistence/schema/entities';
 import * as CaseService from '../services/case-service';
 import { getUser } from '../services/user-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const createCases: DEAGatewayProxyHandler = async (
   event,
@@ -31,11 +32,5 @@ export const createCases: DEAGatewayProxyHandler = async (
 
   const updateBody = await CaseService.createCases(deaCase, user, repositoryProvider);
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify(updateBody),
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-    },
-  };
+  return responseOk(updateBody);
 };

--- a/source/dea-app/src/app/resources/dea-lambda-utils.ts
+++ b/source/dea-app/src/app/resources/dea-lambda-utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { CognitoIdTokenPayload } from 'aws-jwt-verify/jwt-model';
+import { APIGatewayProxyResult } from 'aws-lambda';
 import { getDeaUserFromToken, getTokenPayload } from '../../cognito-token-helpers';
 import { getRequiredHeader } from '../../lambda-http-helpers';
 import { logger } from '../../logger';
@@ -93,6 +94,26 @@ const addUserToDatabase = async (
   const deaUserResult = await UserService.createUser(deaUser, repositoryProvider);
 
   return deaUserResult;
+};
+
+export const responseOk = (body: unknown): APIGatewayProxyResult => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify(body),
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+    },
+  };
+};
+
+export const responseNoContent = (): APIGatewayProxyResult => {
+  return {
+    statusCode: 204,
+    body: '',
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+    },
+  };
 };
 
 // Session Management Checks Helper Functions

--- a/source/dea-app/src/app/resources/delete-case-membership.ts
+++ b/source/dea-app/src/app/resources/delete-case-membership.ts
@@ -8,6 +8,7 @@ import { joiUlid } from '../../models/validation/joi-common';
 import { defaultProvider } from '../../persistence/schema/entities';
 import { deleteCaseUser } from '../services/case-user-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseNoContent } from './dea-lambda-utils';
 
 export const deleteCaseMembership: DEAGatewayProxyHandler = async (
   event,
@@ -19,9 +20,6 @@ export const deleteCaseMembership: DEAGatewayProxyHandler = async (
   const caseId = getRequiredPathParam(event, 'caseId', joiUlid);
   const userId = getRequiredPathParam(event, 'userId', joiUlid);
 
-  const caseUserResult = await deleteCaseUser(userId, caseId, repositoryProvider);
-  return {
-    statusCode: 204,
-    body: JSON.stringify(caseUserResult),
-  };
+  await deleteCaseUser(userId, caseId, repositoryProvider);
+  return responseNoContent();
 };

--- a/source/dea-app/src/app/resources/delete-cases.ts
+++ b/source/dea-app/src/app/resources/delete-cases.ts
@@ -8,6 +8,7 @@ import { joiUlid } from '../../models/validation/joi-common';
 import { defaultProvider } from '../../persistence/schema/entities';
 import * as CaseService from '../services/case-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseNoContent } from './dea-lambda-utils';
 
 export const deleteCase: DEAGatewayProxyHandler = async (
   event,
@@ -20,8 +21,5 @@ export const deleteCase: DEAGatewayProxyHandler = async (
 
   await CaseService.deleteCase(caseId, repositoryProvider);
 
-  return {
-    statusCode: 204,
-    body: '',
-  };
+  return responseNoContent();
 };

--- a/source/dea-app/src/app/resources/download-case-file.ts
+++ b/source/dea-app/src/app/resources/download-case-file.ts
@@ -12,6 +12,7 @@ import { NotFoundError } from '../exceptions/not-found-exception';
 import { ValidationError } from '../exceptions/validation-exception';
 import { getCaseFile } from '../services/case-file-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const downloadCaseFile: DEAGatewayProxyHandler = async (
   event,
@@ -35,10 +36,5 @@ export const downloadCaseFile: DEAGatewayProxyHandler = async (
 
   const downloadUrl = await getPresignedUrlForDownload(retrievedCaseFile, datasetsProvider);
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify({
-      downloadUrl,
-    }),
-  };
+  return responseOk({ downloadUrl });
 };

--- a/source/dea-app/src/app/resources/get-all-cases.ts
+++ b/source/dea-app/src/app/resources/get-all-cases.ts
@@ -7,6 +7,7 @@ import { getPaginationParameters } from '../../lambda-http-helpers';
 import { defaultProvider } from '../../persistence/schema/entities';
 import { listAllCases } from '../services/case-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 import { getNextToken } from './get-next-token';
 
 export const getAllCases: DEAGatewayProxyHandler = async (
@@ -24,15 +25,9 @@ export const getAllCases: DEAGatewayProxyHandler = async (
     repositoryProvider
   );
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify({
-      cases: pageOfCases,
-      total: pageOfCases.count,
-      next: getNextToken(pageOfCases.next),
-    }),
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-    },
-  };
+  return responseOk({
+    cases: pageOfCases,
+    total: pageOfCases.count,
+    next: getNextToken(pageOfCases.next),
+  });
 };

--- a/source/dea-app/src/app/resources/get-case-details.ts
+++ b/source/dea-app/src/app/resources/get-case-details.ts
@@ -9,6 +9,7 @@ import { defaultProvider } from '../../persistence/schema/entities';
 import { NotFoundError } from '../exceptions/not-found-exception';
 import * as CaseService from '../services/case-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const getCase: DEAGatewayProxyHandler = async (
   event,
@@ -24,11 +25,5 @@ export const getCase: DEAGatewayProxyHandler = async (
     throw new NotFoundError(`Case with ulid ${caseId} not found.`);
   }
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify(retreivedCase),
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-    },
-  };
+  return responseOk(retreivedCase);
 };

--- a/source/dea-app/src/app/resources/get-case-file-details.ts
+++ b/source/dea-app/src/app/resources/get-case-file-details.ts
@@ -9,6 +9,7 @@ import { defaultProvider } from '../../persistence/schema/entities';
 import { NotFoundError } from '../exceptions/not-found-exception';
 import { getCaseFile } from '../services/case-file-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const getCaseFileDetails: DEAGatewayProxyHandler = async (
   event,
@@ -25,8 +26,5 @@ export const getCaseFileDetails: DEAGatewayProxyHandler = async (
     throw new NotFoundError(`Could not find file: ${fileId} in the DB`);
   }
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify(retrievedCaseFile),
-  };
+  return responseOk(retrievedCaseFile);
 };

--- a/source/dea-app/src/app/resources/get-credentials.ts
+++ b/source/dea-app/src/app/resources/get-credentials.ts
@@ -6,16 +6,11 @@ import { getRequiredPathParam } from '../../lambda-http-helpers';
 import { idToken } from '../../models/validation/joi-common';
 import { getCredentialsByToken } from '../services/auth-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const getCredentials: DEAGatewayProxyHandler = async (event) => {
   const idTokenString = getRequiredPathParam(event, 'idToken', idToken);
   const response = await getCredentialsByToken(idTokenString);
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify(response),
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-    },
-  };
+  return responseOk(response);
 };

--- a/source/dea-app/src/app/resources/get-login-url.ts
+++ b/source/dea-app/src/app/resources/get-login-url.ts
@@ -7,16 +7,11 @@ import { loginUrlRegex } from '../../models/validation/joi-common';
 import { getLoginHostedUiUrl } from '../services/auth-service';
 
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const getLoginUrl: DEAGatewayProxyHandler = async () => {
   const loginUrl = await getLoginHostedUiUrl();
 
   Joi.assert(loginUrl, loginUrlRegex);
-  return {
-    statusCode: 200,
-    body: JSON.stringify(loginUrl),
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-    },
-  };
+  return responseOk(loginUrl);
 };

--- a/source/dea-app/src/app/resources/get-my-cases.ts
+++ b/source/dea-app/src/app/resources/get-my-cases.ts
@@ -7,6 +7,7 @@ import { getPaginationParameters, getUserUlid } from '../../lambda-http-helpers'
 import { defaultProvider } from '../../persistence/schema/entities';
 import { listCasesForUser } from '../services/case-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 import { getNextToken } from './get-next-token';
 
 export const getMyCases: DEAGatewayProxyHandler = async (
@@ -26,12 +27,9 @@ export const getMyCases: DEAGatewayProxyHandler = async (
     repositoryProvider
   );
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify({
-      cases: pageOfCases,
-      total: pageOfCases.count,
-      next: getNextToken(pageOfCases.next),
-    }),
-  };
+  return responseOk({
+    cases: pageOfCases,
+    total: pageOfCases.count,
+    next: getNextToken(pageOfCases.next),
+  });
 };

--- a/source/dea-app/src/app/resources/get-token.ts
+++ b/source/dea-app/src/app/resources/get-token.ts
@@ -7,17 +7,12 @@ import { getRequiredPathParam } from '../../lambda-http-helpers';
 import { idToken, authCode as authCodeRegex } from '../../models/validation/joi-common';
 import { exchangeAuthorizationCode } from '../services/auth-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const getToken: DEAGatewayProxyHandler = async (event) => {
   const authCode = getRequiredPathParam(event, 'authCode', authCodeRegex);
   const getTokenResult = await exchangeAuthorizationCode(authCode, event.headers['origin']);
 
   Joi.assert(getTokenResult, idToken);
-  return {
-    statusCode: 200,
-    body: JSON.stringify(getTokenResult),
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-    },
-  };
+  return responseOk(getTokenResult);
 };

--- a/source/dea-app/src/app/resources/get-users.ts
+++ b/source/dea-app/src/app/resources/get-users.ts
@@ -7,6 +7,7 @@ import { getPaginationParameters } from '../../lambda-http-helpers';
 import { defaultProvider } from '../../persistence/schema/entities';
 import * as UserService from '../services/user-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 import { getNextToken } from './get-next-token';
 
 export const getUsers: DEAGatewayProxyHandler = async (
@@ -29,14 +30,11 @@ export const getUsers: DEAGatewayProxyHandler = async (
     repositoryProvider
   );
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify({
-      //intentionally unused tokenId - this removes it during the map operation
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      users: pageOfUsers.map(({ tokenId, ...user }) => user),
-      total: pageOfUsers.count,
-      next: getNextToken(pageOfUsers.next),
-    }),
-  };
+  return responseOk({
+    //intentionally unused tokenId - this removes it during the map operation
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    users: pageOfUsers.map(({ tokenId, ...user }) => user),
+    total: pageOfUsers.count,
+    next: getNextToken(pageOfUsers.next),
+  });
 };

--- a/source/dea-app/src/app/resources/initiate-case-file-upload.ts
+++ b/source/dea-app/src/app/resources/initiate-case-file-upload.ts
@@ -11,6 +11,7 @@ import { DatasetsProvider, defaultDatasetsProvider } from '../../storage/dataset
 import * as CaseFileService from '../services/case-file-service';
 import { validateInitiateUploadRequirements } from '../services/case-file-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const initiateCaseFileUpload: DEAGatewayProxyHandler = async (
   event,
@@ -37,11 +38,5 @@ export const initiateCaseFileUpload: DEAGatewayProxyHandler = async (
     datasetsProvider
   );
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify(initiateUploadResponse),
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-    },
-  };
+  return responseOk(initiateUploadResponse);
 };

--- a/source/dea-app/src/app/resources/list-case-files.ts
+++ b/source/dea-app/src/app/resources/list-case-files.ts
@@ -11,6 +11,7 @@ import { NotFoundError } from '../exceptions/not-found-exception';
 import { listCaseFilesByFilePath } from '../services/case-file-service';
 import { getCase } from '../services/case-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 import { getNextToken } from './get-next-token';
 
 export const listCaseFiles: DEAGatewayProxyHandler = async (
@@ -42,12 +43,10 @@ export const listCaseFiles: DEAGatewayProxyHandler = async (
     repositoryProvider,
     paginationParams.nextToken
   );
-  return {
-    statusCode: 200,
-    body: JSON.stringify({
-      cases: pageOfCaseFiles,
-      total: pageOfCaseFiles.count,
-      next: getNextToken(pageOfCaseFiles.next),
-    }),
-  };
+
+  return responseOk({
+    cases: pageOfCaseFiles,
+    total: pageOfCaseFiles.count,
+    next: getNextToken(pageOfCaseFiles.next),
+  });
 };

--- a/source/dea-app/src/app/resources/update-case-membership.ts
+++ b/source/dea-app/src/app/resources/update-case-membership.ts
@@ -11,6 +11,7 @@ import { defaultProvider } from '../../persistence/schema/entities';
 import { ValidationError } from '../exceptions/validation-exception';
 import { updateCaseUserMembershipFromDTO } from '../services/case-user-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const updateCaseMembership: DEAGatewayProxyHandler = async (
   event,
@@ -33,8 +34,6 @@ export const updateCaseMembership: DEAGatewayProxyHandler = async (
   }
 
   const caseUserResult = await updateCaseUserMembershipFromDTO(caseUser, repositoryProvider);
-  return {
-    statusCode: 200,
-    body: JSON.stringify(caseUserResult),
-  };
+
+  return responseOk(caseUserResult);
 };

--- a/source/dea-app/src/app/resources/update-cases.ts
+++ b/source/dea-app/src/app/resources/update-cases.ts
@@ -11,6 +11,7 @@ import { defaultProvider } from '../../persistence/schema/entities';
 import { ValidationError } from '../exceptions/validation-exception';
 import * as CaseService from '../services/case-service';
 import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
 
 export const updateCases: DEAGatewayProxyHandler = async (
   event,
@@ -28,8 +29,6 @@ export const updateCases: DEAGatewayProxyHandler = async (
   }
 
   const caseUpdateResult = await CaseService.updateCases(deaCase, repositoryProvider);
-  return {
-    statusCode: 200,
-    body: JSON.stringify(caseUpdateResult),
-  };
+
+  return responseOk(caseUpdateResult);
 };


### PR DESCRIPTION
- use response methods to centralize our response body and headers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
