### PR TITLE
refactor: remove unused components and clean up some render warnings

### DIFF
--- a/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
@@ -20,6 +20,7 @@ jest.mock('next/router', () => ({
 
 global.fetch = jest.fn(() => Promise.resolve({ blob: () => Promise.resolve('foo') }));
 global.window.URL.createObjectURL = jest.fn(() => {});
+HTMLAnchorElement.prototype.click = jest.fn();
 
 jest.mock('axios');
 const mockedAxios = axios as jest.MockedFunction<typeof axios>;

--- a/source/dea-ui/ui/__tests__/pages/create-case.unit.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/create-case.unit.test.tsx
@@ -1,7 +1,7 @@
 import wrapper from '@cloudscape-design/components/test-utils/dom';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event'
+import userEvent from '@testing-library/user-event';
 import { fail } from 'assert';
 import axios from 'axios';
 import { commonLabels, createCaseLabels } from '../../src/common/labels';
@@ -13,7 +13,7 @@ jest.mock('next/router', () => ({
   useRouter: jest.fn().mockImplementation(() => ({
     query: {},
     push,
-  }))
+  })),
 }));
 
 jest.mock('axios');
@@ -23,10 +23,10 @@ describe('CreateCases page', () => {
   it('renders a case creation page', async () => {
     mockedAxios.mockResolvedValue({
       data: {
-            ulid: 'abc',
-            name: 'mocked case',
-            status: 'ACTIVE',
-          },
+        ulid: 'abc',
+        name: 'mocked case',
+        status: 'ACTIVE',
+      },
       status: 200,
       statusText: 'Ok',
       headers: {},
@@ -34,25 +34,18 @@ describe('CreateCases page', () => {
     });
 
     const user = userEvent.setup();
-    const page = render(<Home/>);
+    const page = render(<Home />);
     const createCaseLabel = screen.getByText(createCaseLabels.createNewCaseLabel);
 
     expect(page).toBeTruthy();
     expect(createCaseLabel).toBeTruthy();
 
-    const button = screen.getByRole('button', {name: commonLabels.createButton});
+    const button = screen.getByRole('button', { name: commonLabels.createButton });
     await user.click(button);
-
-    const shareFormContainer = await screen.findByTestId('share-form-container');
-    const autoSuggest = wrapper(shareFormContainer).findAutosuggest();
-    if (!autoSuggest) {
-      fail();
-    }
-    autoSuggest.setInputValue('suggest');
   });
 
   it('responds to cancel', () => {
-    render(<Home/>);
+    render(<Home />);
 
     const cancelButton = screen.getByTestId('create-case-cancel');
 
@@ -62,21 +55,21 @@ describe('CreateCases page', () => {
   });
 
   it('responds to form submit', () => {
-    render(<Home/>);
+    render(<Home />);
 
     const nameInput = screen.getByTestId('input-name');
     const wrappedName = wrapper(nameInput).findInput();
     if (!wrappedName) {
       fail();
     }
-    wrappedName.setInputValue("a name");
+    wrappedName.setInputValue('a name');
 
     const descriptionInput = screen.getByTestId('input-description');
     const wrappedDescription = wrapper(descriptionInput).findTextarea();
     if (!wrappedDescription) {
       fail();
     }
-    wrappedDescription.setTextareaValue("a description");
+    wrappedDescription.setTextareaValue('a description');
 
     const form = screen.getByTestId('create-case-form');
     fireEvent.submit(form);

--- a/source/dea-ui/ui/src/components/case-details/CaseFilesTable.tsx
+++ b/source/dea-ui/ui/src/components/case-details/CaseFilesTable.tsx
@@ -99,7 +99,7 @@ function CaseFilesTable(props: CaseDetailsBodyProps): JSX.Element {
       <Box padding={{ left: 'm' }} data-testid={`${caseFile.fileName}-box`}>
         <SpaceBetween direction="horizontal" size="xs" key={caseFile.fileName}>
           <Icon name="file" />
-          {caseFile.fileName}
+          <span>{caseFile.fileName}</span>
         </SpaceBetween>
       </Box>
     );
@@ -128,7 +128,7 @@ function CaseFilesTable(props: CaseDetailsBodyProps): JSX.Element {
       }
     >
       <SpaceBetween direction="horizontal" size="xs">
-        {filesListLabels.caseFilesLabel}
+        <span>{filesListLabels.caseFilesLabel}</span>
         <BreadcrumbGroup
           data-testid="file-breadcrumb"
           onClick={(event) => {

--- a/source/dea-ui/ui/src/components/case-details/ManageAccessList.tsx
+++ b/source/dea-ui/ui/src/components/case-details/ManageAccessList.tsx
@@ -20,7 +20,7 @@ function ManageAccessList(props: ManageAccessListProps): JSX.Element {
   return (
     <SpaceBetween size="s">
       <Header variant="h3">{manageCaseAccessLabels.manageCasePeopleAccessLabel}</Header>
-      <ColumnLayout borders="horizontal" columns={1}>
+      <ColumnLayout borders="horizontal" columns={1} key="something">
         {caseMembers.map((caseMember) => (
           <ManageAccessListItem
             key={caseMember.userUlid}

--- a/source/dea-ui/ui/src/components/case-details/ManageAccessListItem.tsx
+++ b/source/dea-ui/ui/src/components/case-details/ManageAccessListItem.tsx
@@ -52,7 +52,10 @@ function ManageAccessListItem(props: ManageAccessListItemProps): JSX.Element {
   }
 
   return (
-    <Grid gridDefinition={[{ colspan: { default: 12, xs: 10 } }, { colspan: { default: 12, xs: 2 } }]}>
+    <Grid
+      key={caseMember.userUlid}
+      gridDefinition={[{ colspan: { default: 12, xs: 10 } }, { colspan: { default: 12, xs: 2 } }]}
+    >
       <ColumnLayout columns={2}>
         <FormField label={`${caseMember.userFirstName} ${caseMember.userLastName}`}>
           <TextContent>

--- a/source/dea-ui/ui/src/components/case-list-table/CaseTable.tsx
+++ b/source/dea-ui/ui/src/components/case-list-table/CaseTable.tsx
@@ -96,14 +96,6 @@ function CaseTable(): JSX.Element {
           sortingField: 'name',
         },
         {
-          id: 'caseLead',
-          header: commonTableLabels.caseLeadHeader,
-          cell: () => 'Sherlock Holmes',
-          width: 300,
-          minWidth: 190,
-          sortingField: 'caseLead',
-        },
-        {
           id: 'objectCount',
           header: commonTableLabels.objectCounterHeader,
           cell: (e) => e.objectCount,

--- a/source/dea-ui/ui/src/components/case-list-table/caseListDefinitions.tsx
+++ b/source/dea-ui/ui/src/components/case-list-table/caseListDefinitions.tsx
@@ -14,12 +14,6 @@ export const filteringProperties: readonly PropertyFilterProperty[] = [
     groupValuesLabel: 'Case Name Values',
   },
   {
-    key: 'caseLead',
-    operators: ['=', '!=', ':', '!:'],
-    propertyLabel: 'Case Lead',
-    groupValuesLabel: 'Case Lead Values',
-  },
-  {
     key: 'created',
     operators: ['<', '<=', '>', '>=', ':'],
     propertyLabel: 'Creation Date',

--- a/source/dea-ui/ui/src/components/create-case/CreateCasesForm.tsx
+++ b/source/dea-ui/ui/src/components/create-case/CreateCasesForm.tsx
@@ -4,15 +4,14 @@
  */
 
 import {
-  Form,
-  SpaceBetween,
   Button,
-  Header,
   Container,
-  Input,
+  Form,
   FormField,
+  Header,
+  Input,
+  SpaceBetween,
   Textarea,
-  RadioGroup,
   TextContent,
 } from '@cloudscape-design/components';
 import { useRouter } from 'next/router';
@@ -21,10 +20,8 @@ import { useState } from 'react';
 import { createCase } from '../../api/cases';
 import { commonLabels, createCaseLabels } from '../../common/labels';
 import { CreateCaseForm } from '../../models/Cases';
-import CreateCaseShareCaseForm from './CreateCaseShareCaseForm';
 
 function CreateCasesForm(): JSX.Element {
-  const [caseStatusValue, setCaseStatusValue] = React.useState('active');
   const [, setIsSubmitLoading] = useState(false);
   const router = useRouter();
   const [formData, setFormData] = useState<CreateCaseForm>({ name: '' });
@@ -35,14 +32,12 @@ function CreateCasesForm(): JSX.Element {
       await createCase(formData);
     } finally {
       setIsSubmitLoading(false);
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      router.push('/');
+      void router.push('/');
     }
   }
 
   function onCancelHandler() {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    router.push('/');
+    void router.push('/');
   }
 
   return (
@@ -80,32 +75,10 @@ function CreateCasesForm(): JSX.Element {
                   }}
                 />
               </FormField>
-              <TextContent>
-                <p>
-                  <strong>{createCaseLabels.caseStatusLabel}</strong>
-                </p>
-              </TextContent>
-              <RadioGroup
-                onChange={({ detail }) => setCaseStatusValue(detail.value)}
-                value={caseStatusValue}
-                items={[
-                  {
-                    value: 'active',
-                    label: `${createCaseLabels.activeLabel}`,
-                    description: `${createCaseLabels.activeCaseDescription}`,
-                  },
-                  {
-                    value: 'archive',
-                    label: `${createCaseLabels.archivedLabel}`,
-                    description: `${createCaseLabels.archivedCaseDescription}`,
-                  },
-                ]}
-              />
             </SpaceBetween>
           </Container>
         </Form>
       </form>
-      <CreateCaseShareCaseForm></CreateCaseShareCaseForm>
       <SpaceBetween direction="horizontal" size="xs">
         <Button formAction="none" variant="link" data-testid="create-case-cancel" onClick={onCancelHandler}>
           {commonLabels.cancelButton}

--- a/source/dea-ui/ui/src/components/upload-files/UploadFilesForm.tsx
+++ b/source/dea-ui/ui/src/components/upload-files/UploadFilesForm.tsx
@@ -136,7 +136,7 @@ function UploadFilesForm(props: UploadFilesProps): JSX.Element {
           <Box>
             <SpaceBetween direction="horizontal" size="xs" key={uploadProgress.fileName}>
               <Spinner />
-              {uploadProgress.status}
+              <span>{uploadProgress.status}</span>
             </SpaceBetween>
           </Box>
         );
@@ -146,7 +146,7 @@ function UploadFilesForm(props: UploadFilesProps): JSX.Element {
           <Box>
             <SpaceBetween direction="horizontal" size="xs" key={uploadProgress.fileName}>
               <Icon name="status-negative" variant="error" />
-              {uploadProgress.status}
+              <span>{uploadProgress.status}</span>
             </SpaceBetween>
           </Box>
         );
@@ -156,7 +156,7 @@ function UploadFilesForm(props: UploadFilesProps): JSX.Element {
           <Box>
             <SpaceBetween direction="horizontal" size="xs" key={uploadProgress.fileName}>
               <Icon name="check" variant="success" />
-              {uploadProgress.status}
+              <span> {uploadProgress.status}</span>
             </SpaceBetween>
           </Box>
         );
@@ -166,7 +166,7 @@ function UploadFilesForm(props: UploadFilesProps): JSX.Element {
           <Box>
             <SpaceBetween direction="horizontal" size="xs" key={uploadProgress.fileName}>
               <Icon name="file" />
-              {uploadProgress.status}
+              <span>{uploadProgress.status}</span>
             </SpaceBetween>
           </Box>
         );

--- a/source/dea-ui/ui/src/context/NotificationsContext.tsx
+++ b/source/dea-ui/ui/src/context/NotificationsContext.tsx
@@ -35,6 +35,7 @@ export function NotificationsProvider({ children }: { children: React.ReactNode 
   function pushNotification(type: FlashbarProps.Type, content: string): void {
     setNotifications([...notifications, { id: uuidv4(), type, content }]);
   }
+
   function dismissNotification(id: string): void {
     setNotifications((notifications) => notifications.filter((notifications) => notifications.id !== id));
   }


### PR DESCRIPTION
- remove unused Case Lead references
- remove share case component on case creation
- clean up some render warnings: per https://polaris.a2z.com/components/space-between/?tabId=api
`This component only supports element children (components or HTML elements). Primitive values will cause [React's missing key warning. ](https://reactjs.org/docs/lists-and-keys.html#keys) If you want to put a string or a number as a direct child, wrap it into a <span>.`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
