### PR TITLE
Simplify download case-file logic

### DIFF
--- a/source/dea-app/src/storage/datasets.ts
+++ b/source/dea-app/src/storage/datasets.ts
@@ -142,6 +142,7 @@ export const getPresignedUrlForDownload = async (
     Key: s3Key,
     VersionId: caseFile.versionId,
     ResponseContentType: caseFile.contentType,
+    ResponseContentDisposition: `attachment; filename="${caseFile.fileName}"`,
   });
   return getSignedUrl(datasetsProvider.s3Client, getObjectCommand, {
     expiresIn: datasetsProvider.presignedCommandExpirySeconds,

--- a/source/dea-ui/ui/src/components/case-details/CaseFilesTable.tsx
+++ b/source/dea-ui/ui/src/components/case-details/CaseFilesTable.tsx
@@ -179,27 +179,10 @@ function CaseFilesTable(props: CaseDetailsBodyProps): JSX.Element {
       for (const file of selectedFiles) {
         setDownloadInProgress(true);
         const downloadResponse = await getPresignedUrl({ caseUlid: file.caseUlid, ulid: file.ulid });
-        //TODO: need to figure out hash validation on download
-        fetch(downloadResponse.downloadUrl, { method: 'GET' })
-          .then((response) => {
-            response
-              .blob()
-              .then((blob) => {
-                const fileUrl = window.URL.createObjectURL(blob);
-                const alink = document.createElement('a');
-                alink.href = fileUrl;
-                alink.download = file.fileName;
-                alink.click();
-              })
-              .catch((reason) => {
-                // TODO add error banner like in figma
-                console.log(reason);
-              });
-          })
-          .catch((reason) => {
-            // TODO add error banner like in figma
-            console.log(reason);
-          });
+        const alink = document.createElement('a');
+        alink.href = downloadResponse.downloadUrl;
+        alink.download = file.fileName;
+        alink.click();
       }
     } finally {
       setDownloadInProgress(false);


### PR DESCRIPTION
*Description of changes:*
- Previous logic was downloading file into memory before saving on disk. This one goes directly from S3 to disk

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
