### PR TITLE
feat: add case file table with navigation and breadcrumb

### DIFF
--- a/source/dea-app/src/persistence/case-file.ts
+++ b/source/dea-app/src/persistence/case-file.ts
@@ -72,7 +72,11 @@ const createCaseFilePaths = async (deaCaseFile: DeaCaseFile, repositoryProvider:
       });
       await createCaseFilePaths(newFileObj, repositoryProvider);
     } catch (error) {
-      logger.debug(`Path ${newFileObj.filePath}/${newFileObj.fileName} already exists, moving on...`);
+      if ('code' in error && error.code === 'UniqueError') {
+        logger.debug(`Path ${newFileObj.filePath}/${newFileObj.fileName} already exists, moving on...`);
+      } else {
+        throw error;
+      }
     }
   }
 };

--- a/source/dea-ui/ui/README.md
+++ b/source/dea-ui/ui/README.md
@@ -8,7 +8,7 @@ This is a prototype app and you should expect to modify the source code to refle
 
 | Statements                                                                                   | Branches                                                                                 | Functions                                                                                  | Lines                                                                              |
 | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-91.12%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-83.92%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-85.82%25-yellow.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-91.98%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-91.64%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-84.61%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-86.42%25-yellow.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-92.45%25-brightgreen.svg?style=flat) |
 
 
 ## Deploying code changes

--- a/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
@@ -1,10 +1,10 @@
+import wrapper from '@cloudscape-design/components/test-utils/dom';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { fail } from 'assert';
 import axios from 'axios';
 import { caseDetailLabels } from '../../src/common/labels';
 import CaseDetailsPage from '../../src/pages/case-detail';
-import wrapper from '@cloudscape-design/components/test-utils/dom';
-import { fail } from 'assert';
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn().mockImplementation(() => ({
@@ -16,25 +16,145 @@ jest.mock('next/router', () => ({
 jest.mock('axios');
 const mockedAxios = axios as jest.MockedFunction<typeof axios>;
 
+const mockFilesRoot = {
+  cases: [
+    {
+      ulid: '01GV3NH93AX2GYHBQNVR27NEMJ',
+      caseUlid: '01GV15BH762P6MW1QH8EQDGBFQ',
+      fileName: 'food',
+      contentType: 'application/octet-stream',
+      createdBy: '01GV13XRYZE1VKY7TY88Y7RPH0',
+      filePath: '/',
+      fileSizeMb: 50,
+      uploadId:
+        'aiV5S5CTX6FSWerMkYsVw9vXDp8Xes2gyEDQPPxI4b7LZjk8fKPOFrX7cn_bOupAE.xZ9M0d2HkB_075dVSYsAOKhixAN987_YXJbyUulyWgW8ORp93oRO1U0WMwhmxTE7o5gWoiJlHuVIZptds8Thgpac.4K9ChEeh2Sac35kNGH43XoSFadbzzcWCB9ZKFGP9P0gxfxRlSg4YdTyXIaw--',
+      sha256Hash: 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9',
+      versionId: '8pXrPWVxZoRiCszVYB2lShmCoxWH9Fca',
+      status: 'ACTIVE',
+      created: '2023-03-09T17:08:40.682Z',
+      updated: '2023-03-09T17:08:40.682Z',
+      isFile: false,
+      ttl: 1678385311,
+    },
+    {
+      ulid: '01GV4J7C6D18WQVCBA7RAPXTT1',
+      caseUlid: '01GV15BH762P6MW1QH8EQDGBFQ',
+      fileName: 'rootFile',
+      contentType: 'application/octet-stream',
+      createdBy: '01GV13XRYZE1VKY7TY88Y7RPH0',
+      filePath: '/',
+      fileSizeMb: 50,
+      uploadId:
+        'OEQeZM6D6jYzdHm6nnpXggWDlDhSZbZ1mcUe7JKdpfHP5zSnWlQ3kU.iz5v6zyOiQVvPqS9BfFixgBQgxRaa242L6XQyT2MwzUw7Nizk1pvXQJR_anulhvuvjGH_hpQ1x7ciO5yEDWEKTaxBF5vtxSryncXAFpHfBWBzSQi01Eou9I8PzadqnirZU0PBlN.3DxFuJP8pG2FTMHlBQSlEcA--',
+      sha256Hash: 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9',
+      versionId: 'mwXq6KDGPfw8qD3oUeDNjh2dsSGWWHad',
+      status: 'ACTIVE',
+      created: '2023-03-10T01:30:04.877Z',
+      updated: '2023-03-10T01:30:14.326Z',
+      isFile: true,
+    },
+  ],
+  total: 2,
+};
+
+const mockFilesFood = {
+  cases: [
+    {
+      ulid: '01GV3NH93AX2GYHBQNVR27NEMJ',
+      caseUlid: '01GV15BH762P6MW1QH8EQDGBFQ',
+      fileName: 'sushi.png',
+      contentType: 'application/octet-stream',
+      createdBy: '01GV13XRYZE1VKY7TY88Y7RPH0',
+      filePath: '/food',
+      fileSizeMb: 50,
+      uploadId:
+        'aiV5S5CTX6FSWerMkYsVw9vXDp8Xes2gyEDQPPxI4b7LZjk8fKPOFrX7cn_bOupAE.xZ9M0d2HkB_075dVSYsAOKhixAN987_YXJbyUulyWgW8ORp93oRO1U0WMwhmxTE7o5gWoiJlHuVIZptds8Thgpac.4K9ChEeh2Sac35kNGH43XoSFadbzzcWCB9ZKFGP9P0gxfxRlSg4YdTyXIaw--',
+      sha256Hash: 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9',
+      versionId: '8pXrPWVxZoRiCszVYB2lShmCoxWH9Fca',
+      status: 'ACTIVE',
+      created: '2023-03-09T17:08:40.682Z',
+      updated: '2023-03-09T17:08:40.682Z',
+      isFile: true,
+      ttl: 1678385311,
+    },
+  ],
+  total: 1,
+};
+
+const mockedCaseDetail = {
+  ulid: 'abc',
+  name: 'mocked case',
+  status: 'ACTIVE',
+};
+
 describe('CaseDetailsPage', () => {
   it('renders a case details page', async () => {
-    mockedAxios.mockResolvedValue({
-      data: {
-        ulid: 'abc',
-        name: 'mocked case',
-        status: 'ACTIVE',
-      },
-      status: 200,
-      statusText: 'Ok',
-      headers: {},
-      config: {},
+    mockedAxios.mockImplementation((event) => {
+      const eventObj: any = event;
+      if (eventObj.url === 'https://localhostcases/100/') {
+        return Promise.resolve({
+          data: mockedCaseDetail,
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      } else if (eventObj.url === 'https://localhostcases/100/files?filePath=/food/') {
+        return Promise.resolve({
+          data: mockFilesFood,
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      } else {
+        return Promise.resolve({
+          data: mockFilesRoot,
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      }
     });
 
     const page = render(<CaseDetailsPage />);
-    const mockedCaseInfo = await screen.findByText('mocked case');
-
     expect(page).toBeTruthy();
+
+    const mockedCaseInfo = await screen.findByText('mocked case');
     expect(mockedCaseInfo).toBeTruthy();
+
+    const table = await screen.findByTestId('file-table');
+    const tableWrapper = wrapper(table);
+    // the table exists
+    expect(table).toBeTruthy();
+
+    const folderEntry = await screen.findByTestId('food-button');
+    const fileEntry = await screen.findByTestId('rootFile-box');
+    // the folder button exists
+    expect(folderEntry).toBeTruthy();
+    // the file exists as a box
+    expect(fileEntry).toBeTruthy();
+
+    // click on the folder to navigate
+    fireEvent.click(folderEntry);
+
+    // we should now see the new file "sushi.png"
+    await screen.findByTestId('sushi.png-box');
+    const breadcrumb = tableWrapper.findBreadcrumbGroup();
+    if (!breadcrumb) {
+      fail();
+    }
+    const links = breadcrumb.findBreadcrumbLinks();
+    expect(links.length).toEqual(2);
+
+    // click the breadcrumb to return to the root
+    const rootLink = await screen.findByText('/');
+    fireEvent.click(rootLink);
+
+    // should find the original rows again
+    await screen.findByTestId('food-button');
+    await screen.findByTestId('rootFile-box');
   });
 
   it('navigates to manage access page', async () => {

--- a/source/dea-ui/ui/__tests__/pages/case-detail.unit.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/case-detail.unit.test.tsx
@@ -19,8 +19,8 @@ jest.mock('../../src/api/cases', () => ({
 describe('CaseDetailsPage', () => {
   it('renders a blank page with no caseId', async () => {
     useGetCaseById.mockImplementation(() => ({
-      caseDetail: undefined,
-      areCasesLoading: false,
+      data: undefined,
+      isLoading: false,
     }));
     const page = render(<CaseDetailsPage />);
     const anyHeader = screen.queryByRole('heading');
@@ -31,8 +31,8 @@ describe('CaseDetailsPage', () => {
 
   it('renders a loading label during fetch', () => {
     useGetCaseById.mockImplementation(() => ({
-      caseDetail: undefined,
-      areCasesLoading: true,
+      data: undefined,
+      isLoading: true,
     }));
     const page = render(<CaseDetailsPage />);
     const label = screen.getByText(commonLabels.loadingLabel);
@@ -44,8 +44,8 @@ describe('CaseDetailsPage', () => {
   it('renders a not found warning if no caseId is provided', () => {
     query = { caseId: undefined };
     useGetCaseById.mockImplementation(() => ({
-      caseDetail: undefined,
-      areCasesLoading: false,
+      data: undefined,
+      isLoading: false,
     }));
     const page = render(<CaseDetailsPage />);
     const anyHeader = screen.queryByRole('heading');

--- a/source/dea-ui/ui/src/api/cases.tsx
+++ b/source/dea-ui/ui/src/api/cases.tsx
@@ -4,24 +4,38 @@
  */
 
 import { DeaCase } from '@aws/dea-app';
+import { DeaCaseFile } from '@aws/dea-app/lib/models/case-file';
 import useSWR from 'swr';
 import { httpApiGet, httpApiPost } from '../helpers/apiHelper';
 import { CreateCaseForm } from '../models/Cases';
 
-const useListAllCases = (): { cases: DeaCase[]; areCasesLoading: boolean } => {
+export interface DeaListResult<T> {
+  data: T[];
+  isLoading: boolean;
+}
+
+export interface DeaSingleResult<T> {
+  data: T;
+  isLoading: boolean;
+}
+
+export const useListAllCases = (): DeaListResult<DeaCase> => {
   const { data, isValidating } = useSWR(() => `cases/all-cases`, httpApiGet);
   const cases: DeaCase[] = data?.cases ?? [];
-  return { cases, areCasesLoading: isValidating };
+  return { data: cases, isLoading: isValidating };
 };
 
-const useGetCaseById = (id: string): { caseDetail: DeaCase; areCasesLoading: boolean } => {
+export const useGetCaseById = (id: string): DeaSingleResult<DeaCase> => {
   const { data, isValidating } = useSWR(() => `cases/${id}/`, httpApiGet);
-  const caseDetail: DeaCase = data;
-  return { caseDetail, areCasesLoading: isValidating };
+  return { data, isLoading: isValidating };
 };
 
-const createCase = async (createCaseForm: CreateCaseForm): Promise<void> => {
+export const createCase = async (createCaseForm: CreateCaseForm): Promise<void> => {
   await httpApiPost(`cases`, { ...createCaseForm });
 };
 
-export { useListAllCases, useGetCaseById, createCase };
+export const useListCaseFiles = (id: string, filePath = '/'): DeaListResult<DeaCaseFile> => {
+  const { data, isValidating } = useSWR(() => `cases/${id}/files?filePath=${filePath}`, httpApiGet);
+  const caseFiles: DeaCaseFile[] = data?.cases ?? [];
+  return { data: caseFiles, isLoading: isValidating && !data };
+};

--- a/source/dea-ui/ui/src/components/case-details/CaseDetailsBody.tsx
+++ b/source/dea-ui/ui/src/components/case-details/CaseDetailsBody.tsx
@@ -8,23 +8,23 @@ import { useGetCaseById } from '../../api/cases';
 import { commonLabels } from '../../common/labels';
 import CaseDetailsTabs from './CaseDetailsTabs';
 
-interface CaseDetailsBodyProps {
-  readonly caseId: string | string;
+export interface CaseDetailsBodyProps {
+  readonly caseId: string;
 }
 
 function CaseDetailsBody(props: CaseDetailsBodyProps): JSX.Element {
-  const { caseDetail, areCasesLoading } = useGetCaseById(props.caseId);
-  if (areCasesLoading) {
+  const { data, isLoading } = useGetCaseById(props.caseId);
+  if (isLoading) {
     return <h1>{commonLabels.loadingLabel}</h1>;
   } else {
-    if (!caseDetail) {
+    if (!data) {
       return <h1>{commonLabels.notFoundLabel}</h1>;
     }
     return (
       <ContentLayout
         header={
           <SpaceBetween size="m">
-            <Header variant="h1">{caseDetail.name}</Header>
+            <Header variant="h1">{data.name}</Header>
           </SpaceBetween>
         }
       >
@@ -39,7 +39,7 @@ function CaseDetailsBody(props: CaseDetailsBodyProps): JSX.Element {
             </div>
             <div>
               <h4>Description</h4>
-              <p>{caseDetail.description}</p>
+              <p>{data.description}</p>
             </div>
             <div>
               {' '}
@@ -47,7 +47,7 @@ function CaseDetailsBody(props: CaseDetailsBodyProps): JSX.Element {
             </div>
           </ColumnLayout>
         </Container>
-        <CaseDetailsTabs></CaseDetailsTabs>
+        <CaseDetailsTabs caseId={props.caseId}></CaseDetailsTabs>
       </ContentLayout>
     );
   }

--- a/source/dea-ui/ui/src/components/case-details/CaseDetailsTabs.tsx
+++ b/source/dea-ui/ui/src/components/case-details/CaseDetailsTabs.tsx
@@ -6,10 +6,11 @@
 import { Tabs } from '@cloudscape-design/components';
 import * as React from 'react';
 import { caseDetailLabels } from '../../common/labels';
+import { CaseDetailsBodyProps } from './CaseDetailsBody';
 import CaseFilesTable from './CaseFilesTable';
 import ManageAccessForm from './ManageAccessForm';
 
-function CaseDetailsTabs(): JSX.Element {
+function CaseDetailsTabs(props: CaseDetailsBodyProps): JSX.Element {
   return (
     <Tabs
       data-testid="case-details-tabs"
@@ -17,7 +18,7 @@ function CaseDetailsTabs(): JSX.Element {
         {
           label: caseDetailLabels.caseFilesLabel,
           id: 'caseFiles',
-          content: <CaseFilesTable></CaseFilesTable>,
+          content: <CaseFilesTable caseId={props.caseId}></CaseFilesTable>,
         },
         {
           label: caseDetailLabels.manageAccessLabel,

--- a/source/dea-ui/ui/src/components/case-details/CaseFilesTable.tsx
+++ b/source/dea-ui/ui/src/components/case-details/CaseFilesTable.tsx
@@ -3,42 +3,125 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
+import { DeaCaseFile } from '@aws/dea-app/lib/models/case-file';
 import {
-  Table,
   Box,
+  BreadcrumbGroup,
   Button,
-  TextFilter,
-  Pagination,
   Header,
+  Icon,
+  Pagination,
   SpaceBetween,
+  Table,
+  TextFilter,
 } from '@cloudscape-design/components';
 import * as React from 'react';
-import { commonTableLabels, filesListLabels, commonLabels } from '../../common/labels';
+import { useListCaseFiles } from '../../api/cases';
+import { commonLabels, commonTableLabels, filesListLabels } from '../../common/labels';
+import { CaseDetailsBodyProps } from './CaseDetailsBody';
 
-function CaseFilesTable(): JSX.Element {
+function CaseFilesTable(props: CaseDetailsBodyProps): JSX.Element {
   // Property and date filter collections
-  const items = [
-    {
-      fileName: 'Dummy file 1',
-      fileType: 'jpeg',
-    },
-    {
-      fileName: 'Dummy file 2',
-      fileType: 'doc',
-    },
-    {
-      fileName: 'Dummy file 3',
-      fileType: 'xml',
-    },
-  ];
+  const [basePath, setBasePath] = React.useState('/');
+  const { data, isLoading } = useListCaseFiles(props.caseId, basePath);
+
+  if (isLoading) {
+    return <h1>{commonLabels.loadingLabel}</h1>;
+  }
+
+  const pathParts = basePath.split('/');
+  const breadcrumbItems = [{ text: '/', href: '#' }];
+
+  let hrefString = '#';
+  pathParts.forEach((part) => {
+    if (part !== '') {
+      hrefString += part + '#';
+      breadcrumbItems.push({ text: part, href: hrefString });
+    }
+  });
+
+  const fileFolderCell = (caseFile: DeaCaseFile) => {
+    return !caseFile.isFile ? (
+      <Button
+        data-testid={`${caseFile.fileName}-button`}
+        iconName="folder"
+        variant="link"
+        onClick={(e: { preventDefault: () => void }) => {
+          e.preventDefault();
+          setBasePath(basePath + caseFile.fileName + '/');
+        }}
+      >
+        {caseFile.fileName}
+      </Button>
+    ) : (
+      <Box padding={{ left: 'm' }} data-testid={`${caseFile.fileName}-box`}>
+        <SpaceBetween direction="horizontal" size="xs" key={caseFile.fileName}>
+          <Icon name="file" />
+          {caseFile.fileName}
+        </SpaceBetween>
+      </Box>
+    );
+  };
+
+  // table header Element
+  const tableHeader = (
+    <Header
+      variant="h2"
+      description={filesListLabels.filterDescription}
+      actions={
+        <SpaceBetween direction="horizontal" size="xs">
+          <Button>{commonLabels.uploadButton}</Button>
+          <Button variant="primary">{commonLabels.downloadButton}</Button>
+        </SpaceBetween>
+      }
+    >
+      <SpaceBetween direction="horizontal" size="xs">
+        {filesListLabels.caseFilesLabel}
+        <BreadcrumbGroup
+          data-testid="file-breadcrumb"
+          onClick={(event) => {
+            event.preventDefault();
+            setBasePath(event.detail.href.replaceAll('#', '/'));
+          }}
+          items={breadcrumbItems}
+          ariaLabel="Breadcrumbs"
+        />
+      </SpaceBetween>
+    </Header>
+  );
+
+  // empty table Element
+  const emptyConfig = (
+    <Box textAlign="center" color="inherit">
+      <b>{filesListLabels.noFilesLabel}</b>
+      <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+        {filesListLabels.noDisplayLabel}
+      </Box>
+      <Button>{filesListLabels.uploadFileLabel}</Button>
+    </Box>
+  );
+
+  // pagination element
+  const tablePagination = (
+    <Pagination
+      currentPageIndex={1}
+      pagesCount={1}
+      ariaLabels={{
+        nextPageLabel: 'Next page',
+        previousPageLabel: 'Previous page',
+        pageLabel: (pageNumber) => `Page ${pageNumber} of all pages`,
+      }}
+    />
+  );
 
   return (
     <Table
+      data-testid="file-table"
       columnDefinitions={[
         {
           id: 'name',
           header: commonTableLabels.nameHeader,
-          cell: (e) => e.fileName,
+          cell: fileFolderCell,
           width: 170,
           minWidth: 165,
           sortingField: 'name',
@@ -46,7 +129,7 @@ function CaseFilesTable(): JSX.Element {
         {
           id: 'fileType',
           header: commonTableLabels.fileTypeHeader,
-          cell: (e) => e.fileType,
+          cell: (e) => e.contentType,
           width: 170,
           minWidth: 165,
           sortingField: 'fileType',
@@ -54,7 +137,7 @@ function CaseFilesTable(): JSX.Element {
         {
           id: 'uploadDate',
           header: commonTableLabels.dateUploadedHeader,
-          cell: () => 'FOO, 00/00/00',
+          cell: (e) => e.created,
           width: 170,
           minWidth: 165,
           sortingField: 'uploadDate',
@@ -62,51 +145,20 @@ function CaseFilesTable(): JSX.Element {
         {
           id: 'uploader',
           header: commonTableLabels.uploadedByHeader,
-          cell: () => 'Sherlock Holmes',
+          cell: (e) => e.createdBy,
           width: 170,
           minWidth: 165,
           sortingField: 'uploader',
         },
       ]}
-      items={items}
+      items={data}
       loadingText={filesListLabels.loading}
       resizableColumns
-      selectionType="single"
-      empty={
-        <Box textAlign="center" color="inherit">
-          <b>{filesListLabels.noFilesLabel}</b>
-          <Box padding={{ bottom: 's' }} variant="p" color="inherit">
-            {filesListLabels.noDisplayLabel}
-          </Box>
-          <Button>{filesListLabels.uploadFileLabel}</Button>
-        </Box>
-      }
+      selectionType="multi"
+      empty={emptyConfig}
       filter={<TextFilter filteringPlaceholder={filesListLabels.searchLabel} filteringText="" />}
-      header={
-        <Header
-          variant="h2"
-          description={filesListLabels.filterDescription}
-          actions={
-            <SpaceBetween direction="horizontal" size="xs">
-              <Button>{commonLabels.uploadButton}</Button>
-              <Button variant="primary">{commonLabels.downloadButton}</Button>
-            </SpaceBetween>
-          }
-        >
-          {filesListLabels.caseFilesLabel}
-        </Header>
-      }
-      pagination={
-        <Pagination
-          currentPageIndex={1}
-          pagesCount={1}
-          ariaLabels={{
-            nextPageLabel: 'Next page',
-            previousPageLabel: 'Previous page',
-            pageLabel: (pageNumber) => `Page ${pageNumber} of all pages`,
-          }}
-        />
-      }
+      header={tableHeader}
+      pagination={tablePagination}
     />
   );
 }

--- a/source/dea-ui/ui/src/components/case-list-table/CaseTable.tsx
+++ b/source/dea-ui/ui/src/components/case-list-table/CaseTable.tsx
@@ -15,10 +15,10 @@ import { filteringOptions, filteringProperties, searchableColumns } from './case
 
 function CaseTable(): JSX.Element {
   const router = useRouter();
-  const { cases, areCasesLoading } = useListAllCases();
+  const { data, isLoading } = useListAllCases();
 
   // Property and date filter collections
-  const { items, filteredItemsCount, propertyFilterProps } = useCollection(cases, {
+  const { items, filteredItemsCount, propertyFilterProps } = useCollection(data, {
     filtering: {
       empty: TableEmptyDisplay(caseListLabels.noCasesLabel),
       noMatch: TableNoMatchDisplay(caseListLabels.noCasesLabel),
@@ -53,7 +53,7 @@ function CaseTable(): JSX.Element {
     <Table
       data-testid="case-table"
       trackBy="ulid"
-      loading={areCasesLoading}
+      loading={isLoading}
       variant="full-page"
       items={items}
       loadingText={caseListLabels.loading}
@@ -72,7 +72,7 @@ function CaseTable(): JSX.Element {
               </Button>{' '}
             </SpaceBetween>
           }
-          totalItems={cases}
+          totalItems={data}
         />
       }
       columnDefinitions={[


### PR DESCRIPTION
- add populating case file list table
- navigate via clicking folders 
- navigate via breadcrumbs


https://user-images.githubusercontent.com/16548582/224459583-9459fb7a-fd07-4aec-995e-50befffd423e.mov


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
