### PR TITLE
refactor: do not allow resource paths to end with a wildcard

### DIFF
--- a/DEA_Insomnia.yaml
+++ b/DEA_Insomnia.yaml
@@ -7,7 +7,7 @@ resources:
     parentId: wrk_eff9e05b8f094067a85a5360070a0c5d
     modified: 1677185777682
     created: 1675974209968
-    url: "{{ _.deaApiUrl }}cases/someulid"
+    url: "{{ _.deaApiUrl }}cases/someulid/details"
     name: DELETE case
     description: ""
     method: DELETE
@@ -47,7 +47,7 @@ resources:
     parentId: wrk_eff9e05b8f094067a85a5360070a0c5d
     modified: 1676047532567
     created: 1675974318195
-    url: "{{ _.deaApiUrl }}cases/someulid"
+    url: "{{ _.deaApiUrl }}cases/someulid/details"
     name: PUT case
     description: ""
     method: GET
@@ -218,7 +218,7 @@ resources:
     parentId: wrk_eff9e05b8f094067a85a5360070a0c5d
     modified: 1677269903599
     created: 1677186652542
-    url: "{{deaApiUrl}}cases/someulid/files/someulid"
+    url: "{{deaApiUrl}}cases/someulid/files/someulid/details"
     name: GET case-file-description
     description: ""
     method: GET
@@ -282,7 +282,7 @@ resources:
     parentId: wrk_eff9e05b8f094067a85a5360070a0c5d
     modified: 1676047604505
     created: 1673052526957
-    url: "{{deaApiUrl}}cases/someulid"
+    url: "{{deaApiUrl}}cases/someulid/details"
     name: GET case by id
     description: ""
     method: GET
@@ -400,7 +400,7 @@ resources:
     parentId: wrk_eff9e05b8f094067a85a5360070a0c5d
     modified: 1677270060185
     created: 1677269751873
-    url: "{{ _.deaApiUrl }}cases/someulid/files/someulid"
+    url: "{{ _.deaApiUrl }}cases/someulid/files/someulid/contents"
     name: PUT complete casefile upload
     description: ""
     method: PUT

--- a/source/common/config/chewbacca.json
+++ b/source/common/config/chewbacca.json
@@ -8,22 +8,18 @@
       "endpoints": [
         {
           "path": "/cases",
-          "method": "GET"
-        },
-        {
-          "path": "/cases",
           "method": "POST"
         },
         {
-          "path": "/cases/{caseId}",
+          "path": "/cases/{caseId}/details",
           "method": "GET"
         },
         {
-          "path": "/cases/{caseId}",
+          "path": "/cases/{caseId}/details",
           "method": "PUT"
         },
         {
-          "path": "/cases/{caseId}",
+          "path": "/cases/{caseId}/details",
           "method": "DELETE"
         },
         {
@@ -35,23 +31,23 @@
           "method": "POST"
         },
         {
-          "path": "/cases/{caseId}/userMemberships{userId}",
+          "path": "/cases/{caseId}/users/{userId}/memberships",
           "method": "PUT"
         },
         {
-          "path": "/cases/{caseId}/userMemberships{userId}",
+          "path": "/cases/{caseId}/users/{userId}/memberships",
           "method": "DELETE"
         },
         {
-          "path": "/auth/getToken/{authCode}",
+          "path": "/auth/{authCode}/token",
           "method": "POST"
         },
         {
-          "path": "/auth/getLoginUrl",
+          "path": "/auth/loginUrl",
           "method": "GET"
         },
         {
-          "path": "/auth/getCredentials/{idToken}",
+          "path": "/auth/credentials/{idToken}/exchange",
           "method": "GET"
         },
         {
@@ -67,15 +63,19 @@
           "method": "GET"
         },
         {
-          "path": "/cases/{caseId}/files/{fileId}",
+          "path": "/cases/{caseId}/files/{fileId}/contents",
           "method": "PUT"
         },
         {
-          "path": "/cases/{caseId}/files/{fileId}",
+          "path": "/cases/{caseId}/files/{fileId}/details",
           "method": "GET"
         },
         {
           "path": "/cases/{caseId}/files/{fileId}/contents",
+          "method": "GET"
+        },
+        {
+          "path": "/cases/my-cases",
           "method": "GET"
         }
       ]
@@ -99,15 +99,15 @@
           "method": "GET"
         },
         {
-          "path": "/auth/getToken/{authCode}",
+          "path": "/auth/token",
           "method": "POST"
         },
         {
-          "path": "/auth/getCredentials/{idToken}",
+          "path": "/auth/credentials/{idToken}/exchange",
           "method": "GET"
         },
         {
-          "path": "/auth/getLoginUrl",
+          "path": "/auth/loginUrl",
           "method": "GET"
         }
       ]
@@ -121,7 +121,7 @@
           "method": "POST"
         },
         {
-          "path": "/cases/{caseId}",
+          "path": "/cases/{caseId}/details",
           "method": "DELETE"
         },
         {
@@ -129,15 +129,15 @@
           "method": "GET"
         },
         {
-          "path": "/auth/getToken/{authCode}",
+          "path": "/auth/token",
           "method": "POST"
         },
         {
-          "path": "/auth/getCredentials/{idToken}",
+          "path": "/auth/credentials/{idToken}/exchange",
           "method": "GET"
         },
         {
-          "path": "/auth/getLoginUrl",
+          "path": "/auth/loginUrl",
           "method": "GET"
         }
       ]
@@ -151,23 +151,23 @@
           "method": "POST"
         },
         {
-          "path": "/cases/{caseId}",
+          "path": "/cases/{caseId}/details",
           "method": "GET"
         },
         {
-          "path": "/cases/{caseId}",
+          "path": "/cases/{caseId}/details",
           "method": "DELETE"
         },
         {
-          "path": "/auth/getToken/{authCode}",
+          "path": "/auth/token",
           "method": "POST"
         },
         {
-          "path": "/auth/getCredentials/{idToken}",
+          "path": "/auth/credentials/{idToken}/exchange",
           "method": "GET"
         },
         {
-          "path": "/auth/getLoginUrl",
+          "path": "/auth/loginUrl",
           "method": "GET"
         }
       ]
@@ -181,11 +181,11 @@
           "method": "POST"
         },
         {
-          "path": "/cases/{caseId}",
+          "path": "/cases/{caseId}/details",
           "method": "GET"
         },
         {
-          "path": "/cases/{caseId}",
+          "path": "/cases/{caseId}/details",
           "method": "DELETE"
         },
         {

--- a/source/common/config/palpatine.json
+++ b/source/common/config/palpatine.json
@@ -13,15 +13,15 @@
           "method": "POST"
         },
         {
-          "path": "/cases/{caseId}",
+          "path": "/cases/{caseId}/details",
           "method": "GET"
         },
         {
-          "path": "/cases/{caseId}",
+          "path": "/cases/{caseId}/details",
           "method": "PUT"
         },
         {
-          "path": "/cases/{caseId}",
+          "path": "/cases/{caseId}/details",
           "method": "DELETE"
         },
         {
@@ -29,19 +29,19 @@
           "method": "POST"
         },
         {
-          "path": "/cases/{caseId}/userMemberships{userId}",
+          "path": "/cases/{caseId}/users/{userId}/memberships",
           "method": "PUT"
         },
         {
-          "path": "/cases/{caseId}/userMemberships{userId}",
+          "path": "/cases/{caseId}/users/{userId}/memberships",
           "method": "DELETE"
         },
         {
-          "path": "/auth/getToken/{authCode}",
+          "path": "/auth/{authCode}/token",
           "method": "POST"
         },
         {
-          "path": "/auth/getCredentials/{idToken}",
+          "path": "/auth/credentials/{idToken}/exchange",
           "method": "GET"
         },
         {
@@ -57,11 +57,11 @@
           "method": "GET"
         },
         {
-          "path": "/cases/{caseId}/files/{fileId}",
+          "path": "/cases/{caseId}/files/{fileId}/contents",
           "method": "PUT"
         },
         {
-          "path": "/cases/{caseId}/files/{fileId}",
+          "path": "/cases/{caseId}/files/{fileId}/details",
           "method": "GET"
         },
         {

--- a/source/dea-app/src/oas/openapi-case.yml
+++ b/source/dea-app/src/oas/openapi-case.yml
@@ -176,7 +176,7 @@ paths:
                       $ref: '#/components/schemas/Users'
                   next:
                     type: string
-  /cases/{caseId}/userMemberships/{userId}:
+  /cases/{caseId}/users/{userId}/memberships:
     put:
       summary: Update case user
       description: Update the details on an existing case membership
@@ -253,7 +253,7 @@ paths:
                       $ref: '#/components/schemas/Cases'
                   next:
                     type: string
-  /cases/{caseId}:
+  /cases/{caseId}/details:
     get:
       summary: Return case details by case Id
       description: Get metadata for a specific case. return not found if user doesn’t have access
@@ -294,31 +294,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Case'
-  /cases/{caseId}/status:
-    put:
-      summary: Update case status
-      tags:
-        - cases
-      parameters:
-        - in: path
-          name: caseId
-          schema:
-            type: string
-          required: true
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CaseStatusRequest'
-      responses:
-        200:
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Case'
-        304:
-          description: unchanged status
   /cases/{caseId}/files:
     post:
       summary: Begin case file upload
@@ -379,7 +354,7 @@ paths:
                       $ref: '#/components/schemas/CaseFiles'
                   next:
                     type: string
-  /cases/{caseId}/files/{fileId}:
+  /cases/{caseId}/files/{fileId}/details:
     get:
       summary: File details
       description: Get details for a file within a case

--- a/source/dea-app/src/test-e2e/auth/auth.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/auth/auth.e2e.test.ts
@@ -99,8 +99,8 @@ describe('API authentication', () => {
     const expectedUrl = `${cognitoParams.cognitoDomainUrl}/oauth2/authorize?response_type=code&client_id=${cognitoParams.clientId}&redirect_uri=${cognitoParams.callbackUrl}`;
 
     // fetch url
-    const url = `${deaApiUrl}auth/getLoginUrl`;
-    const response = await client.get(url);
+    const url = `${deaApiUrl}auth/loginUrl`;
+    const response = await client.get(url, { validateStatus });
     expect(response.data).toEqual(expectedUrl);
   });
 
@@ -120,7 +120,7 @@ describe('API authentication', () => {
     );
 
     // 3. Exchange auth code for id token
-    const url = `${deaApiUrl}auth/getToken/${authCode}`;
+    const url = `${deaApiUrl}auth/${authCode}/token`;
     const headers = { 'callback-override': authTestUrl };
     const response = await client.post(url, undefined, { headers, validateStatus });
     expect(response.status).toEqual(200);
@@ -128,7 +128,7 @@ describe('API authentication', () => {
     const idToken = retrievedTokens.id_token;
 
     // 3. Exchange id token for credentials
-    const credentialsUrl = `${deaApiUrl}auth/getCredentials/${idToken}`;
+    const credentialsUrl = `${deaApiUrl}auth/credentials/${idToken}/exchange`;
     const credsResponse = await client.get(credentialsUrl, { validateStatus });
     expect(credsResponse.status).toEqual(200);
   }, 40000);
@@ -137,7 +137,7 @@ describe('API authentication', () => {
     const client = axios.create();
     const authCode = 'ABCDEFGHIJKL123';
 
-    const url = `${deaApiUrl}auth/getToken/${authCode}`;
+    const url = `${deaApiUrl}auth/${authCode}/token`;
     const response = await client.get(url, { validateStatus });
     expect(response.status).toEqual(403);
     expect(response.statusText).toEqual('Forbidden');
@@ -147,7 +147,7 @@ describe('API authentication', () => {
     const client = axios.create();
     const idToken = 'fake.fake.fake';
 
-    const url = `${deaApiUrl}auth/getCredentials/${idToken}`;
+    const url = `${deaApiUrl}auth/credentials/${idToken}/exchange`;
     const response = await client.get(url, { validateStatus });
     expect(response.status).toEqual(500);
     expect(response.statusText).toEqual('Internal Server Error');

--- a/source/dea-app/src/test-e2e/resources/case-api-acls.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/case-api-acls.e2e.test.ts
@@ -27,13 +27,13 @@ const RANDOM_STRING = '{rand}';
 const getCaseDetailsArgs: argsType = [
   'getCaseDetailsACLs',
   [CaseAction.VIEW_CASE_DETAILS],
-  `cases/${CASE_ID}`,
+  `cases/${CASE_ID}/details`,
   'GET',
 ];
 const putCaseDetailsArgs: argsType = [
   'putCaseDetailsACLs',
   [CaseAction.UPDATE_CASE_DETAILS],
-  `cases/${CASE_ID}`,
+  `cases/${CASE_ID}/details`,
   'PUT',
   JSON.stringify({
     ulid: CASE_ID,
@@ -66,7 +66,7 @@ const getCaseCollabsArgs: argsType = [
 const deleteMembershipArgs: argsType = [
   'removeFromCaseACLs',
   [CaseAction.INVITE],
-  `cases/${CASE_ID}/userMemberships/${COMPANION_ID}`,
+  `cases/${CASE_ID}/users/${COMPANION_ID}/memberships`,
   'DELETE',
   undefined,
   true,
@@ -74,7 +74,7 @@ const deleteMembershipArgs: argsType = [
 const putCaseUserArgs: argsType = [
   'putCaseUserACLs',
   [CaseAction.INVITE],
-  `cases/${CASE_ID}/userMemberships/${COMPANION_ID}`,
+  `cases/${CASE_ID}/users/${COMPANION_ID}/memberships`,
   'PUT',
   JSON.stringify({
     userUlid: COMPANION_ID,
@@ -108,7 +108,7 @@ const listCaseFilesArgs: argsType = [
 const getCaseFileDetailsArgs: argsType = [
   'getCaseFileDetails',
   [CaseAction.VIEW_FILES],
-  `cases/${CASE_ID}/files/${FILE_ID}`,
+  `cases/${CASE_ID}/files/${FILE_ID}/details`,
   'GET',
   undefined,
   false,
@@ -117,7 +117,7 @@ const getCaseFileDetailsArgs: argsType = [
 const completeCaseFileUploadArgs: argsType = [
   'completeCaseFileUpload',
   [CaseAction.UPLOAD],
-  `cases/${CASE_ID}/files/${FILE_ID}`,
+  `cases/${CASE_ID}/files/${FILE_ID}/contents`,
   'PUT',
   JSON.stringify({
     caseUlid: CASE_ID,

--- a/source/dea-app/src/test-e2e/resources/case-membership.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/case-membership.e2e.test.ts
@@ -76,7 +76,7 @@ describe('CaseMembership E2E', () => {
   it('should CRUD CaseUsers', async () => {
     // confirm invitee doesn't have access
     const noAccessResponse = await callDeaAPIWithCreds(
-      `${deaApiUrl}cases/${targetCase.ulid}`,
+      `${deaApiUrl}cases/${targetCase.ulid}/details`,
       'GET',
       inviteeToken,
       inviteeCreds
@@ -115,7 +115,7 @@ describe('CaseMembership E2E', () => {
 
     // confirm invitee has view access
     const accessResponse = await callDeaAPIWithCreds(
-      `${deaApiUrl}cases/${targetCase.ulid}`,
+      `${deaApiUrl}cases/${targetCase.ulid}/details`,
       'GET',
       inviteeToken,
       inviteeCreds
@@ -129,7 +129,7 @@ describe('CaseMembership E2E', () => {
       description: 'Updated Description',
     };
     const updateAttempt = await callDeaAPIWithCreds(
-      `${deaApiUrl}cases/${targetCase.ulid}`,
+      `${deaApiUrl}cases/${targetCase.ulid}/details`,
       'PUT',
       inviteeToken,
       inviteeCreds,
@@ -139,7 +139,7 @@ describe('CaseMembership E2E', () => {
 
     // in addition to the 404 above, confirm the case is unchanged
     const caseAfterFailedUpdate = await callDeaAPIWithCreds(
-      `${deaApiUrl}cases/${targetCase.ulid}`,
+      `${deaApiUrl}cases/${targetCase.ulid}/details`,
       'GET',
       inviteeToken,
       inviteeCreds
@@ -157,7 +157,7 @@ describe('CaseMembership E2E', () => {
     };
 
     const grantUpdateAccess = await callDeaAPIWithCreds(
-      `${deaApiUrl}cases/${targetCase.ulid}/userMemberships/${inviteeUlid}`,
+      `${deaApiUrl}cases/${targetCase.ulid}/users/${inviteeUlid}/memberships`,
       'PUT',
       ownerToken,
       ownerCreds,
@@ -167,7 +167,7 @@ describe('CaseMembership E2E', () => {
 
     // Confirm invitee can now update the case
     const updateReattempt = await callDeaAPIWithCreds(
-      `${deaApiUrl}cases/${targetCase.ulid}`,
+      `${deaApiUrl}cases/${targetCase.ulid}/details`,
       'PUT',
       inviteeToken,
       inviteeCreds,
@@ -177,7 +177,7 @@ describe('CaseMembership E2E', () => {
 
     // In addition to the 200 above, confirm changes were persisted
     const caseAfterUpdate = await callDeaAPIWithCreds(
-      `${deaApiUrl}cases/${targetCase.ulid}`,
+      `${deaApiUrl}cases/${targetCase.ulid}/details`,
       'GET',
       inviteeToken,
       inviteeCreds
@@ -189,7 +189,7 @@ describe('CaseMembership E2E', () => {
 
     // Delete the membership
     const dismissResponse = await callDeaAPIWithCreds(
-      `${deaApiUrl}cases/${targetCase.ulid}/userMemberships/${inviteeUlid}`,
+      `${deaApiUrl}cases/${targetCase.ulid}/users/${inviteeUlid}/memberships`,
       'DELETE',
       ownerToken,
       ownerCreds
@@ -198,7 +198,7 @@ describe('CaseMembership E2E', () => {
 
     // confirm invitee doesn't have access
     const removedAccessResponse = await callDeaAPIWithCreds(
-      `${deaApiUrl}cases/${targetCase.ulid}`,
+      `${deaApiUrl}cases/${targetCase.ulid}/details`,
       'GET',
       inviteeToken,
       inviteeCreds
@@ -286,7 +286,7 @@ describe('CaseMembership E2E', () => {
   describe('PUT', () => {
     it('should produce an error when payload is missing', async () => {
       const inviteResponse = await callDeaAPIWithCreds(
-        `${deaApiUrl}cases/${targetCase.ulid}/userMemberships/${inviteeUlid}`,
+        `${deaApiUrl}cases/${targetCase.ulid}/users/${inviteeUlid}/memberships`,
         'PUT',
         ownerToken,
         ownerCreds
@@ -301,7 +301,7 @@ describe('CaseMembership E2E', () => {
         caseUlid: targetCase.ulid!,
       };
       const inviteResponse = await callDeaAPIWithCreds(
-        `${deaApiUrl}cases/${targetCase.ulid}/userMemberships/${inviteeUlid}`,
+        `${deaApiUrl}cases/${targetCase.ulid}/users/${inviteeUlid}/memberships`,
         'PUT',
         ownerToken,
         ownerCreds,
@@ -318,7 +318,7 @@ describe('CaseMembership E2E', () => {
         actions: [CaseAction.VIEW_CASE_DETAILS],
       };
       const inviteResponse = await callDeaAPIWithCreds(
-        `${deaApiUrl}cases/${targetCase.ulid}/userMemberships/${inviteeUlid}`,
+        `${deaApiUrl}cases/${targetCase.ulid}/users/${inviteeUlid}/memberships`,
         'PUT',
         ownerToken,
         ownerCreds,
@@ -335,7 +335,7 @@ describe('CaseMembership E2E', () => {
         actions: [CaseAction.VIEW_CASE_DETAILS],
       };
       const inviteResponse = await callDeaAPIWithCreds(
-        `${deaApiUrl}cases/${targetCase.ulid}/userMemberships/${inviteeUlid}`,
+        `${deaApiUrl}cases/${targetCase.ulid}/users/${inviteeUlid}/memberships`,
         'PUT',
         ownerToken,
         ownerCreds,
@@ -352,7 +352,7 @@ describe('CaseMembership E2E', () => {
         actions: [CaseAction.VIEW_CASE_DETAILS],
       };
       const inviteResponse = await callDeaAPIWithCreds(
-        `${deaApiUrl}cases/${targetCase.ulid}/userMemberships/${bogusUlid}`,
+        `${deaApiUrl}cases/${targetCase.ulid}/users/${bogusUlid}/memberships`,
         'PUT',
         ownerToken,
         ownerCreds,
@@ -366,7 +366,7 @@ describe('CaseMembership E2E', () => {
   describe('DELETE', () => {
     it('should return success if the case user does not exist', async () => {
       const inviteResponse = await callDeaAPIWithCreds(
-        `${deaApiUrl}cases/${targetCase.ulid}/userMemberships/${bogusUlid}`,
+        `${deaApiUrl}cases/${targetCase.ulid}/users/${bogusUlid}/memberships`,
         'DELETE',
         ownerToken,
         ownerCreds

--- a/source/dea-app/src/test-e2e/resources/get-case-details.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/get-case-details.e2e.test.ts
@@ -45,7 +45,7 @@ describe('get case api', () => {
 
     // Now call Get and Check response is what we created
     const getResponse = await callDeaAPIWithCreds(
-      `${deaApiUrl}cases/${createdCase.ulid}`,
+      `${deaApiUrl}cases/${createdCase.ulid}/details`,
       'GET',
       testUserToken,
       testUserCreds
@@ -63,7 +63,12 @@ describe('get case api', () => {
   it('should throw an error when the case is not found', async () => {
     const url = `${deaApiUrl}cases`;
     const caseId = 'FAKEEFGHHJKKMNNPQRSTTVWXY9';
-    const response = await callDeaAPIWithCreds(`${url}/${caseId}`, 'GET', testUserToken, testUserCreds);
+    const response = await callDeaAPIWithCreds(
+      `${url}/${caseId}/details`,
+      'GET',
+      testUserToken,
+      testUserCreds
+    );
 
     expect(response.status).toEqual(404);
   });

--- a/source/dea-app/src/test-e2e/resources/test-helpers.ts
+++ b/source/dea-app/src/test-e2e/resources/test-helpers.ts
@@ -49,7 +49,7 @@ export async function deleteCase(
   idToken: string,
   creds: Credentials
 ): Promise<void> {
-  const response = await callDeaAPIWithCreds(`${baseUrl}cases/${caseUlid}`, 'DELETE', idToken, creds);
+  const response = await callDeaAPIWithCreds(`${baseUrl}cases/${caseUlid}/details`, 'DELETE', idToken, creds);
 
   expect(response.status).toEqual(204);
 }
@@ -208,7 +208,7 @@ export const describeCaseFileDetailsSuccess = async (
   fileUlid: string | undefined
 ): Promise<DeaCaseFile> => {
   const response = await callDeaAPIWithCreds(
-    `${deaApiUrl}cases/${caseUlid}/files/${fileUlid}`,
+    `${deaApiUrl}cases/${caseUlid}/files/${fileUlid}/details`,
     'GET',
     idToken,
     creds
@@ -284,7 +284,7 @@ export const completeCaseFileUploadSuccess = async (
   fileContent: string
 ): Promise<DeaCaseFile> => {
   const completeUploadResponse = await callDeaAPIWithCreds(
-    `${deaApiUrl}cases/${caseUlid}/files/${ulid}`,
+    `${deaApiUrl}cases/${caseUlid}/files/${ulid}/contents`,
     'PUT',
     idToken,
     creds,

--- a/source/dea-app/src/test/integration-objects.ts
+++ b/source/dea-app/src/test/integration-objects.ts
@@ -14,8 +14,8 @@ import {
 } from '../app/services/audit-service';
 
 const dummyEvent: APIGatewayProxyEvent = {
-  resource: '/cases/{caseId}',
-  path: '/cases/01GSX40H73JQ9Q2T2EERPYWN6C',
+  resource: '/cases/{caseId}/details',
+  path: '/cases/01GSX40H73JQ9Q2T2EERPYWN6C/details',
   httpMethod: 'GET',
   headers: {
     'CloudFront-Forwarded-Proto': 'https',
@@ -63,11 +63,11 @@ const dummyEvent: APIGatewayProxyEvent = {
   stageVariables: null,
   requestContext: {
     resourceId: 'abc',
-    resourcePath: '/cases/{caseId}',
+    resourcePath: '/cases/{caseId}/details',
     httpMethod: 'GET',
     extendedRequestId: 'abc123',
     requestTime: '22/Feb/2023:17:51:21 +0000',
-    path: '/dev/cases/01GSX40H73JQ9Q2T2EERPYWN6C',
+    path: '/dev/cases/01GSX40H73JQ9Q2T2EERPYWN6C/details',
     accountId: '123456789012',
     protocol: 'HTTP/1.1',
     stage: 'dev',

--- a/source/dea-backend/src/constructs/dea-rest-api.ts
+++ b/source/dea-backend/src/constructs/dea-rest-api.ts
@@ -150,7 +150,12 @@ export class DeaRestApiConstruct extends Construct {
       }
 
       if (index === urlParts.length - 1) {
-        const lambda = this._createLambda(`${route.httpMethod}_${part}`, role, route.pathToSource, lambdaEnv);
+        const lambda = this._createLambda(
+          `${route.httpMethod}_${route.eventName}`,
+          role,
+          route.pathToSource,
+          lambdaEnv
+        );
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let queryParams: any = {};
@@ -186,6 +191,9 @@ export class DeaRestApiConstruct extends Construct {
           authorizationType: route.authMethod ?? AuthorizationType.IAM,
         });
 
+        if (method.methodArn.endsWith('*')) {
+          throw new Error('Resource paths must not end with a wildcard.');
+        }
         this.apiEndpointArns.set(route.path + route.httpMethod, method.methodArn);
       }
       parent = resource;

--- a/source/dea-backend/src/handlers/create-dea-handler.ts
+++ b/source/dea-backend/src/handlers/create-dea-handler.ts
@@ -114,14 +114,14 @@ const getInitialIdentity = (event: APIGatewayProxyEvent): ActorIdentity => {
     };
   }
 
-  if (event.resource === '/auth/getLoginUrl') {
+  if (event.resource === '/auth/loginUrl') {
     return {
       idType: IdentityType.LOGIN_URL_REQUESTOR,
       sourceIp: event.requestContext.identity.sourceIp,
     };
   }
 
-  if (event.resource === '/auth/getLogoutUrl') {
+  if (event.resource === '/auth/logoutUrl') {
     return {
       idType: IdentityType.LOGOUT_URL_REQUESTOR,
       sourceIp: event.requestContext.identity.sourceIp,

--- a/source/dea-backend/src/resources/dea-route-config.ts
+++ b/source/dea-backend/src/resources/dea-route-config.ts
@@ -31,19 +31,19 @@ export const deaApiRouteConfig: ApiGatewayRouteConfig = {
     },
     {
       eventName: AuditEventType.GET_CASE_DETAILS,
-      path: '/cases/{caseId}',
+      path: '/cases/{caseId}/details',
       httpMethod: ApiGatewayMethod.GET,
       pathToSource: '../../src/handlers/get-case-detail-handler.ts',
     },
     {
       eventName: AuditEventType.UPDATE_CASE_DETAILS,
-      path: '/cases/{caseId}',
+      path: '/cases/{caseId}/details',
       httpMethod: ApiGatewayMethod.PUT,
       pathToSource: '../../src/handlers/update-cases-handler.ts',
     },
     {
       eventName: AuditEventType.DELETE_CASE,
-      path: '/cases/{caseId}',
+      path: '/cases/{caseId}/details',
       httpMethod: ApiGatewayMethod.DELETE,
       pathToSource: '../../src/handlers/delete-case-handler.ts',
     },
@@ -61,13 +61,13 @@ export const deaApiRouteConfig: ApiGatewayRouteConfig = {
     },
     {
       eventName: AuditEventType.REMOVE_USER_FROM_CASE,
-      path: '/cases/{caseId}/userMemberships/{userId}',
+      path: '/cases/{caseId}/users/{userId}/memberships',
       httpMethod: ApiGatewayMethod.DELETE,
       pathToSource: '../../src/handlers/delete-case-user-handler.ts',
     },
     {
       eventName: AuditEventType.MODIFY_USER_PERMISSIONS_ON_CASE,
-      path: '/cases/{caseId}/userMemberships/{userId}',
+      path: '/cases/{caseId}/users/{userId}/memberships',
       httpMethod: ApiGatewayMethod.PUT,
       pathToSource: '../../src/handlers/update-case-user-handler.ts',
     },
@@ -85,13 +85,13 @@ export const deaApiRouteConfig: ApiGatewayRouteConfig = {
     },
     {
       eventName: AuditEventType.COMPLETE_CASE_FILE_UPLOAD,
-      path: '/cases/{caseId}/files/{fileId}',
+      path: '/cases/{caseId}/files/{fileId}/contents',
       httpMethod: ApiGatewayMethod.PUT,
       pathToSource: '../../src/handlers/complete-case-file-upload-handler.ts',
     },
     {
       eventName: AuditEventType.GET_CASE_FILE_DETAIL,
-      path: '/cases/{caseId}/files/{fileId}',
+      path: '/cases/{caseId}/files/{fileId}/details',
       httpMethod: ApiGatewayMethod.GET,
       pathToSource: '../../src/handlers/get-case-file-detail-handler.ts',
     },
@@ -103,7 +103,7 @@ export const deaApiRouteConfig: ApiGatewayRouteConfig = {
     },
     {
       eventName: AuditEventType.GET_AUTH_TOKEN,
-      path: '/auth/getToken/{authCode}',
+      path: '/auth/{authCode}/token',
       httpMethod: ApiGatewayMethod.POST,
       pathToSource: '../../src/handlers/get-token-handler.ts',
       // TODO: Implement custom authorizer for UI trying to access token exchange
@@ -113,7 +113,7 @@ export const deaApiRouteConfig: ApiGatewayRouteConfig = {
     },
     {
       eventName: AuditEventType.GET_LOGIN_URL,
-      path: '/auth/getLoginUrl',
+      path: '/auth/loginUrl',
       httpMethod: ApiGatewayMethod.GET,
       pathToSource: '../../src/handlers/get-login-url-handler.ts',
       // TODO: Implement custom authorizer for UI trying to access credentials
@@ -121,7 +121,7 @@ export const deaApiRouteConfig: ApiGatewayRouteConfig = {
     },
     {
       eventName: AuditEventType.GET_LOGOUT_URL,
-      path: '/auth/getLogoutUrl',
+      path: '/auth/logoutUrl',
       httpMethod: ApiGatewayMethod.GET,
       pathToSource: '../../src/handlers/get-logout-url-handler.ts',
       // TODO: Implement custom authorizer for UI trying to access credentials
@@ -129,7 +129,7 @@ export const deaApiRouteConfig: ApiGatewayRouteConfig = {
     },
     {
       eventName: AuditEventType.EXCHANGE_TOKEN_FOR_CREDS,
-      path: '/auth/getCredentials/{idToken}',
+      path: '/auth/credentials/{idToken}/exchange',
       httpMethod: ApiGatewayMethod.GET,
       pathToSource: '../../src/handlers/get-credentials-handler.ts',
       // TODO: Implement custom authorizer for UI trying to access credentials

--- a/source/dea-backend/src/test/handlers/audit-events.unit.test.ts
+++ b/source/dea-backend/src/test/handlers/audit-events.unit.test.ts
@@ -235,7 +235,7 @@ describe('dea lambda audits', () => {
 
     const theEvent = getDummyEvent();
     theEvent.requestContext.identity.cognitoIdentityId = null;
-    theEvent.resource = '/auth/getLoginUrl';
+    theEvent.resource = '/auth/loginUrl';
 
     const response = await sut(theEvent, dummyContext);
     expect(response).toEqual({ body: ':D', statusCode: 200 });
@@ -265,7 +265,7 @@ describe('dea lambda audits', () => {
 
     const theEvent = getDummyEvent();
     theEvent.requestContext.identity.cognitoIdentityId = null;
-    theEvent.resource = '/auth/getLogoutUrl';
+    theEvent.resource = '/auth/logoutUrl';
 
     const response = await sut(theEvent, dummyContext);
     expect(response).toEqual({ body: ':D', statusCode: 200 });

--- a/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
+++ b/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
@@ -774,7 +774,7 @@ Object {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "DeaRestApiConstructDELETEcaseIdE0E7560F": Object {
+    "DeaRestApiConstructDELETEDeleteCase9C8CBC88": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
         "DeaRestApiConstructdeabaselambdarole9EA2B06B",
@@ -833,7 +833,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructDELETEuserId97F2887D": Object {
+    "DeaRestApiConstructDELETERemoveUserFromCase315FE1CE": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
         "DeaRestApiConstructdeabaselambdarole9EA2B06B",
@@ -892,7 +892,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructGETallcases490E3EC5": Object {
+    "DeaRestApiConstructGETDownloadCaseFile04DF0D0C": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
         "DeaRestApiConstructdeabaselambdarole9EA2B06B",
@@ -951,243 +951,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructGETcaseId3B128BAD": Object {
-      "DependsOn": Array [
-        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
-        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
-      ],
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W58",
-              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
-            },
-            Object {
-              "id": "W92",
-              "reason": "Reserved concurrency is currently not required. Revisit in the future",
-            },
-            Object {
-              "id": "W89",
-              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "[HASH REMOVED].zip",
-        },
-        "Environment": Object {
-          "Variables": Object {
-            "AUDIT_LOG_GROUP_NAME": Object {
-              "Ref": "deaAuditLogs7B75D3F1",
-            },
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
-            "DATASETS_BUCKET_NAME": Object {
-              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
-            },
-            "NODE_OPTIONS": "--enable-source-maps",
-            "STAGE": "[STAGE-REMOVED]",
-            "TABLE_NAME": Object {
-              "Ref": "DeaBackendConstructDeaTableB48721A0",
-            },
-          },
-        },
-        "Handler": "index.handler",
-        "MemorySize": 512,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "DeaRestApiConstructGETcontents7698B1E0": Object {
-      "DependsOn": Array [
-        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
-        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
-      ],
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W58",
-              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
-            },
-            Object {
-              "id": "W92",
-              "reason": "Reserved concurrency is currently not required. Revisit in the future",
-            },
-            Object {
-              "id": "W89",
-              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "[HASH REMOVED].zip",
-        },
-        "Environment": Object {
-          "Variables": Object {
-            "AUDIT_LOG_GROUP_NAME": Object {
-              "Ref": "deaAuditLogs7B75D3F1",
-            },
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
-            "DATASETS_BUCKET_NAME": Object {
-              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
-            },
-            "NODE_OPTIONS": "--enable-source-maps",
-            "STAGE": "[STAGE-REMOVED]",
-            "TABLE_NAME": Object {
-              "Ref": "DeaBackendConstructDeaTableB48721A0",
-            },
-          },
-        },
-        "Handler": "index.handler",
-        "MemorySize": 512,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "DeaRestApiConstructGETfileIdADEC2A08": Object {
-      "DependsOn": Array [
-        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
-        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
-      ],
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W58",
-              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
-            },
-            Object {
-              "id": "W92",
-              "reason": "Reserved concurrency is currently not required. Revisit in the future",
-            },
-            Object {
-              "id": "W89",
-              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "[HASH REMOVED].zip",
-        },
-        "Environment": Object {
-          "Variables": Object {
-            "AUDIT_LOG_GROUP_NAME": Object {
-              "Ref": "deaAuditLogs7B75D3F1",
-            },
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
-            "DATASETS_BUCKET_NAME": Object {
-              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
-            },
-            "NODE_OPTIONS": "--enable-source-maps",
-            "STAGE": "[STAGE-REMOVED]",
-            "TABLE_NAME": Object {
-              "Ref": "DeaBackendConstructDeaTableB48721A0",
-            },
-          },
-        },
-        "Handler": "index.handler",
-        "MemorySize": 512,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "DeaRestApiConstructGETfiles2EFEBB64": Object {
-      "DependsOn": Array [
-        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
-        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
-      ],
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W58",
-              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
-            },
-            Object {
-              "id": "W92",
-              "reason": "Reserved concurrency is currently not required. Revisit in the future",
-            },
-            Object {
-              "id": "W89",
-              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "[HASH REMOVED].zip",
-        },
-        "Environment": Object {
-          "Variables": Object {
-            "AUDIT_LOG_GROUP_NAME": Object {
-              "Ref": "deaAuditLogs7B75D3F1",
-            },
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
-            "DATASETS_BUCKET_NAME": Object {
-              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
-            },
-            "NODE_OPTIONS": "--enable-source-maps",
-            "STAGE": "[STAGE-REMOVED]",
-            "TABLE_NAME": Object {
-              "Ref": "DeaBackendConstructDeaTableB48721A0",
-            },
-          },
-        },
-        "Handler": "index.handler",
-        "MemorySize": 512,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "DeaRestApiConstructGETgetLoginUrl3FEA95D9": Object {
+    "DeaRestApiConstructGETExchangeAuthTokenForCredentials6E69D669": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeaauthlambdaroleDefaultPolicy15F6BB8F",
         "DeaRestApiConstructdeaauthlambdarole2081E9E6",
@@ -1246,7 +1010,302 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructGETgetLogoutUrlB58CD35E": Object {
+    "DeaRestApiConstructGETGetAllCasesD64E9594": Object {
+      "DependsOn": Array [
+        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
+        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaRestApiConstructGETGetAllUsers77F79D7D": Object {
+      "DependsOn": Array [
+        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
+        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaRestApiConstructGETGetCaseDetails37F7FEA5": Object {
+      "DependsOn": Array [
+        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
+        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaRestApiConstructGETGetCaseFileDetailAC2C6003": Object {
+      "DependsOn": Array [
+        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
+        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaRestApiConstructGETGetCaseFilesB601FAF5": Object {
+      "DependsOn": Array [
+        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
+        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaRestApiConstructGETGetLoginUrlA95063AD": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeaauthlambdaroleDefaultPolicy15F6BB8F",
         "DeaRestApiConstructdeaauthlambdarole2081E9E6",
@@ -1305,7 +1364,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructGETidToken48065721": Object {
+    "DeaRestApiConstructGETGetLogoutUrl77EA9407": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeaauthlambdaroleDefaultPolicy15F6BB8F",
         "DeaRestApiConstructdeaauthlambdarole2081E9E6",
@@ -1364,7 +1423,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructGETmycasesF570E0D9": Object {
+    "DeaRestApiConstructGETGetMyCasesBB9194E7": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
         "DeaRestApiConstructdeabaselambdarole9EA2B06B",
@@ -1423,7 +1482,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructGETuserMemberships425EF4DF": Object {
+    "DeaRestApiConstructGETGetUsersFromCase05D0A5BE": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
         "DeaRestApiConstructdeabaselambdarole9EA2B06B",
@@ -1482,7 +1541,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructGETusersDD8AA5AF": Object {
+    "DeaRestApiConstructPOSTCreateCase203FC2B5": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
         "DeaRestApiConstructdeabaselambdarole9EA2B06B",
@@ -1541,7 +1600,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructPOSTauthCode8A1B1E18": Object {
+    "DeaRestApiConstructPOSTGetAuthenticationToken7831CF5E": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeaauthlambdaroleDefaultPolicy15F6BB8F",
         "DeaRestApiConstructdeaauthlambdarole2081E9E6",
@@ -1600,7 +1659,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructPOSTcases71FC396B": Object {
+    "DeaRestApiConstructPOSTInitiateCaseFileUpload4072CE29": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
         "DeaRestApiConstructdeabaselambdarole9EA2B06B",
@@ -1659,7 +1718,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructPOSTfilesD0E72419": Object {
+    "DeaRestApiConstructPOSTInviteUserToCaseE52152F4": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
         "DeaRestApiConstructdeabaselambdarole9EA2B06B",
@@ -1718,7 +1777,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructPOSTuserMembershipsA9A79B32": Object {
+    "DeaRestApiConstructPUTCompleteCaseFileUpload51639C21": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
         "DeaRestApiConstructdeabaselambdarole9EA2B06B",
@@ -1777,7 +1836,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructPUTcaseId804DFA77": Object {
+    "DeaRestApiConstructPUTModifyUserCasePermissions3887B3D5": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
         "DeaRestApiConstructdeabaselambdarole9EA2B06B",
@@ -1836,66 +1895,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaRestApiConstructPUTfileId8DA844F1": Object {
-      "DependsOn": Array [
-        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
-        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
-      ],
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W58",
-              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
-            },
-            Object {
-              "id": "W92",
-              "reason": "Reserved concurrency is currently not required. Revisit in the future",
-            },
-            Object {
-              "id": "W89",
-              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "[HASH REMOVED].zip",
-        },
-        "Environment": Object {
-          "Variables": Object {
-            "AUDIT_LOG_GROUP_NAME": Object {
-              "Ref": "deaAuditLogs7B75D3F1",
-            },
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
-            "DATASETS_BUCKET_NAME": Object {
-              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
-            },
-            "NODE_OPTIONS": "--enable-source-maps",
-            "STAGE": "[STAGE-REMOVED]",
-            "TABLE_NAME": Object {
-              "Ref": "DeaBackendConstructDeaTableB48721A0",
-            },
-          },
-        },
-        "Handler": "index.handler",
-        "MemorySize": 512,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "DeaRestApiConstructPUTuserId248180A2": Object {
+    "DeaRestApiConstructPUTUpdateCaseDetailsCAA16781": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
         "DeaRestApiConstructdeabaselambdarole9EA2B06B",
@@ -2036,50 +2036,60 @@ Object {
       },
       "Type": "AWS::ApiGateway::UsagePlan",
     },
-    "DeaRestApiConstructdeaapiDeploymentC27C6CB1bc8ca967e75064fa1cabb3d91eb4122b": Object {
+    "DeaRestApiConstructdeaapiDeploymentC27C6CB19c14345e062c8191b5ac1df8a8d19b95": Object {
       "DependsOn": Array [
-        "DeaRestApiConstructdeaapiauthgetCredentialsidTokenGETF30F6BC2",
-        "DeaRestApiConstructdeaapiauthgetCredentialsidTokenOPTIONSA66044D9",
-        "DeaRestApiConstructdeaapiauthgetCredentialsidToken81FDE330",
-        "DeaRestApiConstructdeaapiauthgetCredentialsOPTIONS6F2C55DF",
-        "DeaRestApiConstructdeaapiauthgetCredentials162DF0F2",
-        "DeaRestApiConstructdeaapiauthgetLoginUrlGET12D3D75B",
-        "DeaRestApiConstructdeaapiauthgetLoginUrlOPTIONS50BC7200",
-        "DeaRestApiConstructdeaapiauthgetLoginUrl3DD5B9A2",
-        "DeaRestApiConstructdeaapiauthgetLogoutUrlGET82C9D63F",
-        "DeaRestApiConstructdeaapiauthgetLogoutUrlOPTIONSC24D222C",
-        "DeaRestApiConstructdeaapiauthgetLogoutUrlEB8109B5",
-        "DeaRestApiConstructdeaapiauthgetTokenauthCodeOPTIONS7DF32090",
-        "DeaRestApiConstructdeaapiauthgetTokenauthCodePOST3DCF3F52",
-        "DeaRestApiConstructdeaapiauthgetTokenauthCode1D020E3A",
-        "DeaRestApiConstructdeaapiauthgetTokenOPTIONS914E22A0",
-        "DeaRestApiConstructdeaapiauthgetTokenF874EF26",
+        "DeaRestApiConstructdeaapiauthauthCodeOPTIONS886A6DD8",
+        "DeaRestApiConstructdeaapiauthauthCodeFF00F04A",
+        "DeaRestApiConstructdeaapiauthauthCodetokenOPTIONSE3AA1727",
+        "DeaRestApiConstructdeaapiauthauthCodetokenPOST81D6F43B",
+        "DeaRestApiConstructdeaapiauthauthCodetokenC94184D9",
+        "DeaRestApiConstructdeaapiauthcredentialsidTokenexchangeGETF349A14C",
+        "DeaRestApiConstructdeaapiauthcredentialsidTokenexchangeOPTIONSAF98F436",
+        "DeaRestApiConstructdeaapiauthcredentialsidTokenexchange60E243B6",
+        "DeaRestApiConstructdeaapiauthcredentialsidTokenOPTIONSC4B7B290",
+        "DeaRestApiConstructdeaapiauthcredentialsidTokenD84F85A8",
+        "DeaRestApiConstructdeaapiauthcredentialsOPTIONS3DC1232A",
+        "DeaRestApiConstructdeaapiauthcredentials42AAF7ED",
+        "DeaRestApiConstructdeaapiauthloginUrlGET4F783A6D",
+        "DeaRestApiConstructdeaapiauthloginUrlOPTIONSFCC225D0",
+        "DeaRestApiConstructdeaapiauthloginUrlA5F3FDDA",
+        "DeaRestApiConstructdeaapiauthlogoutUrlGETC563ACE3",
+        "DeaRestApiConstructdeaapiauthlogoutUrlOPTIONS3CD200C5",
+        "DeaRestApiConstructdeaapiauthlogoutUrlC5CCF412",
         "DeaRestApiConstructdeaapiauthOPTIONSF807407C",
         "DeaRestApiConstructdeaapiauthE4846931",
-        "DeaRestApiConstructdeaapicasescaseIdDELETEE13D0EAA",
+        "DeaRestApiConstructdeaapicasescaseIddetailsDELETED0F47C2D",
+        "DeaRestApiConstructdeaapicasescaseIddetailsGET0AC0D58C",
+        "DeaRestApiConstructdeaapicasescaseIddetailsOPTIONSA19CA131",
+        "DeaRestApiConstructdeaapicasescaseIddetailsPUT33A3214F",
+        "DeaRestApiConstructdeaapicasescaseIddetailsBD77A885",
         "DeaRestApiConstructdeaapicasescaseIdfilesfileIdcontentsGET4172E867",
         "DeaRestApiConstructdeaapicasescaseIdfilesfileIdcontentsOPTIONSC1A05A50",
+        "DeaRestApiConstructdeaapicasescaseIdfilesfileIdcontentsPUTF371EF84",
         "DeaRestApiConstructdeaapicasescaseIdfilesfileIdcontentsDFF6E865",
-        "DeaRestApiConstructdeaapicasescaseIdfilesfileIdGET842C28D2",
+        "DeaRestApiConstructdeaapicasescaseIdfilesfileIddetailsGET9D8798CC",
+        "DeaRestApiConstructdeaapicasescaseIdfilesfileIddetailsOPTIONSEAFA766D",
+        "DeaRestApiConstructdeaapicasescaseIdfilesfileIddetails51AD2E55",
         "DeaRestApiConstructdeaapicasescaseIdfilesfileIdOPTIONS0739484E",
-        "DeaRestApiConstructdeaapicasescaseIdfilesfileIdPUTDD763A2A",
         "DeaRestApiConstructdeaapicasescaseIdfilesfileId71AE0C3F",
         "DeaRestApiConstructdeaapicasescaseIdfilesGETB7EECD96",
         "DeaRestApiConstructdeaapicasescaseIdfilesOPTIONS18C09E02",
         "DeaRestApiConstructdeaapicasescaseIdfilesPOST6C02B6FD",
         "DeaRestApiConstructdeaapicasescaseIdfilesC98413A7",
-        "DeaRestApiConstructdeaapicasescaseIdGET31A0ADCB",
         "DeaRestApiConstructdeaapicasescaseIdOPTIONS28A51954",
-        "DeaRestApiConstructdeaapicasescaseIdPUTDAF01FBF",
         "DeaRestApiConstructdeaapicasescaseId5919A5AE",
-        "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserIdDELETE5C89D30D",
-        "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserIdOPTIONS2A768A43",
-        "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserIdPUTC33F61E0",
-        "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserId13BB910A",
         "DeaRestApiConstructdeaapicasescaseIduserMembershipsGETC6D66454",
         "DeaRestApiConstructdeaapicasescaseIduserMembershipsOPTIONS8FB7464B",
         "DeaRestApiConstructdeaapicasescaseIduserMembershipsPOST84A13ED4",
         "DeaRestApiConstructdeaapicasescaseIduserMembershipsD5C1FDF3",
+        "DeaRestApiConstructdeaapicasescaseIdusersuserIdmembershipsDELETE66E50CD4",
+        "DeaRestApiConstructdeaapicasescaseIdusersuserIdmembershipsOPTIONS925E45CE",
+        "DeaRestApiConstructdeaapicasescaseIdusersuserIdmembershipsPUT67F6E361",
+        "DeaRestApiConstructdeaapicasescaseIdusersuserIdmemberships2E2BE7E6",
+        "DeaRestApiConstructdeaapicasescaseIdusersuserIdOPTIONS15B78F29",
+        "DeaRestApiConstructdeaapicasescaseIdusersuserId4ECBA1E2",
+        "DeaRestApiConstructdeaapicasescaseIdusersOPTIONS61C453FB",
+        "DeaRestApiConstructdeaapicasescaseIdusers13CDB0B7",
         "DeaRestApiConstructdeaapicasesallcasesGET3D7FE7B4",
         "DeaRestApiConstructdeaapicasesallcasesOPTIONSA5C611C6",
         "DeaRestApiConstructdeaapicasesallcases5A486593",
@@ -2117,7 +2127,7 @@ Object {
           "Format": "{\\"stage\\":\\"$context.stage\\",\\"requestId\\":\\"$context.requestId\\",\\"integrationRequestId\\":\\"$context.integration.requestId\\",\\"status\\":\\"$context.status\\",\\"apiId\\":\\"$context.apiId\\",\\"resourcePath\\":\\"$context.resourcePath\\",\\"path\\":\\"$context.path\\",\\"resourceId\\":\\"$context.resourceId\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"userAgent\\":\\"$context.identity.userAgent\\"}",
         },
         "DeploymentId": Object {
-          "Ref": "DeaRestApiConstructdeaapiDeploymentC27C6CB1bc8ca967e75064fa1cabb3d91eb4122b",
+          "Ref": "DeaRestApiConstructdeaapiDeploymentC27C6CB19c14345e062c8191b5ac1df8a8d19b95",
         },
         "RestApiId": Object {
           "Ref": "DeaRestApiConstructdeaapi6587DDA1",
@@ -2226,629 +2236,10 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "DeaRestApiConstructdeaapiauthgetCredentials162DF0F2": Object {
+    "DeaRestApiConstructdeaapiauthauthCodeFF00F04A": Object {
       "Properties": Object {
         "ParentId": Object {
           "Ref": "DeaRestApiConstructdeaapiauthE4846931",
-        },
-        "PathPart": "getCredentials",
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "DeaRestApiConstructdeaapiauthgetCredentialsOPTIONS6F2C55DF": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": Object {
-          "IntegrationResponses": Array [
-            Object {
-              "ResponseParameters": Object {
-                "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": Object {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": Array [
-          Object {
-            "ResponseParameters": Object {
-              "method.response.header.Access-Control-Allow-Credentials": true,
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetCredentials162DF0F2",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapiauthgetCredentialsidToken81FDE330": Object {
-      "Properties": Object {
-        "ParentId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetCredentials162DF0F2",
-        },
-        "PathPart": "{idToken}",
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "DeaRestApiConstructdeaapiauthgetCredentialsidTokenGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETauthgetCredentialsidTokenC2CFE426": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETidToken48065721",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/test-invoke-stage/GET/auth/getCredentials/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapiauthgetCredentialsidTokenGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETauthgetCredentialsidTokenADD4B7DF": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETidToken48065721",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/GET/auth/getCredentials/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapiauthgetCredentialsidTokenGETF30F6BC2": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaRestApiConstructGETidToken48065721",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetCredentialsidToken81FDE330",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapiauthgetCredentialsidTokenOPTIONSA66044D9": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": Object {
-          "IntegrationResponses": Array [
-            Object {
-              "ResponseParameters": Object {
-                "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": Object {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": Array [
-          Object {
-            "ResponseParameters": Object {
-              "method.response.header.Access-Control-Allow-Credentials": true,
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetCredentialsidToken81FDE330",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapiauthgetLoginUrl3DD5B9A2": Object {
-      "Properties": Object {
-        "ParentId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthE4846931",
-        },
-        "PathPart": "getLoginUrl",
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "DeaRestApiConstructdeaapiauthgetLoginUrlGET12D3D75B": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaRestApiConstructGETgetLoginUrl3FEA95D9",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetLoginUrl3DD5B9A2",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapiauthgetLoginUrlGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETauthgetLoginUrl595F2B82": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETgetLoginUrl3FEA95D9",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/test-invoke-stage/GET/auth/getLoginUrl",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapiauthgetLoginUrlGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETauthgetLoginUrl663B0B08": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETgetLoginUrl3FEA95D9",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/GET/auth/getLoginUrl",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapiauthgetLoginUrlOPTIONS50BC7200": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": Object {
-          "IntegrationResponses": Array [
-            Object {
-              "ResponseParameters": Object {
-                "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": Object {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": Array [
-          Object {
-            "ResponseParameters": Object {
-              "method.response.header.Access-Control-Allow-Credentials": true,
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetLoginUrl3DD5B9A2",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapiauthgetLogoutUrlEB8109B5": Object {
-      "Properties": Object {
-        "ParentId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthE4846931",
-        },
-        "PathPart": "getLogoutUrl",
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "DeaRestApiConstructdeaapiauthgetLogoutUrlGET82C9D63F": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaRestApiConstructGETgetLogoutUrlB58CD35E",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetLogoutUrlEB8109B5",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapiauthgetLogoutUrlGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETauthgetLogoutUrl4626D7C0": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETgetLogoutUrlB58CD35E",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/test-invoke-stage/GET/auth/getLogoutUrl",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapiauthgetLogoutUrlGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETauthgetLogoutUrl4D806A20": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETgetLogoutUrlB58CD35E",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/GET/auth/getLogoutUrl",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapiauthgetLogoutUrlOPTIONSC24D222C": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": Object {
-          "IntegrationResponses": Array [
-            Object {
-              "ResponseParameters": Object {
-                "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": Object {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": Array [
-          Object {
-            "ResponseParameters": Object {
-              "method.response.header.Access-Control-Allow-Credentials": true,
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetLogoutUrlEB8109B5",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapiauthgetTokenF874EF26": Object {
-      "Properties": Object {
-        "ParentId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthE4846931",
-        },
-        "PathPart": "getToken",
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "DeaRestApiConstructdeaapiauthgetTokenOPTIONS914E22A0": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": Object {
-          "IntegrationResponses": Array [
-            Object {
-              "ResponseParameters": Object {
-                "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": Object {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": Array [
-          Object {
-            "ResponseParameters": Object {
-              "method.response.header.Access-Control-Allow-Credentials": true,
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetTokenF874EF26",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapiauthgetTokenauthCode1D020E3A": Object {
-      "Properties": Object {
-        "ParentId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetTokenF874EF26",
         },
         "PathPart": "{authCode}",
         "RestApiId": Object {
@@ -2857,7 +2248,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "DeaRestApiConstructdeaapiauthgetTokenauthCodeOPTIONS7DF32090": Object {
+    "DeaRestApiConstructdeaapiauthauthCodeOPTIONS886A6DD8": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
         "HttpMethod": "OPTIONS",
@@ -2890,7 +2281,7 @@ Object {
           },
         ],
         "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetTokenauthCode1D020E3A",
+          "Ref": "DeaRestApiConstructdeaapiauthauthCodeFF00F04A",
         },
         "RestApiId": Object {
           "Ref": "DeaRestApiConstructdeaapi6587DDA1",
@@ -2898,7 +2289,60 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "DeaRestApiConstructdeaapiauthgetTokenauthCodePOST3DCF3F52": Object {
+    "DeaRestApiConstructdeaapiauthauthCodetokenC94184D9": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthauthCodeFF00F04A",
+        },
+        "PathPart": "token",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapiauthauthCodetokenOPTIONSE3AA1727": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthauthCodetokenC94184D9",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiauthauthCodetokenPOST81D6F43B": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
         "HttpMethod": "POST",
@@ -2920,7 +2364,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructPOSTauthCode8A1B1E18",
+                    "DeaRestApiConstructPOSTGetAuthenticationToken7831CF5E",
                     "Arn",
                   ],
                 },
@@ -2930,7 +2374,7 @@ Object {
           },
         },
         "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapiauthgetTokenauthCode1D020E3A",
+          "Ref": "DeaRestApiConstructdeaapiauthauthCodetokenC94184D9",
         },
         "RestApiId": Object {
           "Ref": "DeaRestApiConstructdeaapi6587DDA1",
@@ -2938,12 +2382,12 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "DeaRestApiConstructdeaapiauthgetTokenauthCodePOSTApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4POSTauthgetTokenauthCodeACE7580F": Object {
+    "DeaRestApiConstructdeaapiauthauthCodetokenPOSTApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4POSTauthauthCodetokenA42BE3E6": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPOSTauthCode8A1B1E18",
+            "DeaRestApiConstructPOSTGetAuthenticationToken7831CF5E",
             "Arn",
           ],
         },
@@ -2968,19 +2412,19 @@ Object {
               Object {
                 "Ref": "DeaRestApiConstructdeaapi6587DDA1",
               },
-              "/test-invoke-stage/POST/auth/getToken/*",
+              "/test-invoke-stage/POST/auth/*/token",
             ],
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "DeaRestApiConstructdeaapiauthgetTokenauthCodePOSTApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4POSTauthgetTokenauthCode64CC0A48": Object {
+    "DeaRestApiConstructdeaapiauthauthCodetokenPOSTApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4POSTauthauthCodetokenE48A5552": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPOSTauthCode8A1B1E18",
+            "DeaRestApiConstructPOSTGetAuthenticationToken7831CF5E",
             "Arn",
           ],
         },
@@ -3009,12 +2453,631 @@ Object {
               Object {
                 "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
               },
-              "/POST/auth/getToken/*",
+              "/POST/auth/*/token",
             ],
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapiauthcredentials42AAF7ED": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthE4846931",
+        },
+        "PathPart": "credentials",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapiauthcredentialsOPTIONS3DC1232A": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthcredentials42AAF7ED",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiauthcredentialsidTokenD84F85A8": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthcredentials42AAF7ED",
+        },
+        "PathPart": "{idToken}",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapiauthcredentialsidTokenOPTIONSC4B7B290": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthcredentialsidTokenD84F85A8",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiauthcredentialsidTokenexchange60E243B6": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthcredentialsidTokenD84F85A8",
+        },
+        "PathPart": "exchange",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapiauthcredentialsidTokenexchangeGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETauthcredentialsidTokenexchange4BABF834": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETExchangeAuthTokenForCredentials6E69D669",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/GET/auth/credentials/*/exchange",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapiauthcredentialsidTokenexchangeGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETauthcredentialsidTokenexchangeD4321ED1": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETExchangeAuthTokenForCredentials6E69D669",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/auth/credentials/*/exchange",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapiauthcredentialsidTokenexchangeGETF349A14C": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructGETExchangeAuthTokenForCredentials6E69D669",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthcredentialsidTokenexchange60E243B6",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiauthcredentialsidTokenexchangeOPTIONSAF98F436": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthcredentialsidTokenexchange60E243B6",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiauthloginUrlA5F3FDDA": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthE4846931",
+        },
+        "PathPart": "loginUrl",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapiauthloginUrlGET4F783A6D": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructGETGetLoginUrlA95063AD",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthloginUrlA5F3FDDA",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiauthloginUrlGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETauthloginUrl21F61114": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetLoginUrlA95063AD",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/GET/auth/loginUrl",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapiauthloginUrlGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETauthloginUrl306C3EFF": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetLoginUrlA95063AD",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/auth/loginUrl",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapiauthloginUrlOPTIONSFCC225D0": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthloginUrlA5F3FDDA",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiauthlogoutUrlC5CCF412": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthE4846931",
+        },
+        "PathPart": "logoutUrl",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapiauthlogoutUrlGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETauthlogoutUrlF8A5551B": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetLogoutUrl77EA9407",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/GET/auth/logoutUrl",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapiauthlogoutUrlGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETauthlogoutUrl42120548": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetLogoutUrl77EA9407",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/auth/logoutUrl",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapiauthlogoutUrlGETC563ACE3": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructGETGetLogoutUrl77EA9407",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthlogoutUrlC5CCF412",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiauthlogoutUrlOPTIONS3CD200C5": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiauthlogoutUrlC5CCF412",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
     },
     "DeaRestApiConstructdeaapicasesC2FD1C2B": Object {
       "Properties": Object {
@@ -3094,7 +3157,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructPOSTcases71FC396B",
+                    "DeaRestApiConstructPOSTCreateCase203FC2B5",
                     "Arn",
                   ],
                 },
@@ -3117,7 +3180,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPOSTcases71FC396B",
+            "DeaRestApiConstructPOSTCreateCase203FC2B5",
             "Arn",
           ],
         },
@@ -3154,7 +3217,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPOSTcases71FC396B",
+            "DeaRestApiConstructPOSTCreateCase203FC2B5",
             "Arn",
           ],
         },
@@ -3228,7 +3291,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructGETallcases490E3EC5",
+                    "DeaRestApiConstructGETGetAllCasesD64E9594",
                     "Arn",
                   ],
                 },
@@ -3255,7 +3318,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETallcases490E3EC5",
+            "DeaRestApiConstructGETGetAllCasesD64E9594",
             "Arn",
           ],
         },
@@ -3292,7 +3355,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETallcases490E3EC5",
+            "DeaRestApiConstructGETGetAllCasesD64E9594",
             "Arn",
           ],
         },
@@ -3381,242 +3444,6 @@ Object {
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "DeaRestApiConstructdeaapicasescaseIdDELETEApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4DELETEcasescaseIdF0BFC230": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructDELETEcaseIdE0E7560F",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/test-invoke-stage/DELETE/cases/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapicasescaseIdDELETEApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4DELETEcasescaseId683887F7": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructDELETEcaseIdE0E7560F",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/DELETE/cases/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapicasescaseIdDELETEE13D0EAA": Object {
-      "Properties": Object {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "DELETE",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaRestApiConstructDELETEcaseIdE0E7560F",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapicasescaseId5919A5AE",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapicasescaseIdGET31A0ADCB": Object {
-      "Properties": Object {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "GET",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaRestApiConstructGETcaseId3B128BAD",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapicasescaseId5919A5AE",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapicasescaseIdGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETcasescaseId9EC4CD2A": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETcaseId3B128BAD",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/test-invoke-stage/GET/cases/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapicasescaseIdGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETcasescaseId3A6CC8C8": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETcaseId3B128BAD",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/GET/cases/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
     "DeaRestApiConstructdeaapicasescaseIdOPTIONS28A51954": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
@@ -3658,12 +3485,24 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "DeaRestApiConstructdeaapicasescaseIdPUTApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseId37A77CC0": Object {
+    "DeaRestApiConstructdeaapicasescaseIddetailsBD77A885": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseId5919A5AE",
+        },
+        "PathPart": "details",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapicasescaseIddetailsDELETEApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4DELETEcasescaseIddetails918BFC1A": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPUTcaseId804DFA77",
+            "DeaRestApiConstructDELETEDeleteCase9C8CBC88",
             "Arn",
           ],
         },
@@ -3688,19 +3527,19 @@ Object {
               Object {
                 "Ref": "DeaRestApiConstructdeaapi6587DDA1",
               },
-              "/test-invoke-stage/PUT/cases/*",
+              "/test-invoke-stage/DELETE/cases/*/details",
             ],
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "DeaRestApiConstructdeaapicasescaseIdPUTApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseId6D37C013": Object {
+    "DeaRestApiConstructdeaapicasescaseIddetailsDELETEApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4DELETEcasescaseIddetails2FC44B5A": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPUTcaseId804DFA77",
+            "DeaRestApiConstructDELETEDeleteCase9C8CBC88",
             "Arn",
           ],
         },
@@ -3729,14 +3568,213 @@ Object {
               Object {
                 "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
               },
-              "/PUT/cases/*",
+              "/DELETE/cases/*/details",
             ],
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "DeaRestApiConstructdeaapicasescaseIdPUTDAF01FBF": Object {
+    "DeaRestApiConstructdeaapicasescaseIddetailsDELETED0F47C2D": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "DELETE",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructDELETEDeleteCase9C8CBC88",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIddetailsBD77A885",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapicasescaseIddetailsGET0AC0D58C": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructGETGetCaseDetails37F7FEA5",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIddetailsBD77A885",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapicasescaseIddetailsGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETcasescaseIddetails7EEFD469": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetCaseDetails37F7FEA5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/GET/cases/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapicasescaseIddetailsGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETcasescaseIddetails44CA90D4": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetCaseDetails37F7FEA5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/cases/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapicasescaseIddetailsOPTIONSA19CA131": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIddetailsBD77A885",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapicasescaseIddetailsPUT33A3214F": Object {
       "Properties": Object {
         "AuthorizationType": "AWS_IAM",
         "HttpMethod": "PUT",
@@ -3758,7 +3796,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructPUTcaseId804DFA77",
+                    "DeaRestApiConstructPUTUpdateCaseDetailsCAA16781",
                     "Arn",
                   ],
                 },
@@ -3768,13 +3806,91 @@ Object {
           },
         },
         "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapicasescaseId5919A5AE",
+          "Ref": "DeaRestApiConstructdeaapicasescaseIddetailsBD77A885",
         },
         "RestApiId": Object {
           "Ref": "DeaRestApiConstructdeaapi6587DDA1",
         },
       },
       "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapicasescaseIddetailsPUTApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseIddetailsD3729DE8": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructPUTUpdateCaseDetailsCAA16781",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/PUT/cases/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapicasescaseIddetailsPUTApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseIddetails7B2B7A41": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructPUTUpdateCaseDetailsCAA16781",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/PUT/cases/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "DeaRestApiConstructdeaapicasescaseIdfilesC98413A7": Object {
       "Properties": Object {
@@ -3793,7 +3909,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETfiles2EFEBB64",
+            "DeaRestApiConstructGETGetCaseFilesB601FAF5",
             "Arn",
           ],
         },
@@ -3830,7 +3946,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETfiles2EFEBB64",
+            "DeaRestApiConstructGETGetCaseFilesB601FAF5",
             "Arn",
           ],
         },
@@ -3888,7 +4004,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructGETfiles2EFEBB64",
+                    "DeaRestApiConstructGETGetCaseFilesB601FAF5",
                     "Arn",
                   ],
                 },
@@ -3969,7 +4085,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructPOSTfilesD0E72419",
+                    "DeaRestApiConstructPOSTInitiateCaseFileUpload4072CE29",
                     "Arn",
                   ],
                 },
@@ -3992,7 +4108,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPOSTfilesD0E72419",
+            "DeaRestApiConstructPOSTInitiateCaseFileUpload4072CE29",
             "Arn",
           ],
         },
@@ -4029,7 +4145,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPOSTfilesD0E72419",
+            "DeaRestApiConstructPOSTInitiateCaseFileUpload4072CE29",
             "Arn",
           ],
         },
@@ -4077,124 +4193,6 @@ Object {
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "DeaRestApiConstructdeaapicasescaseIdfilesfileIdGET842C28D2": Object {
-      "Properties": Object {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "GET",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaRestApiConstructGETfileIdADEC2A08",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapicasescaseIdfilesfileId71AE0C3F",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapicasescaseIdfilesfileIdGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETcasescaseIdfilesfileIdF9FD920E": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETfileIdADEC2A08",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/test-invoke-stage/GET/cases/*/files/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapicasescaseIdfilesfileIdGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETcasescaseIdfilesfileIdF45F0559": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETfileIdADEC2A08",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/GET/cases/*/files/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
     "DeaRestApiConstructdeaapicasescaseIdfilesfileIdOPTIONS0739484E": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
@@ -4227,124 +4225,6 @@ Object {
             "StatusCode": "204",
           },
         ],
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapicasescaseIdfilesfileId71AE0C3F",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapicasescaseIdfilesfileIdPUTApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseIdfilesfileIdE52AC54F": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructPUTfileId8DA844F1",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/test-invoke-stage/PUT/cases/*/files/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapicasescaseIdfilesfileIdPUTApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseIdfilesfileId670DC465": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructPUTfileId8DA844F1",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/PUT/cases/*/files/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapicasescaseIdfilesfileIdPUTDD763A2A": Object {
-      "Properties": Object {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "PUT",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaRestApiConstructPUTfileId8DA844F1",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
         "ResourceId": Object {
           "Ref": "DeaRestApiConstructdeaapicasescaseIdfilesfileId71AE0C3F",
         },
@@ -4388,7 +4268,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructGETcontents7698B1E0",
+                    "DeaRestApiConstructGETDownloadCaseFile04DF0D0C",
                     "Arn",
                   ],
                 },
@@ -4411,7 +4291,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETcontents7698B1E0",
+            "DeaRestApiConstructGETDownloadCaseFile04DF0D0C",
             "Arn",
           ],
         },
@@ -4448,7 +4328,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETcontents7698B1E0",
+            "DeaRestApiConstructGETDownloadCaseFile04DF0D0C",
             "Arn",
           ],
         },
@@ -4525,6 +4405,295 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
+    "DeaRestApiConstructdeaapicasescaseIdfilesfileIdcontentsPUTApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseIdfilesfileIdcontents638F2797": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructPUTCompleteCaseFileUpload51639C21",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/PUT/cases/*/files/*/contents",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdfilesfileIdcontentsPUTApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseIdfilesfileIdcontentsC77F4949": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructPUTCompleteCaseFileUpload51639C21",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/PUT/cases/*/files/*/contents",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdfilesfileIdcontentsPUTF371EF84": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "PUT",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructPUTCompleteCaseFileUpload51639C21",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIdfilesfileIdcontentsDFF6E865",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdfilesfileIddetails51AD2E55": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIdfilesfileId71AE0C3F",
+        },
+        "PathPart": "details",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdfilesfileIddetailsGET9D8798CC": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructGETGetCaseFileDetailAC2C6003",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIdfilesfileIddetails51AD2E55",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdfilesfileIddetailsGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETcasescaseIdfilesfileIddetailsE200023B": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetCaseFileDetailAC2C6003",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/GET/cases/*/files/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdfilesfileIddetailsGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETcasescaseIdfilesfileIddetails0DD1BE73": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetCaseFileDetailAC2C6003",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/cases/*/files/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdfilesfileIddetailsOPTIONSEAFA766D": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIdfilesfileIddetails51AD2E55",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
     "DeaRestApiConstructdeaapicasescaseIduserMembershipsD5C1FDF3": Object {
       "Properties": Object {
         "ParentId": Object {
@@ -4542,7 +4711,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETuserMemberships425EF4DF",
+            "DeaRestApiConstructGETGetUsersFromCase05D0A5BE",
             "Arn",
           ],
         },
@@ -4579,7 +4748,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETuserMemberships425EF4DF",
+            "DeaRestApiConstructGETGetUsersFromCase05D0A5BE",
             "Arn",
           ],
         },
@@ -4637,7 +4806,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructGETuserMemberships425EF4DF",
+                    "DeaRestApiConstructGETGetUsersFromCase05D0A5BE",
                     "Arn",
                   ],
                 },
@@ -4718,7 +4887,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructPOSTuserMembershipsA9A79B32",
+                    "DeaRestApiConstructPOSTInviteUserToCaseE52152F4",
                     "Arn",
                   ],
                 },
@@ -4741,7 +4910,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPOSTuserMembershipsA9A79B32",
+            "DeaRestApiConstructPOSTInviteUserToCaseE52152F4",
             "Arn",
           ],
         },
@@ -4778,7 +4947,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPOSTuserMembershipsA9A79B32",
+            "DeaRestApiConstructPOSTInviteUserToCaseE52152F4",
             "Arn",
           ],
         },
@@ -4814,137 +4983,19 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserId13BB910A": Object {
+    "DeaRestApiConstructdeaapicasescaseIdusers13CDB0B7": Object {
       "Properties": Object {
         "ParentId": Object {
-          "Ref": "DeaRestApiConstructdeaapicasescaseIduserMembershipsD5C1FDF3",
+          "Ref": "DeaRestApiConstructdeaapicasescaseId5919A5AE",
         },
-        "PathPart": "{userId}",
+        "PathPart": "users",
         "RestApiId": Object {
           "Ref": "DeaRestApiConstructdeaapi6587DDA1",
         },
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserIdDELETE5C89D30D": Object {
-      "Properties": Object {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "DELETE",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaRestApiConstructDELETEuserId97F2887D",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserId13BB910A",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserIdDELETEApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4DELETEcasescaseIduserMembershipsuserId309358C9": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructDELETEuserId97F2887D",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/test-invoke-stage/DELETE/cases/*/userMemberships/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserIdDELETEApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4DELETEcasescaseIduserMembershipsuserId4DEF5A06": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaRestApiConstructDELETEuserId97F2887D",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
-              },
-              "/",
-              Object {
-                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/DELETE/cases/*/userMemberships/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserIdOPTIONS2A768A43": Object {
+    "DeaRestApiConstructdeaapicasescaseIdusersOPTIONS61C453FB": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
         "HttpMethod": "OPTIONS",
@@ -4977,7 +5028,7 @@ Object {
           },
         ],
         "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserId13BB910A",
+          "Ref": "DeaRestApiConstructdeaapicasescaseIdusers13CDB0B7",
         },
         "RestApiId": Object {
           "Ref": "DeaRestApiConstructdeaapi6587DDA1",
@@ -4985,12 +5036,117 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserIdPUTApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseIduserMembershipsuserIdE325F9CF": Object {
+    "DeaRestApiConstructdeaapicasescaseIdusersuserId4ECBA1E2": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIdusers13CDB0B7",
+        },
+        "PathPart": "{userId}",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdusersuserIdOPTIONS15B78F29": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIdusersuserId4ECBA1E2",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdusersuserIdmemberships2E2BE7E6": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIdusersuserId4ECBA1E2",
+        },
+        "PathPart": "memberships",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdusersuserIdmembershipsDELETE66E50CD4": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "DELETE",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructDELETERemoveUserFromCase315FE1CE",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIdusersuserIdmemberships2E2BE7E6",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdusersuserIdmembershipsDELETEApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4DELETEcasescaseIdusersuserIdmemberships7FD5F1FA": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPUTuserId248180A2",
+            "DeaRestApiConstructDELETERemoveUserFromCase315FE1CE",
             "Arn",
           ],
         },
@@ -5015,19 +5171,19 @@ Object {
               Object {
                 "Ref": "DeaRestApiConstructdeaapi6587DDA1",
               },
-              "/test-invoke-stage/PUT/cases/*/userMemberships/*",
+              "/test-invoke-stage/DELETE/cases/*/users/*/memberships",
             ],
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserIdPUTApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseIduserMembershipsuserId1CD72580": Object {
+    "DeaRestApiConstructdeaapicasescaseIdusersuserIdmembershipsDELETEApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4DELETEcasescaseIdusersuserIdmemberships94BCD26D": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructPUTuserId248180A2",
+            "DeaRestApiConstructDELETERemoveUserFromCase315FE1CE",
             "Arn",
           ],
         },
@@ -5056,14 +5212,55 @@ Object {
               Object {
                 "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
               },
-              "/PUT/cases/*/userMemberships/*",
+              "/DELETE/cases/*/users/*/memberships",
             ],
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserIdPUTC33F61E0": Object {
+    "DeaRestApiConstructdeaapicasescaseIdusersuserIdmembershipsOPTIONS925E45CE": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapicasescaseIdusersuserIdmemberships2E2BE7E6",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdusersuserIdmembershipsPUT67F6E361": Object {
       "Properties": Object {
         "AuthorizationType": "AWS_IAM",
         "HttpMethod": "PUT",
@@ -5085,7 +5282,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructPUTuserId248180A2",
+                    "DeaRestApiConstructPUTModifyUserCasePermissions3887B3D5",
                     "Arn",
                   ],
                 },
@@ -5095,13 +5292,91 @@ Object {
           },
         },
         "ResourceId": Object {
-          "Ref": "DeaRestApiConstructdeaapicasescaseIduserMembershipsuserId13BB910A",
+          "Ref": "DeaRestApiConstructdeaapicasescaseIdusersuserIdmemberships2E2BE7E6",
         },
         "RestApiId": Object {
           "Ref": "DeaRestApiConstructdeaapi6587DDA1",
         },
       },
       "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdusersuserIdmembershipsPUTApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseIdusersuserIdmemberships4134D8D9": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructPUTModifyUserCasePermissions3887B3D5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/PUT/cases/*/users/*/memberships",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapicasescaseIdusersuserIdmembershipsPUTApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4PUTcasescaseIdusersuserIdmemberships748F3883": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructPUTModifyUserCasePermissions3887B3D5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/PUT/cases/*/users/*/memberships",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "DeaRestApiConstructdeaapicasesmycases5E6BEFAC": Object {
       "Properties": Object {
@@ -5120,7 +5395,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETmycasesF570E0D9",
+            "DeaRestApiConstructGETGetMyCasesBB9194E7",
             "Arn",
           ],
         },
@@ -5157,7 +5432,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETmycasesF570E0D9",
+            "DeaRestApiConstructGETGetMyCasesBB9194E7",
             "Arn",
           ],
         },
@@ -5219,7 +5494,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructGETmycasesF570E0D9",
+                    "DeaRestApiConstructGETGetMyCasesBB9194E7",
                     "Arn",
                   ],
                 },
@@ -5322,7 +5597,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaRestApiConstructGETusersDD8AA5AF",
+                    "DeaRestApiConstructGETGetAllUsers77F79D7D",
                     "Arn",
                   ],
                 },
@@ -5348,7 +5623,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETusersDD8AA5AF",
+            "DeaRestApiConstructGETGetAllUsers77F79D7D",
             "Arn",
           ],
         },
@@ -5385,7 +5660,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaRestApiConstructGETusersDD8AA5AF",
+            "DeaRestApiConstructGETGetAllUsers77F79D7D",
             "Arn",
           ],
         },

--- a/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
+++ b/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
@@ -76,7 +76,7 @@ describe('DeaBackend constructs', () => {
 
     //handlers
     const expectedLambdaCount = 21;
-    const expectedMethodCount = 38;
+    const expectedMethodCount = 43;
     template.resourceCountIs('AWS::Lambda::Function', expectedLambdaCount);
     template.resourceCountIs('AWS::ApiGateway::Method', expectedMethodCount);
 

--- a/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
+++ b/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
@@ -391,7 +391,7 @@ Object {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "DeaApiGatewayDELETEcaseId8BA29E4C": Object {
+    "DeaApiGatewayDELETEDeleteCase91CB5F89": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
         "DeaApiGatewaydeabaselambdarole91512884",
@@ -450,7 +450,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayDELETEuserId62E08A5C": Object {
+    "DeaApiGatewayDELETERemoveUserFromCaseD22CC76C": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
         "DeaApiGatewaydeabaselambdarole91512884",
@@ -509,7 +509,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayGETallcasesF6A8BE63": Object {
+    "DeaApiGatewayGETDownloadCaseFile32575192": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
         "DeaApiGatewaydeabaselambdarole91512884",
@@ -568,243 +568,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayGETcaseIdACE0459E": Object {
-      "DependsOn": Array [
-        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
-        "DeaApiGatewaydeabaselambdarole91512884",
-      ],
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W58",
-              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
-            },
-            Object {
-              "id": "W92",
-              "reason": "Reserved concurrency is currently not required. Revisit in the future",
-            },
-            Object {
-              "id": "W89",
-              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "[HASH REMOVED].zip",
-        },
-        "Environment": Object {
-          "Variables": Object {
-            "AUDIT_LOG_GROUP_NAME": Object {
-              "Ref": "deaAuditLogs7B75D3F1",
-            },
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
-            "DATASETS_BUCKET_NAME": Object {
-              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
-            },
-            "NODE_OPTIONS": "--enable-source-maps",
-            "STAGE": "[STAGE-REMOVED]",
-            "TABLE_NAME": Object {
-              "Ref": "DeaBackendStackDeaTableE9FE4A05",
-            },
-          },
-        },
-        "Handler": "index.handler",
-        "MemorySize": 512,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewaydeabaselambdarole91512884",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "DeaApiGatewayGETcontentsF4247FB2": Object {
-      "DependsOn": Array [
-        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
-        "DeaApiGatewaydeabaselambdarole91512884",
-      ],
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W58",
-              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
-            },
-            Object {
-              "id": "W92",
-              "reason": "Reserved concurrency is currently not required. Revisit in the future",
-            },
-            Object {
-              "id": "W89",
-              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "[HASH REMOVED].zip",
-        },
-        "Environment": Object {
-          "Variables": Object {
-            "AUDIT_LOG_GROUP_NAME": Object {
-              "Ref": "deaAuditLogs7B75D3F1",
-            },
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
-            "DATASETS_BUCKET_NAME": Object {
-              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
-            },
-            "NODE_OPTIONS": "--enable-source-maps",
-            "STAGE": "[STAGE-REMOVED]",
-            "TABLE_NAME": Object {
-              "Ref": "DeaBackendStackDeaTableE9FE4A05",
-            },
-          },
-        },
-        "Handler": "index.handler",
-        "MemorySize": 512,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewaydeabaselambdarole91512884",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "DeaApiGatewayGETfileId8331FE8E": Object {
-      "DependsOn": Array [
-        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
-        "DeaApiGatewaydeabaselambdarole91512884",
-      ],
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W58",
-              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
-            },
-            Object {
-              "id": "W92",
-              "reason": "Reserved concurrency is currently not required. Revisit in the future",
-            },
-            Object {
-              "id": "W89",
-              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "[HASH REMOVED].zip",
-        },
-        "Environment": Object {
-          "Variables": Object {
-            "AUDIT_LOG_GROUP_NAME": Object {
-              "Ref": "deaAuditLogs7B75D3F1",
-            },
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
-            "DATASETS_BUCKET_NAME": Object {
-              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
-            },
-            "NODE_OPTIONS": "--enable-source-maps",
-            "STAGE": "[STAGE-REMOVED]",
-            "TABLE_NAME": Object {
-              "Ref": "DeaBackendStackDeaTableE9FE4A05",
-            },
-          },
-        },
-        "Handler": "index.handler",
-        "MemorySize": 512,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewaydeabaselambdarole91512884",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "DeaApiGatewayGETfiles306BFDB2": Object {
-      "DependsOn": Array [
-        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
-        "DeaApiGatewaydeabaselambdarole91512884",
-      ],
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W58",
-              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
-            },
-            Object {
-              "id": "W92",
-              "reason": "Reserved concurrency is currently not required. Revisit in the future",
-            },
-            Object {
-              "id": "W89",
-              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "[HASH REMOVED].zip",
-        },
-        "Environment": Object {
-          "Variables": Object {
-            "AUDIT_LOG_GROUP_NAME": Object {
-              "Ref": "deaAuditLogs7B75D3F1",
-            },
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
-            "DATASETS_BUCKET_NAME": Object {
-              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
-            },
-            "NODE_OPTIONS": "--enable-source-maps",
-            "STAGE": "[STAGE-REMOVED]",
-            "TABLE_NAME": Object {
-              "Ref": "DeaBackendStackDeaTableE9FE4A05",
-            },
-          },
-        },
-        "Handler": "index.handler",
-        "MemorySize": 512,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewaydeabaselambdarole91512884",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "DeaApiGatewayGETgetLoginUrl68C09232": Object {
+    "DeaApiGatewayGETExchangeAuthTokenForCredentials18777BF4": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeaauthlambdaroleDefaultPolicy1298F4B5",
         "DeaApiGatewaydeaauthlambdarole4F5CC393",
@@ -863,7 +627,302 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayGETgetLogoutUrl00F60A7C": Object {
+    "DeaApiGatewayGETGetAllCases83536312": Object {
+      "DependsOn": Array [
+        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
+        "DeaApiGatewaydeabaselambdarole91512884",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewaydeabaselambdarole91512884",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaApiGatewayGETGetAllUsersD6F48F6E": Object {
+      "DependsOn": Array [
+        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
+        "DeaApiGatewaydeabaselambdarole91512884",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewaydeabaselambdarole91512884",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaApiGatewayGETGetCaseDetails2DAE602F": Object {
+      "DependsOn": Array [
+        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
+        "DeaApiGatewaydeabaselambdarole91512884",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewaydeabaselambdarole91512884",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaApiGatewayGETGetCaseFileDetail9C46D770": Object {
+      "DependsOn": Array [
+        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
+        "DeaApiGatewaydeabaselambdarole91512884",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewaydeabaselambdarole91512884",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaApiGatewayGETGetCaseFiles5D776CE0": Object {
+      "DependsOn": Array [
+        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
+        "DeaApiGatewaydeabaselambdarole91512884",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewaydeabaselambdarole91512884",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaApiGatewayGETGetLoginUrl6676EA3E": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeaauthlambdaroleDefaultPolicy1298F4B5",
         "DeaApiGatewaydeaauthlambdarole4F5CC393",
@@ -922,7 +981,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayGETidToken8E5E80D8": Object {
+    "DeaApiGatewayGETGetLogoutUrl36676722": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeaauthlambdaroleDefaultPolicy1298F4B5",
         "DeaApiGatewaydeaauthlambdarole4F5CC393",
@@ -981,7 +1040,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayGETmycasesD3845992": Object {
+    "DeaApiGatewayGETGetMyCases60A3BAE4": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
         "DeaApiGatewaydeabaselambdarole91512884",
@@ -1040,7 +1099,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayGETuserMemberships603C52A2": Object {
+    "DeaApiGatewayGETGetUsersFromCaseDF0ABA41": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
         "DeaApiGatewaydeabaselambdarole91512884",
@@ -1099,7 +1158,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayGETusersA9A634E3": Object {
+    "DeaApiGatewayPOSTCreateCaseFBDDC364": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
         "DeaApiGatewaydeabaselambdarole91512884",
@@ -1158,7 +1217,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayPOSTauthCode8F4A75C3": Object {
+    "DeaApiGatewayPOSTGetAuthenticationToken5718D484": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeaauthlambdaroleDefaultPolicy1298F4B5",
         "DeaApiGatewaydeaauthlambdarole4F5CC393",
@@ -1217,7 +1276,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayPOSTcases1FE4F197": Object {
+    "DeaApiGatewayPOSTInitiateCaseFileUpload060E0D60": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
         "DeaApiGatewaydeabaselambdarole91512884",
@@ -1276,7 +1335,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayPOSTfiles4AD6D920": Object {
+    "DeaApiGatewayPOSTInviteUserToCaseB26DE4D4": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
         "DeaApiGatewaydeabaselambdarole91512884",
@@ -1335,7 +1394,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayPOSTuserMembershipsF0715011": Object {
+    "DeaApiGatewayPUTCompleteCaseFileUploadF4BF98F1": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
         "DeaApiGatewaydeabaselambdarole91512884",
@@ -1394,7 +1453,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayPUTcaseIdB013D384": Object {
+    "DeaApiGatewayPUTModifyUserCasePermissionsABF0FB7A": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
         "DeaApiGatewaydeabaselambdarole91512884",
@@ -1453,66 +1512,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "DeaApiGatewayPUTfileId4E34B7A0": Object {
-      "DependsOn": Array [
-        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
-        "DeaApiGatewaydeabaselambdarole91512884",
-      ],
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W58",
-              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
-            },
-            Object {
-              "id": "W92",
-              "reason": "Reserved concurrency is currently not required. Revisit in the future",
-            },
-            Object {
-              "id": "W89",
-              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require acces to resources also within a VPC",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "[HASH REMOVED].zip",
-        },
-        "Environment": Object {
-          "Variables": Object {
-            "AUDIT_LOG_GROUP_NAME": Object {
-              "Ref": "deaAuditLogs7B75D3F1",
-            },
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
-            "DATASETS_BUCKET_NAME": Object {
-              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
-            },
-            "NODE_OPTIONS": "--enable-source-maps",
-            "STAGE": "[STAGE-REMOVED]",
-            "TABLE_NAME": Object {
-              "Ref": "DeaBackendStackDeaTableE9FE4A05",
-            },
-          },
-        },
-        "Handler": "index.handler",
-        "MemorySize": 512,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewaydeabaselambdarole91512884",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "DeaApiGatewayPUTuserId7238D6D2": Object {
+    "DeaApiGatewayPUTUpdateCaseDetails69D719BE": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
         "DeaApiGatewaydeabaselambdarole91512884",
@@ -1653,50 +1653,60 @@ Object {
       },
       "Type": "AWS::ApiGateway::UsagePlan",
     },
-    "DeaApiGatewaydeaapiDeployment99E7762906084b96600eff95971d92b9085d78dd": Object {
+    "DeaApiGatewaydeaapiDeployment99E77629481e133ad60a3b43c556b3a4401ca681": Object {
       "DependsOn": Array [
-        "DeaApiGatewaydeaapiauthgetCredentialsidTokenGETAB2AA9B5",
-        "DeaApiGatewaydeaapiauthgetCredentialsidTokenOPTIONSC67E30C8",
-        "DeaApiGatewaydeaapiauthgetCredentialsidToken739D5E7C",
-        "DeaApiGatewaydeaapiauthgetCredentialsOPTIONS018352AC",
-        "DeaApiGatewaydeaapiauthgetCredentials5A4EB640",
-        "DeaApiGatewaydeaapiauthgetLoginUrlGET6431944C",
-        "DeaApiGatewaydeaapiauthgetLoginUrlOPTIONS45A68225",
-        "DeaApiGatewaydeaapiauthgetLoginUrlA5E913BA",
-        "DeaApiGatewaydeaapiauthgetLogoutUrlGET853AC5A2",
-        "DeaApiGatewaydeaapiauthgetLogoutUrlOPTIONSBE1CC1C1",
-        "DeaApiGatewaydeaapiauthgetLogoutUrlD9695846",
-        "DeaApiGatewaydeaapiauthgetTokenauthCodeOPTIONS85FDF3E9",
-        "DeaApiGatewaydeaapiauthgetTokenauthCodePOSTDBFBDBDA",
-        "DeaApiGatewaydeaapiauthgetTokenauthCode850DD89D",
-        "DeaApiGatewaydeaapiauthgetTokenOPTIONS5F640BA5",
-        "DeaApiGatewaydeaapiauthgetToken6DF4BB5D",
+        "DeaApiGatewaydeaapiauthauthCodeOPTIONS8EA9BA0F",
+        "DeaApiGatewaydeaapiauthauthCodeFC92ADBD",
+        "DeaApiGatewaydeaapiauthauthCodetokenOPTIONSECFF39C3",
+        "DeaApiGatewaydeaapiauthauthCodetokenPOST7CE36F34",
+        "DeaApiGatewaydeaapiauthauthCodetoken7071838E",
+        "DeaApiGatewaydeaapiauthcredentialsidTokenexchangeGET0080A216",
+        "DeaApiGatewaydeaapiauthcredentialsidTokenexchangeOPTIONS9A9B0680",
+        "DeaApiGatewaydeaapiauthcredentialsidTokenexchange7A31FC2E",
+        "DeaApiGatewaydeaapiauthcredentialsidTokenOPTIONS90889E9B",
+        "DeaApiGatewaydeaapiauthcredentialsidToken1565B5B1",
+        "DeaApiGatewaydeaapiauthcredentialsOPTIONSC76ADF0D",
+        "DeaApiGatewaydeaapiauthcredentials9DE853F5",
+        "DeaApiGatewaydeaapiauthloginUrlGETA4078375",
+        "DeaApiGatewaydeaapiauthloginUrlOPTIONSC71EAA7B",
+        "DeaApiGatewaydeaapiauthloginUrlDBEB32CD",
+        "DeaApiGatewaydeaapiauthlogoutUrlGET44834196",
+        "DeaApiGatewaydeaapiauthlogoutUrlOPTIONSA32BAB71",
+        "DeaApiGatewaydeaapiauthlogoutUrlD5D9A02E",
         "DeaApiGatewaydeaapiauthOPTIONS95F6C2CF",
         "DeaApiGatewaydeaapiauth42A62286",
-        "DeaApiGatewaydeaapicasescaseIdDELETEA83E21F2",
+        "DeaApiGatewaydeaapicasescaseIddetailsDELETEE7B8E1B0",
+        "DeaApiGatewaydeaapicasescaseIddetailsGET41929CBD",
+        "DeaApiGatewaydeaapicasescaseIddetailsOPTIONS53E2D203",
+        "DeaApiGatewaydeaapicasescaseIddetailsPUT3D9BC22B",
+        "DeaApiGatewaydeaapicasescaseIddetailsE86153E3",
         "DeaApiGatewaydeaapicasescaseIdfilesfileIdcontentsGETD43BFE99",
         "DeaApiGatewaydeaapicasescaseIdfilesfileIdcontentsOPTIONS1DC417CA",
+        "DeaApiGatewaydeaapicasescaseIdfilesfileIdcontentsPUTF6AA4CB8",
         "DeaApiGatewaydeaapicasescaseIdfilesfileIdcontents21AB00FB",
-        "DeaApiGatewaydeaapicasescaseIdfilesfileIdGETE8901308",
+        "DeaApiGatewaydeaapicasescaseIdfilesfileIddetailsGETB36E97AC",
+        "DeaApiGatewaydeaapicasescaseIdfilesfileIddetailsOPTIONSC262DB0E",
+        "DeaApiGatewaydeaapicasescaseIdfilesfileIddetails962B64B9",
         "DeaApiGatewaydeaapicasescaseIdfilesfileIdOPTIONS25DF38EE",
-        "DeaApiGatewaydeaapicasescaseIdfilesfileIdPUTD371F749",
         "DeaApiGatewaydeaapicasescaseIdfilesfileId16B45CA0",
         "DeaApiGatewaydeaapicasescaseIdfilesGET13698780",
         "DeaApiGatewaydeaapicasescaseIdfilesOPTIONS7517D173",
         "DeaApiGatewaydeaapicasescaseIdfilesPOST3D5F353E",
         "DeaApiGatewaydeaapicasescaseIdfilesF29B9178",
-        "DeaApiGatewaydeaapicasescaseIdGET223D8BD1",
         "DeaApiGatewaydeaapicasescaseIdOPTIONSED4E4189",
-        "DeaApiGatewaydeaapicasescaseIdPUT635DAE21",
         "DeaApiGatewaydeaapicasescaseId3D754C88",
-        "DeaApiGatewaydeaapicasescaseIduserMembershipsuserIdDELETE70CA03B4",
-        "DeaApiGatewaydeaapicasescaseIduserMembershipsuserIdOPTIONS7E161480",
-        "DeaApiGatewaydeaapicasescaseIduserMembershipsuserIdPUT0D87B8B2",
-        "DeaApiGatewaydeaapicasescaseIduserMembershipsuserId01E041D2",
         "DeaApiGatewaydeaapicasescaseIduserMembershipsGET89A6E1EF",
         "DeaApiGatewaydeaapicasescaseIduserMembershipsOPTIONSA41AAFF1",
         "DeaApiGatewaydeaapicasescaseIduserMembershipsPOST9A7D9804",
         "DeaApiGatewaydeaapicasescaseIduserMemberships4457D242",
+        "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsDELETE8D61025A",
+        "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsOPTIONS0F1651A7",
+        "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsPUT6003274C",
+        "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsBA0A2E7C",
+        "DeaApiGatewaydeaapicasescaseIdusersuserIdOPTIONS3B6673A7",
+        "DeaApiGatewaydeaapicasescaseIdusersuserIdEE478FC8",
+        "DeaApiGatewaydeaapicasescaseIdusersOPTIONS09886FE5",
+        "DeaApiGatewaydeaapicasescaseIdusers2F3FB5C6",
         "DeaApiGatewaydeaapicasesallcasesGET92FB3B5C",
         "DeaApiGatewaydeaapicasesallcasesOPTIONSF976C9CD",
         "DeaApiGatewaydeaapicasesallcasesBDAE5421",
@@ -1752,7 +1762,7 @@ Object {
           "Format": "{\\"stage\\":\\"$context.stage\\",\\"requestId\\":\\"$context.requestId\\",\\"integrationRequestId\\":\\"$context.integration.requestId\\",\\"status\\":\\"$context.status\\",\\"apiId\\":\\"$context.apiId\\",\\"resourcePath\\":\\"$context.resourcePath\\",\\"path\\":\\"$context.path\\",\\"resourceId\\":\\"$context.resourceId\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"userAgent\\":\\"$context.identity.userAgent\\"}",
         },
         "DeploymentId": Object {
-          "Ref": "DeaApiGatewaydeaapiDeployment99E7762906084b96600eff95971d92b9085d78dd",
+          "Ref": "DeaApiGatewaydeaapiDeployment99E77629481e133ad60a3b43c556b3a4401ca681",
         },
         "RestApiId": Object {
           "Ref": "DeaApiGatewaydeaapi822A9228",
@@ -1861,629 +1871,10 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "DeaApiGatewaydeaapiauthgetCredentials5A4EB640": Object {
+    "DeaApiGatewaydeaapiauthauthCodeFC92ADBD": Object {
       "Properties": Object {
         "ParentId": Object {
           "Ref": "DeaApiGatewaydeaapiauth42A62286",
-        },
-        "PathPart": "getCredentials",
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "DeaApiGatewaydeaapiauthgetCredentialsOPTIONS018352AC": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": Object {
-          "IntegrationResponses": Array [
-            Object {
-              "ResponseParameters": Object {
-                "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": Object {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": Array [
-          Object {
-            "ResponseParameters": Object {
-              "method.response.header.Access-Control-Allow-Credentials": true,
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetCredentials5A4EB640",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapiauthgetCredentialsidToken739D5E7C": Object {
-      "Properties": Object {
-        "ParentId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetCredentials5A4EB640",
-        },
-        "PathPart": "{idToken}",
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "DeaApiGatewaydeaapiauthgetCredentialsidTokenGETAB2AA9B5": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaApiGatewayGETidToken8E5E80D8",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetCredentialsidToken739D5E7C",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapiauthgetCredentialsidTokenGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthgetCredentialsidTokenBD37B3AE": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayGETidToken8E5E80D8",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/",
-              Object {
-                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/GET/auth/getCredentials/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapiauthgetCredentialsidTokenGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthgetCredentialsidToken2D01D198": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayGETidToken8E5E80D8",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/test-invoke-stage/GET/auth/getCredentials/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapiauthgetCredentialsidTokenOPTIONSC67E30C8": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": Object {
-          "IntegrationResponses": Array [
-            Object {
-              "ResponseParameters": Object {
-                "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": Object {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": Array [
-          Object {
-            "ResponseParameters": Object {
-              "method.response.header.Access-Control-Allow-Credentials": true,
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetCredentialsidToken739D5E7C",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapiauthgetLoginUrlA5E913BA": Object {
-      "Properties": Object {
-        "ParentId": Object {
-          "Ref": "DeaApiGatewaydeaapiauth42A62286",
-        },
-        "PathPart": "getLoginUrl",
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "DeaApiGatewaydeaapiauthgetLoginUrlGET6431944C": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaApiGatewayGETgetLoginUrl68C09232",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetLoginUrlA5E913BA",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapiauthgetLoginUrlGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthgetLoginUrl5EECDE24": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayGETgetLoginUrl68C09232",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/",
-              Object {
-                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/GET/auth/getLoginUrl",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapiauthgetLoginUrlGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthgetLoginUrl11B6B048": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayGETgetLoginUrl68C09232",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/test-invoke-stage/GET/auth/getLoginUrl",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapiauthgetLoginUrlOPTIONS45A68225": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": Object {
-          "IntegrationResponses": Array [
-            Object {
-              "ResponseParameters": Object {
-                "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": Object {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": Array [
-          Object {
-            "ResponseParameters": Object {
-              "method.response.header.Access-Control-Allow-Credentials": true,
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetLoginUrlA5E913BA",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapiauthgetLogoutUrlD9695846": Object {
-      "Properties": Object {
-        "ParentId": Object {
-          "Ref": "DeaApiGatewaydeaapiauth42A62286",
-        },
-        "PathPart": "getLogoutUrl",
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "DeaApiGatewaydeaapiauthgetLogoutUrlGET853AC5A2": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaApiGatewayGETgetLogoutUrl00F60A7C",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetLogoutUrlD9695846",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapiauthgetLogoutUrlGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthgetLogoutUrl864AC6FA": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayGETgetLogoutUrl00F60A7C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/",
-              Object {
-                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/GET/auth/getLogoutUrl",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapiauthgetLogoutUrlGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthgetLogoutUrl1DB4112A": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayGETgetLogoutUrl00F60A7C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/test-invoke-stage/GET/auth/getLogoutUrl",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapiauthgetLogoutUrlOPTIONSBE1CC1C1": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": Object {
-          "IntegrationResponses": Array [
-            Object {
-              "ResponseParameters": Object {
-                "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": Object {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": Array [
-          Object {
-            "ResponseParameters": Object {
-              "method.response.header.Access-Control-Allow-Credentials": true,
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetLogoutUrlD9695846",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapiauthgetToken6DF4BB5D": Object {
-      "Properties": Object {
-        "ParentId": Object {
-          "Ref": "DeaApiGatewaydeaapiauth42A62286",
-        },
-        "PathPart": "getToken",
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "DeaApiGatewaydeaapiauthgetTokenOPTIONS5F640BA5": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": Object {
-          "IntegrationResponses": Array [
-            Object {
-              "ResponseParameters": Object {
-                "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": Object {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": Array [
-          Object {
-            "ResponseParameters": Object {
-              "method.response.header.Access-Control-Allow-Credentials": true,
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetToken6DF4BB5D",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapiauthgetTokenauthCode850DD89D": Object {
-      "Properties": Object {
-        "ParentId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetToken6DF4BB5D",
         },
         "PathPart": "{authCode}",
         "RestApiId": Object {
@@ -2492,7 +1883,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "DeaApiGatewaydeaapiauthgetTokenauthCodeOPTIONS85FDF3E9": Object {
+    "DeaApiGatewaydeaapiauthauthCodeOPTIONS8EA9BA0F": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
         "HttpMethod": "OPTIONS",
@@ -2525,7 +1916,7 @@ Object {
           },
         ],
         "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetTokenauthCode850DD89D",
+          "Ref": "DeaApiGatewaydeaapiauthauthCodeFC92ADBD",
         },
         "RestApiId": Object {
           "Ref": "DeaApiGatewaydeaapi822A9228",
@@ -2533,85 +1924,60 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "DeaApiGatewaydeaapiauthgetTokenauthCodePOSTApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9POSTauthgetTokenauthCodeE7AB4EE0": Object {
+    "DeaApiGatewaydeaapiauthauthCodetoken7071838E": Object {
       "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayPOSTauthCode8F4A75C3",
-            "Arn",
-          ],
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthauthCodeFC92ADBD",
         },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/",
-              Object {
-                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/POST/auth/getToken/*",
-            ],
-          ],
+        "PathPart": "token",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
         },
       },
-      "Type": "AWS::Lambda::Permission",
+      "Type": "AWS::ApiGateway::Resource",
     },
-    "DeaApiGatewaydeaapiauthgetTokenauthCodePOSTApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9POSTauthgetTokenauthCode39100E7C": Object {
+    "DeaApiGatewaydeaapiauthauthCodetokenOPTIONSECFF39C3": Object {
       "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayPOSTauthCode8F4A75C3",
-            "Arn",
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
           ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
         },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/test-invoke-stage/POST/auth/getToken/*",
-            ],
-          ],
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthauthCodetoken7071838E",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
         },
       },
-      "Type": "AWS::Lambda::Permission",
+      "Type": "AWS::ApiGateway::Method",
     },
-    "DeaApiGatewaydeaapiauthgetTokenauthCodePOSTDBFBDBDA": Object {
+    "DeaApiGatewaydeaapiauthauthCodetokenPOST7CE36F34": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
         "HttpMethod": "POST",
@@ -2633,7 +1999,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaApiGatewayPOSTauthCode8F4A75C3",
+                    "DeaApiGatewayPOSTGetAuthenticationToken5718D484",
                     "Arn",
                   ],
                 },
@@ -2643,7 +2009,704 @@ Object {
           },
         },
         "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapiauthgetTokenauthCode850DD89D",
+          "Ref": "DeaApiGatewaydeaapiauthauthCodetoken7071838E",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiauthauthCodetokenPOSTApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9POSTauthauthCodetoken9B5873D4": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPOSTGetAuthenticationToken5718D484",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/POST/auth/*/token",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiauthauthCodetokenPOSTApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9POSTauthauthCodetokenF01BAD47": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPOSTGetAuthenticationToken5718D484",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/POST/auth/*/token",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiauthcredentials9DE853F5": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapiauth42A62286",
+        },
+        "PathPart": "credentials",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapiauthcredentialsOPTIONSC76ADF0D": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthcredentials9DE853F5",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiauthcredentialsidToken1565B5B1": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthcredentials9DE853F5",
+        },
+        "PathPart": "{idToken}",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapiauthcredentialsidTokenOPTIONS90889E9B": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthcredentialsidToken1565B5B1",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiauthcredentialsidTokenexchange7A31FC2E": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthcredentialsidToken1565B5B1",
+        },
+        "PathPart": "exchange",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapiauthcredentialsidTokenexchangeGET0080A216": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayGETExchangeAuthTokenForCredentials18777BF4",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthcredentialsidTokenexchange7A31FC2E",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiauthcredentialsidTokenexchangeGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthcredentialsidTokenexchange534CD314": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETExchangeAuthTokenForCredentials18777BF4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/auth/credentials/*/exchange",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiauthcredentialsidTokenexchangeGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthcredentialsidTokenexchange990493FF": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETExchangeAuthTokenForCredentials18777BF4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/GET/auth/credentials/*/exchange",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiauthcredentialsidTokenexchangeOPTIONS9A9B0680": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthcredentialsidTokenexchange7A31FC2E",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiauthloginUrlDBEB32CD": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapiauth42A62286",
+        },
+        "PathPart": "loginUrl",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapiauthloginUrlGETA4078375": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayGETGetLoginUrl6676EA3E",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthloginUrlDBEB32CD",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiauthloginUrlGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthloginUrl5CC8D391": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetLoginUrl6676EA3E",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/auth/loginUrl",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiauthloginUrlGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthloginUrlB20E499C": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetLoginUrl6676EA3E",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/GET/auth/loginUrl",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiauthloginUrlOPTIONSC71EAA7B": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthloginUrlDBEB32CD",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiauthlogoutUrlD5D9A02E": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapiauth42A62286",
+        },
+        "PathPart": "logoutUrl",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapiauthlogoutUrlGET44834196": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayGETGetLogoutUrl36676722",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthlogoutUrlD5D9A02E",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiauthlogoutUrlGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthlogoutUrl430C249B": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetLogoutUrl36676722",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/auth/logoutUrl",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiauthlogoutUrlGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETauthlogoutUrlB37EA100": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetLogoutUrl36676722",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/GET/auth/logoutUrl",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiauthlogoutUrlOPTIONSA32BAB71": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiauthlogoutUrlD5D9A02E",
         },
         "RestApiId": Object {
           "Ref": "DeaApiGatewaydeaapi822A9228",
@@ -2729,7 +2792,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaApiGatewayPOSTcases1FE4F197",
+                    "DeaApiGatewayPOSTCreateCaseFBDDC364",
                     "Arn",
                   ],
                 },
@@ -2752,7 +2815,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayPOSTcases1FE4F197",
+            "DeaApiGatewayPOSTCreateCaseFBDDC364",
             "Arn",
           ],
         },
@@ -2793,7 +2856,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayPOSTcases1FE4F197",
+            "DeaApiGatewayPOSTCreateCaseFBDDC364",
             "Arn",
           ],
         },
@@ -2863,7 +2926,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaApiGatewayGETallcasesF6A8BE63",
+                    "DeaApiGatewayGETGetAllCases83536312",
                     "Arn",
                   ],
                 },
@@ -2890,7 +2953,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETallcasesF6A8BE63",
+            "DeaApiGatewayGETGetAllCases83536312",
             "Arn",
           ],
         },
@@ -2931,7 +2994,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETallcasesF6A8BE63",
+            "DeaApiGatewayGETGetAllCases83536312",
             "Arn",
           ],
         },
@@ -3016,242 +3079,6 @@ Object {
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "DeaApiGatewaydeaapicasescaseIdDELETEA83E21F2": Object {
-      "Properties": Object {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "DELETE",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaApiGatewayDELETEcaseId8BA29E4C",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapicasescaseId3D754C88",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapicasescaseIdDELETEApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9DELETEcasescaseIdE1A83307": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayDELETEcaseId8BA29E4C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/",
-              Object {
-                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/DELETE/cases/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapicasescaseIdDELETEApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9DELETEcasescaseId99E005A8": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayDELETEcaseId8BA29E4C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/test-invoke-stage/DELETE/cases/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapicasescaseIdGET223D8BD1": Object {
-      "Properties": Object {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "GET",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaApiGatewayGETcaseIdACE0459E",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapicasescaseId3D754C88",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapicasescaseIdGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETcasescaseId72B07DD3": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayGETcaseIdACE0459E",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/",
-              Object {
-                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/GET/cases/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapicasescaseIdGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETcasescaseId26467B7E": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayGETcaseIdACE0459E",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/test-invoke-stage/GET/cases/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
     "DeaApiGatewaydeaapicasescaseIdOPTIONSED4E4189": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
@@ -3293,52 +3120,12 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "DeaApiGatewaydeaapicasescaseIdPUT635DAE21": Object {
-      "Properties": Object {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "PUT",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaApiGatewayPUTcaseIdB013D384",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapicasescaseId3D754C88",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapicasescaseIdPUTApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseIdF626A595": Object {
+    "DeaApiGatewaydeaapicasescaseIddetailsDELETEApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9DELETEcasescaseIddetails2C70D817": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayPUTcaseIdB013D384",
+            "DeaApiGatewayDELETEDeleteCase91CB5F89",
             "Arn",
           ],
         },
@@ -3367,19 +3154,19 @@ Object {
               Object {
                 "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
               },
-              "/PUT/cases/*",
+              "/DELETE/cases/*/details",
             ],
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "DeaApiGatewaydeaapicasescaseIdPUTApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseId89C7AB7F": Object {
+    "DeaApiGatewaydeaapicasescaseIddetailsDELETEApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9DELETEcasescaseIddetails86ADF27E": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayPUTcaseIdB013D384",
+            "DeaApiGatewayDELETEDeleteCase91CB5F89",
             "Arn",
           ],
         },
@@ -3404,7 +3191,336 @@ Object {
               Object {
                 "Ref": "DeaApiGatewaydeaapi822A9228",
               },
-              "/test-invoke-stage/PUT/cases/*",
+              "/test-invoke-stage/DELETE/cases/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapicasescaseIddetailsDELETEE7B8E1B0": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "DELETE",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayDELETEDeleteCase91CB5F89",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIddetailsE86153E3",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapicasescaseIddetailsE86153E3": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseId3D754C88",
+        },
+        "PathPart": "details",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapicasescaseIddetailsGET41929CBD": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayGETGetCaseDetails2DAE602F",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIddetailsE86153E3",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapicasescaseIddetailsGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETcasescaseIddetailsAA4D9CB6": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetCaseDetails2DAE602F",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/cases/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapicasescaseIddetailsGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETcasescaseIddetails4472EF26": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetCaseDetails2DAE602F",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/GET/cases/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapicasescaseIddetailsOPTIONS53E2D203": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIddetailsE86153E3",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapicasescaseIddetailsPUT3D9BC22B": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "PUT",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayPUTUpdateCaseDetails69D719BE",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIddetailsE86153E3",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapicasescaseIddetailsPUTApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseIddetailsD766813D": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPUTUpdateCaseDetails69D719BE",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/PUT/cases/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapicasescaseIddetailsPUTApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseIddetails9A2A063C": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPUTUpdateCaseDetails69D719BE",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/PUT/cases/*/details",
             ],
           ],
         },
@@ -3445,7 +3561,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaApiGatewayGETfiles306BFDB2",
+                    "DeaApiGatewayGETGetCaseFiles5D776CE0",
                     "Arn",
                   ],
                 },
@@ -3468,7 +3584,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETfiles306BFDB2",
+            "DeaApiGatewayGETGetCaseFiles5D776CE0",
             "Arn",
           ],
         },
@@ -3509,7 +3625,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETfiles306BFDB2",
+            "DeaApiGatewayGETGetCaseFiles5D776CE0",
             "Arn",
           ],
         },
@@ -3604,7 +3720,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaApiGatewayPOSTfiles4AD6D920",
+                    "DeaApiGatewayPOSTInitiateCaseFileUpload060E0D60",
                     "Arn",
                   ],
                 },
@@ -3627,7 +3743,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayPOSTfiles4AD6D920",
+            "DeaApiGatewayPOSTInitiateCaseFileUpload060E0D60",
             "Arn",
           ],
         },
@@ -3668,7 +3784,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayPOSTfiles4AD6D920",
+            "DeaApiGatewayPOSTInitiateCaseFileUpload060E0D60",
             "Arn",
           ],
         },
@@ -3712,124 +3828,6 @@ Object {
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "DeaApiGatewaydeaapicasescaseIdfilesfileIdGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETcasescaseIdfilesfileId2266378F": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayGETfileId8331FE8E",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/",
-              Object {
-                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/GET/cases/*/files/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapicasescaseIdfilesfileIdGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETcasescaseIdfilesfileId604A87D1": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayGETfileId8331FE8E",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/test-invoke-stage/GET/cases/*/files/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapicasescaseIdfilesfileIdGETE8901308": Object {
-      "Properties": Object {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "GET",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaApiGatewayGETfileId8331FE8E",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapicasescaseIdfilesfileId16B45CA0",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
     "DeaApiGatewaydeaapicasescaseIdfilesfileIdOPTIONS25DF38EE": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
@@ -3871,124 +3869,6 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "DeaApiGatewaydeaapicasescaseIdfilesfileIdPUTApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseIdfilesfileId3180EF8A": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayPUTfileId4E34B7A0",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/",
-              Object {
-                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/PUT/cases/*/files/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapicasescaseIdfilesfileIdPUTApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseIdfilesfileIdF4131FCE": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayPUTfileId4E34B7A0",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/test-invoke-stage/PUT/cases/*/files/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapicasescaseIdfilesfileIdPUTD371F749": Object {
-      "Properties": Object {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "PUT",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaApiGatewayPUTfileId4E34B7A0",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapicasescaseIdfilesfileId16B45CA0",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
     "DeaApiGatewaydeaapicasescaseIdfilesfileIdcontents21AB00FB": Object {
       "Properties": Object {
         "ParentId": Object {
@@ -4006,7 +3886,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETcontentsF4247FB2",
+            "DeaApiGatewayGETDownloadCaseFile32575192",
             "Arn",
           ],
         },
@@ -4047,7 +3927,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETcontentsF4247FB2",
+            "DeaApiGatewayGETDownloadCaseFile32575192",
             "Arn",
           ],
         },
@@ -4101,7 +3981,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaApiGatewayGETcontentsF4247FB2",
+                    "DeaApiGatewayGETDownloadCaseFile32575192",
                     "Arn",
                   ],
                 },
@@ -4160,6 +4040,295 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
+    "DeaApiGatewaydeaapicasescaseIdfilesfileIdcontentsPUTApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseIdfilesfileIdcontentsC2DBDB31": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPUTCompleteCaseFileUploadF4BF98F1",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/PUT/cases/*/files/*/contents",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapicasescaseIdfilesfileIdcontentsPUTApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseIdfilesfileIdcontents4825A2D8": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPUTCompleteCaseFileUploadF4BF98F1",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/PUT/cases/*/files/*/contents",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapicasescaseIdfilesfileIdcontentsPUTF6AA4CB8": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "PUT",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayPUTCompleteCaseFileUploadF4BF98F1",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIdfilesfileIdcontents21AB00FB",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapicasescaseIdfilesfileIddetails962B64B9": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIdfilesfileId16B45CA0",
+        },
+        "PathPart": "details",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapicasescaseIdfilesfileIddetailsGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETcasescaseIdfilesfileIddetailsC8F4B1A4": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetCaseFileDetail9C46D770",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/cases/*/files/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapicasescaseIdfilesfileIddetailsGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETcasescaseIdfilesfileIddetails1E8C2627": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetCaseFileDetail9C46D770",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/GET/cases/*/files/*/details",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapicasescaseIdfilesfileIddetailsGETB36E97AC": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayGETGetCaseFileDetail9C46D770",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIdfilesfileIddetails962B64B9",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapicasescaseIdfilesfileIddetailsOPTIONSC262DB0E": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIdfilesfileIddetails962B64B9",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
     "DeaApiGatewaydeaapicasescaseIduserMemberships4457D242": Object {
       "Properties": Object {
         "ParentId": Object {
@@ -4194,7 +4363,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaApiGatewayGETuserMemberships603C52A2",
+                    "DeaApiGatewayGETGetUsersFromCaseDF0ABA41",
                     "Arn",
                   ],
                 },
@@ -4217,7 +4386,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETuserMemberships603C52A2",
+            "DeaApiGatewayGETGetUsersFromCaseDF0ABA41",
             "Arn",
           ],
         },
@@ -4258,7 +4427,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETuserMemberships603C52A2",
+            "DeaApiGatewayGETGetUsersFromCaseDF0ABA41",
             "Arn",
           ],
         },
@@ -4353,7 +4522,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaApiGatewayPOSTuserMembershipsF0715011",
+                    "DeaApiGatewayPOSTInviteUserToCaseB26DE4D4",
                     "Arn",
                   ],
                 },
@@ -4376,7 +4545,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayPOSTuserMembershipsF0715011",
+            "DeaApiGatewayPOSTInviteUserToCaseB26DE4D4",
             "Arn",
           ],
         },
@@ -4417,7 +4586,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayPOSTuserMembershipsF0715011",
+            "DeaApiGatewayPOSTInviteUserToCaseB26DE4D4",
             "Arn",
           ],
         },
@@ -4449,137 +4618,19 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "DeaApiGatewaydeaapicasescaseIduserMembershipsuserId01E041D2": Object {
+    "DeaApiGatewaydeaapicasescaseIdusers2F3FB5C6": Object {
       "Properties": Object {
         "ParentId": Object {
-          "Ref": "DeaApiGatewaydeaapicasescaseIduserMemberships4457D242",
+          "Ref": "DeaApiGatewaydeaapicasescaseId3D754C88",
         },
-        "PathPart": "{userId}",
+        "PathPart": "users",
         "RestApiId": Object {
           "Ref": "DeaApiGatewaydeaapi822A9228",
         },
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "DeaApiGatewaydeaapicasescaseIduserMembershipsuserIdDELETE70CA03B4": Object {
-      "Properties": Object {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "DELETE",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "DeaApiGatewayDELETEuserId62E08A5C",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapicasescaseIduserMembershipsuserId01E041D2",
-        },
-        "RestApiId": Object {
-          "Ref": "DeaApiGatewaydeaapi822A9228",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DeaApiGatewaydeaapicasescaseIduserMembershipsuserIdDELETEApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9DELETEcasescaseIduserMembershipsuserIdD4B75C6A": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayDELETEuserId62E08A5C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/",
-              Object {
-                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-              },
-              "/DELETE/cases/*/userMemberships/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapicasescaseIduserMembershipsuserIdDELETEApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9DELETEcasescaseIduserMembershipsuserId88FC912F": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "DeaApiGatewayDELETEuserId62E08A5C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "DeaApiGatewaydeaapi822A9228",
-              },
-              "/test-invoke-stage/DELETE/cases/*/userMemberships/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "DeaApiGatewaydeaapicasescaseIduserMembershipsuserIdOPTIONS7E161480": Object {
+    "DeaApiGatewaydeaapicasescaseIdusersOPTIONS09886FE5": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
         "HttpMethod": "OPTIONS",
@@ -4612,7 +4663,7 @@ Object {
           },
         ],
         "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapicasescaseIduserMembershipsuserId01E041D2",
+          "Ref": "DeaApiGatewaydeaapicasescaseIdusers2F3FB5C6",
         },
         "RestApiId": Object {
           "Ref": "DeaApiGatewaydeaapi822A9228",
@@ -4620,10 +4671,75 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "DeaApiGatewaydeaapicasescaseIduserMembershipsuserIdPUT0D87B8B2": Object {
+    "DeaApiGatewaydeaapicasescaseIdusersuserIdEE478FC8": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIdusers2F3FB5C6",
+        },
+        "PathPart": "{userId}",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapicasescaseIdusersuserIdOPTIONS3B6673A7": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIdusersuserIdEE478FC8",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsBA0A2E7C": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIdusersuserIdEE478FC8",
+        },
+        "PathPart": "memberships",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsDELETE8D61025A": Object {
       "Properties": Object {
         "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "PUT",
+        "HttpMethod": "DELETE",
         "Integration": Object {
           "IntegrationHttpMethod": "POST",
           "Type": "AWS_PROXY",
@@ -4642,7 +4758,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaApiGatewayPUTuserId7238D6D2",
+                    "DeaApiGatewayDELETERemoveUserFromCaseD22CC76C",
                     "Arn",
                   ],
                 },
@@ -4652,7 +4768,7 @@ Object {
           },
         },
         "ResourceId": Object {
-          "Ref": "DeaApiGatewaydeaapicasescaseIduserMembershipsuserId01E041D2",
+          "Ref": "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsBA0A2E7C",
         },
         "RestApiId": Object {
           "Ref": "DeaApiGatewaydeaapi822A9228",
@@ -4660,12 +4776,12 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "DeaApiGatewaydeaapicasescaseIduserMembershipsuserIdPUTApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseIduserMembershipsuserIdE7C4D8D0": Object {
+    "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsDELETEApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9DELETEcasescaseIdusersuserIdmemberships2C9CC8B5": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayPUTuserId7238D6D2",
+            "DeaApiGatewayDELETERemoveUserFromCaseD22CC76C",
             "Arn",
           ],
         },
@@ -4694,19 +4810,19 @@ Object {
               Object {
                 "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
               },
-              "/PUT/cases/*/userMemberships/*",
+              "/DELETE/cases/*/users/*/memberships",
             ],
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "DeaApiGatewaydeaapicasescaseIduserMembershipsuserIdPUTApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseIduserMembershipsuserIdCAB62A4F": Object {
+    "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsDELETEApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9DELETEcasescaseIdusersuserIdmembershipsC5C31048": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayPUTuserId7238D6D2",
+            "DeaApiGatewayDELETERemoveUserFromCaseD22CC76C",
             "Arn",
           ],
         },
@@ -4731,7 +4847,166 @@ Object {
               Object {
                 "Ref": "DeaApiGatewaydeaapi822A9228",
               },
-              "/test-invoke-stage/PUT/cases/*/userMemberships/*",
+              "/test-invoke-stage/DELETE/cases/*/users/*/memberships",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsOPTIONS0F1651A7": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,idToken,x-amz-security-token'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsBA0A2E7C",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsPUT6003274C": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "PUT",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayPUTModifyUserCasePermissionsABF0FB7A",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsBA0A2E7C",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsPUTApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseIdusersuserIdmemberships448538AB": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPUTModifyUserCasePermissionsABF0FB7A",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/PUT/cases/*/users/*/memberships",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapicasescaseIdusersuserIdmembershipsPUTApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9PUTcasescaseIdusersuserIdmembershipsB3E7C0CC": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPUTModifyUserCasePermissionsABF0FB7A",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/PUT/cases/*/users/*/memberships",
             ],
           ],
         },
@@ -4776,7 +5051,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaApiGatewayGETmycasesD3845992",
+                    "DeaApiGatewayGETGetMyCases60A3BAE4",
                     "Arn",
                   ],
                 },
@@ -4803,7 +5078,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETmycasesD3845992",
+            "DeaApiGatewayGETGetMyCases60A3BAE4",
             "Arn",
           ],
         },
@@ -4844,7 +5119,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETmycasesD3845992",
+            "DeaApiGatewayGETGetMyCases60A3BAE4",
             "Arn",
           ],
         },
@@ -5728,7 +6003,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETusersA9A634E3",
+            "DeaApiGatewayGETGetAllUsersD6F48F6E",
             "Arn",
           ],
         },
@@ -5769,7 +6044,7 @@ Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "DeaApiGatewayGETusersA9A634E3",
+            "DeaApiGatewayGETGetAllUsersD6F48F6E",
             "Arn",
           ],
         },
@@ -5826,7 +6101,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "DeaApiGatewayGETusersA9A634E3",
+                    "DeaApiGatewayGETGetAllUsersD6F48F6E",
                     "Arn",
                   ],
                 },
@@ -6393,7 +6668,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/POST/auth/getToken/*",
+                      "/GET/auth/credentials/*/exchange",
                     ],
                   ],
                 },
@@ -6421,35 +6696,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/GET/auth/getCredentials/*",
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":execute-api:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "DeaApiGatewaydeaapi822A9228",
-                      },
-                      "/",
-                      Object {
-                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-                      },
-                      "/GET/auth/getLoginUrl",
+                      "/GET/auth/loginUrl",
                     ],
                   ],
                 },
@@ -6555,7 +6802,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/GET/cases/*",
+                      "/GET/cases/*/details",
                     ],
                   ],
                 },
@@ -6583,7 +6830,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/PUT/cases/*",
+                      "/PUT/cases/*/details",
                     ],
                   ],
                 },
@@ -6611,7 +6858,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/DELETE/cases/*",
+                      "/DELETE/cases/*/details",
                     ],
                   ],
                 },
@@ -6695,7 +6942,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/POST/auth/getToken/*",
+                      "/PUT/cases/*/users/*/memberships",
                     ],
                   ],
                 },
@@ -6723,7 +6970,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/GET/auth/getLoginUrl",
+                      "/DELETE/cases/*/users/*/memberships",
                     ],
                   ],
                 },
@@ -6751,7 +6998,63 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/GET/auth/getCredentials/*",
+                      "/POST/auth/*/token",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/GET/auth/loginUrl",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/GET/auth/credentials/*/exchange",
                     ],
                   ],
                 },
@@ -6863,7 +7166,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/PUT/cases/*/files/*",
+                      "/PUT/cases/*/files/*/contents",
                     ],
                   ],
                 },
@@ -6891,7 +7194,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/GET/cases/*/files/*",
+                      "/GET/cases/*/files/*/details",
                     ],
                   ],
                 },
@@ -6920,6 +7223,34 @@ Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
                       "/GET/cases/*/files/*/contents",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/GET/cases/my-cases",
                     ],
                   ],
                 },
@@ -7025,7 +7356,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/DELETE/cases/*",
+                      "/DELETE/cases/*/details",
                     ],
                   ],
                 },
@@ -7081,7 +7412,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/POST/auth/getToken/*",
+                      "/GET/auth/credentials/*/exchange",
                     ],
                   ],
                 },
@@ -7109,35 +7440,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/GET/auth/getCredentials/*",
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":execute-api:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "DeaApiGatewaydeaapi822A9228",
-                      },
-                      "/",
-                      Object {
-                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-                      },
-                      "/GET/auth/getLoginUrl",
+                      "/GET/auth/loginUrl",
                     ],
                   ],
                 },
@@ -7424,7 +7727,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/GET/cases/*",
+                      "/GET/cases/*/details",
                     ],
                   ],
                 },
@@ -7452,7 +7755,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/DELETE/cases/*",
+                      "/DELETE/cases/*/details",
                     ],
                   ],
                 },
@@ -7480,7 +7783,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/POST/auth/getToken/*",
+                      "/GET/auth/credentials/*/exchange",
                     ],
                   ],
                 },
@@ -7508,35 +7811,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/GET/auth/getCredentials/*",
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":execute-api:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "DeaApiGatewaydeaapi822A9228",
-                      },
-                      "/",
-                      Object {
-                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
-                      },
-                      "/GET/auth/getLoginUrl",
+                      "/GET/auth/loginUrl",
                     ],
                   ],
                 },
@@ -7642,7 +7917,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/GET/cases/*",
+                      "/GET/cases/*/details",
                     ],
                   ],
                 },
@@ -7670,7 +7945,7 @@ Object {
                       Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
-                      "/DELETE/cases/*",
+                      "/DELETE/cases/*/details",
                     ],
                   ],
                 },

--- a/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
@@ -91,7 +91,7 @@ describe('CaseDetailsPage', () => {
   it('renders a case details page', async () => {
     mockedAxios.mockImplementation((event) => {
       const eventObj: any = event;
-      if (eventObj.url === 'https://localhostcases/100/') {
+      if (eventObj.url === 'https://localhostcases/100/details') {
         return Promise.resolve({
           data: mockedCaseDetail,
           status: 200,

--- a/source/dea-ui/ui/src/api/auth.tsx
+++ b/source/dea-ui/ui/src/api/auth.tsx
@@ -7,7 +7,7 @@ import { httpApiGet, httpApiPost } from '../helpers/apiHelper';
 
 const getToken = async (authCode: string): Promise<Oauth2Token> => {
   try {
-    const response = await httpApiPost(`auth/getToken/${authCode}/`, { authCode });
+    const response = await httpApiPost(`auth/${authCode}/token`, { authCode });
     return response;
   } catch (error) {
     console.error(error);
@@ -17,7 +17,7 @@ const getToken = async (authCode: string): Promise<Oauth2Token> => {
 
 const getCredentials = async (idToken: string) => {
   try {
-    const response = await httpApiGet(`auth/getCredentials/${idToken}`, {});
+    const response = await httpApiGet(`auth/credentials/${idToken}/exchange`, {});
     return response;
   } catch (error) {
     console.error(error);
@@ -26,7 +26,7 @@ const getCredentials = async (idToken: string) => {
 
 const getLoginUrl = async () => {
   try {
-    const response = await httpApiGet(`auth/getLoginUrl`, {});
+    const response = await httpApiGet(`auth/loginUrl`, {});
     return response;
   } catch (error) {
     console.error(error);

--- a/source/dea-ui/ui/src/api/cases.tsx
+++ b/source/dea-ui/ui/src/api/cases.tsx
@@ -25,8 +25,14 @@ export const useListAllCases = (): DeaListResult<DeaCase> => {
   return { data: cases, isLoading: isValidating };
 };
 
+export const useListMyCases = (): DeaListResult<DeaCase> => {
+  const { data, isValidating } = useSWR(() => `cases/my-cases`, httpApiGet);
+  const cases: DeaCase[] = data?.cases ?? [];
+  return { data: cases, isLoading: isValidating };
+};
+
 export const useGetCaseById = (id: string): DeaSingleResult<DeaCase> => {
-  const { data, isValidating } = useSWR(() => `cases/${id}/`, httpApiGet);
+  const { data, isValidating } = useSWR(() => `cases/${id}/details`, httpApiGet);
   return { data, isLoading: isValidating };
 };
 


### PR DESCRIPTION
- do not allow resources to end with wildcards (e.g. cases/{id} becomes /cases/*) This prevents unintended access when granting access to resources that end with a wildcard


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
