### PR TITLE
feat(UI): show/hide CaseMembers tab component

### DIFF
--- a/source/dea-app/src/test-e2e/resources/case-membership.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/case-membership.e2e.test.ts
@@ -98,6 +98,16 @@ describe('CaseMembership E2E', () => {
     );
     expect(inviteResponse.status).toEqual(200);
 
+    //confirm duplicate invites throw 400 - Bad Request
+    const duplicateInviteResponse = await callDeaAPIWithCreds(
+      `${deaApiUrl}cases/${targetCase.ulid}/userMemberships`,
+      'POST',
+      ownerToken,
+      ownerCreds,
+      newMembership
+    );
+    expect(duplicateInviteResponse.status).toEqual(400);
+
     // confirm owner and invitee are returned in the membership list.
     const membershipListResponse = await callDeaAPIWithCreds(
       `${deaApiUrl}cases/${targetCase.ulid}/userMemberships`,

--- a/source/dea-ui/ui/README.md
+++ b/source/dea-ui/ui/README.md
@@ -8,7 +8,7 @@ This is a prototype app and you should expect to modify the source code to refle
 
 | Statements                                                                                   | Branches                                                                                 | Functions                                                                                  | Lines                                                                              |
 | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-94.14%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-86.44%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-92.59%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-94.41%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-93.15%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-87.5%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.46%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.41%25-brightgreen.svg?style=flat) |
 
 
 ## Deploying code changes

--- a/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { fail } from 'assert';
 import axios from 'axios';
+import { delay } from '../../src/api/cases';
 import { auditLogLabels, caseDetailLabels, commonLabels } from '../../src/common/labels';
 import { NotificationsProvider } from '../../src/context/NotificationsContext';
 import CaseDetailsPage from '../../src/pages/case-detail';
@@ -96,6 +97,25 @@ const mockedCaseDetail = {
   status: 'ACTIVE',
 };
 
+const mockedCaseActions = {
+  caseUlid: '01GW7HY47X74PSW7QNHZX7EE0H',
+  userUlid: '01GW5N0SKHSXDBMFBKMDB82TAQ',
+  userFirstName: 'John',
+  userLastName: 'Doe',
+  caseName: 'Investigation One',
+  actions: [
+    'VIEW_CASE_DETAILS',
+    'UPDATE_CASE_DETAILS',
+    'UPLOAD',
+    'DOWNLOAD',
+    'VIEW_FILES',
+    'CASE_AUDIT',
+    'INVITE',
+  ],
+  created: '2023-03-23T15:38:26.955Z',
+  updated: '2023-03-23T15:38:26.955Z',
+};
+
 const mockedUsers = {
   users: [
     {
@@ -144,6 +164,14 @@ describe('CaseDetailsPage', () => {
       if (eventObj.url === 'https://localhostcases/100/details') {
         return Promise.resolve({
           data: mockedCaseDetail,
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      } else if (eventObj.url === 'https://localhostcases/100/actions') {
+        return Promise.resolve({
+          data: mockedCaseActions,
           status: 200,
           statusText: 'Ok',
           headers: {},
@@ -228,6 +256,14 @@ describe('CaseDetailsPage', () => {
       if (eventObj.url === `https://localhostcases/${CASE_ID}/details`) {
         return Promise.resolve({
           data: mockedCaseDetail,
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      } else if (eventObj.url === 'https://localhostcases/100/actions') {
+        return Promise.resolve({
+          data: mockedCaseActions,
           status: 200,
           statusText: 'Ok',
           headers: {},
@@ -331,19 +367,32 @@ describe('CaseDetailsPage', () => {
 
     //assert notifications
     const notificationsWrapper = wrapper(page.container).findFlashbar()!;
-    expect(notificationsWrapper).toBeTruthy();
     notificationsWrapper.findItems()[0].findDismissButton()!.click();
+    await delay(100);
+    expect(notificationsWrapper).toBeTruthy();
   });
 
   it('navigates to upload files page', async () => {
-    mockedAxios.mockResolvedValue({
-      data: mockedCaseDetail,
-      status: 200,
-      statusText: 'Ok',
-      headers: {},
-      config: {},
+    mockedAxios.mockImplementation((event) => {
+      const eventObj: any = event;
+      if (eventObj.url === 'https://localhostcases/100/actions') {
+        return Promise.resolve({
+          data: mockedCaseActions,
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      } else {
+        return Promise.resolve({
+          data: mockedCaseDetail,
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      }
     });
-
     const page = render(<CaseDetailsPage />);
     expect(page).toBeTruthy();
 
@@ -353,7 +402,7 @@ describe('CaseDetailsPage', () => {
   });
 
   it('downloads selected files', async () => {
-    mockedAxios.mockImplementation((event) => {
+    mockedAxios.mockImplementation(async (event) => {
       const eventObj: any = event;
       if (eventObj.url === 'https://localhostcases/100/details') {
         return Promise.resolve({
@@ -363,7 +412,16 @@ describe('CaseDetailsPage', () => {
           headers: {},
           config: {},
         });
+      } else if (eventObj.url === 'https://localhostcases/100/actions') {
+        return Promise.resolve({
+          data: mockedCaseActions,
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
       } else {
+        await delay(100);
         return Promise.resolve({
           data: mockFilesRoot,
           status: 200,
@@ -401,6 +459,14 @@ describe('CaseDetailsPage', () => {
       if (eventObj.url === 'https://localhostcases/100/details') {
         return Promise.resolve({
           data: mockedCaseDetail,
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      } else if (eventObj.url === 'https://localhostcases/100/actions') {
+        return Promise.resolve({
+          data: mockedCaseActions,
           status: 200,
           statusText: 'Ok',
           headers: {},
@@ -454,6 +520,14 @@ describe('CaseDetailsPage', () => {
       if (eventObj.url === 'https://localhostcases/100/details') {
         return Promise.resolve({
           data: mockedCaseDetail,
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      } else if (eventObj.url === 'https://localhostcases/100/actions') {
+        return Promise.resolve({
+          data: mockedCaseActions,
           status: 200,
           statusText: 'Ok',
           headers: {},

--- a/source/dea-ui/ui/src/api/cases.tsx
+++ b/source/dea-ui/ui/src/api/cases.tsx
@@ -141,6 +141,11 @@ export const retrieveCaseAuditResult = async (caseId: string, auditId: string): 
   return await httpApiGet(`cases/${caseId}/audit/${auditId}/csv`, undefined);
 }
 
-function delay(ms: number) {
+export function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export const useGetCaseActions = (id: string): DeaSingleResult<CaseUser | undefined> => {
+  const { data, isValidating } = useSWR(() => `cases/${id}/actions`, httpApiGet<CaseUser>);
+  return { data, isLoading: isValidating };
+};

--- a/source/dea-ui/ui/src/common/labels.tsx
+++ b/source/dea-ui/ui/src/common/labels.tsx
@@ -178,44 +178,37 @@ export const caseActionOptions = {
         return {
           value: CaseAction.UPDATE_CASE_DETAILS,
           label: 'Edit case',
-          description: 'They will be able to edit case details, such as name and description',
         };
       case CaseAction.UPLOAD:
         return {
           value: CaseAction.UPLOAD,
           label: 'Upload files',
-          description: 'They will be able to upload files to the case',
         };
       case CaseAction.DOWNLOAD:
         return {
           value: CaseAction.DOWNLOAD,
           label: 'Download files',
-          description: 'They will be able to download files to the case',
         };
       case CaseAction.VIEW_FILES:
         return {
           value: CaseAction.VIEW_FILES,
           label: 'View case files',
-          description: 'They will be able to preview case files and details',
         };
       case CaseAction.CASE_AUDIT:
         return {
           value: CaseAction.CASE_AUDIT,
           label: 'Audit case',
-          description: 'They will be able to audit the activity performed on a case',
         };
       case CaseAction.INVITE:
         return {
           value: CaseAction.INVITE,
           label: 'Invite members',
-          description: 'They will be able to invite other members to the case',
         };
       default:
         // default CaseAction.VIEW_CASE_DETAILS least privilege principle.
         return {
           value: CaseAction.VIEW_CASE_DETAILS,
           label: 'View case',
-          description: 'They will be able to view case details',
         };
     }
   },

--- a/source/dea-ui/ui/src/components/case-details/CaseDetailsTabs.tsx
+++ b/source/dea-ui/ui/src/components/case-details/CaseDetailsTabs.tsx
@@ -3,31 +3,45 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
+import { CaseAction } from '@aws/dea-app/lib/models/case-action';
 import { Tabs } from '@cloudscape-design/components';
-import * as React from 'react';
+import { useMemo, useState } from 'react';
+import { useGetCaseActions } from '../../api/cases';
 import { caseDetailLabels } from '../../common/labels';
 import { CaseDetailsBodyProps } from './CaseDetailsBody';
 import CaseFilesTable from './CaseFilesTable';
 import ManageAccessForm from './ManageAccessForm';
 
 function CaseDetailsTabs(props: CaseDetailsBodyProps): JSX.Element {
-  return (
-    <Tabs
-      data-testid="case-details-tabs"
-      tabs={[
-        {
-          label: caseDetailLabels.caseFilesLabel,
-          id: 'caseFiles',
-          content: <CaseFilesTable caseId={props.caseId}></CaseFilesTable>,
-        },
-        {
-          label: caseDetailLabels.manageAccessLabel,
-          id: 'caseAccess',
-          content: <ManageAccessForm caseId={props.caseId}></ManageAccessForm>,
-        },
-      ]}
-    />
+  const { data } = useGetCaseActions(props.caseId);
+  const [tabs, setTabs] = useState([
+    {
+      label: caseDetailLabels.caseFilesLabel,
+      id: 'caseFiles',
+      content: <CaseFilesTable caseId={props.caseId}></CaseFilesTable>,
+    },
+  ]);
+  useMemo(
+    () => {
+      if (!data) {
+        // do nothing.
+        return;
+      }
+      if (data.actions.find((action) => action === CaseAction.INVITE)) {
+        setTabs([
+          ...tabs,
+          {
+            label: caseDetailLabels.manageAccessLabel,
+            id: 'caseAccess',
+            content: <ManageAccessForm caseId={props.caseId}></ManageAccessForm>,
+          },
+        ]);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [data]
   );
+  return <Tabs data-testid="case-details-tabs" tabs={tabs} />;
 }
 
 export default CaseDetailsTabs;

--- a/source/dea-ui/ui/src/components/case-details/ManageAccessList.tsx
+++ b/source/dea-ui/ui/src/components/case-details/ManageAccessList.tsx
@@ -23,7 +23,7 @@ function ManageAccessList(props: ManageAccessListProps): JSX.Element {
       <ColumnLayout borders="horizontal" columns={1} key="something">
         {caseMembers.map((caseMember) => (
           <ManageAccessListItem
-            key={caseMember.userUlid}
+            key={`${caseMember.caseUlid}-${caseMember.userUlid}`}
             caseMember={caseMember}
             onUpdateMember={(member: CaseUser) => onUpdateMember(member)}
             onRemoveMember={(member: CaseUser) => onRemoveMember(member)}


### PR DESCRIPTION
*Description of changes:*
* `UI`: `Case Members` tab rendering depending on the user's permissions.
* `Api`: new validation on `POST /cases/{caseId}/userMemberships` to enforce a user is being added only once to the case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
