### PR TITLE
feat(UI): add a confirm modal when removing a member from the case access list

### DIFF
--- a/source/dea-ui/ui/README.md
+++ b/source/dea-ui/ui/README.md
@@ -8,7 +8,7 @@ This is a prototype app and you should expect to modify the source code to refle
 
 | Statements                                                                                   | Branches                                                                                 | Functions                                                                                  | Lines                                                                              |
 | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-93.48%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-87.21%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.23%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.75%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-93.04%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-88.96%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.15%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.07%25-brightgreen.svg?style=flat) |
 
 
 ## Deploying code changes

--- a/source/dea-ui/ui/src/common/labels.tsx
+++ b/source/dea-ui/ui/src/common/labels.tsx
@@ -23,6 +23,7 @@ export const commonLabels = {
   dismissMessageLabel: 'Dismiss message',
   description: 'Description',
   creationDate: 'Creation Date',
+  closeModalAriaLabel: 'Close modal',
 };
 
 export const commonTableLabels = {
@@ -144,6 +145,9 @@ export const manageCaseAccessLabels = {
   addCaseMemberFailMessage: (user: string) => `${user} has not been invited to the case.`,
   removeCaseMemberSuccessMessage: (user: string) => `${user} has been removed successfully.`,
   removeCaseMemberFailMessage: (user: string) => `${user} has not been removed.`,
+  removeCaseMemberRequestTitle: (user: string) => `Remove ${user}?`,
+  removeCaseMemberRequestMessage:
+    'There access will be instantly removed and they will be notified by email.',
 };
 
 export const createCaseLabels = {

--- a/source/dea-ui/ui/src/components/case-details/ManageAccessListItem.tsx
+++ b/source/dea-ui/ui/src/components/case-details/ManageAccessListItem.tsx
@@ -18,6 +18,7 @@ import {
 import { useMemo, useState } from 'react';
 import { caseActionOptions, commonLabels, manageCaseAccessLabels } from '../../common/labels';
 import styles from '../../styles/ManageAccessListItem.module.scss';
+import { ConfirmModal } from '../common-components/ConfirmModal';
 
 export interface ManageAccessListItemProps {
   readonly caseMember: CaseUser;
@@ -31,6 +32,7 @@ function ManageAccessListItem(props: ManageAccessListItemProps): JSX.Element {
   const [selectedOptions, setSelectedOptions] = useState<ReadonlyArray<SelectProps.Option>>(
     caseMember.actions.map((action) => caseActionOptions.actionOption(action))
   );
+  const [isOpenRemoveModal, setIsOpenRemoveModal] = useState(false);
   const [isRemoving, setIsRemoving] = useState(false);
   const [isDisabled, setIsDisabled] = useState(false);
   useMemo(() => {
@@ -50,6 +52,7 @@ function ManageAccessListItem(props: ManageAccessListItemProps): JSX.Element {
   }
 
   async function removeCaseMemberHandler() {
+    setIsOpenRemoveModal(false);
     try {
       setIsRemoving(true);
       await onRemoveMember(caseMember);
@@ -83,9 +86,19 @@ function ManageAccessListItem(props: ManageAccessListItemProps): JSX.Element {
         </FormField>
       </ColumnLayout>
       <div className={styles['button-container']}>
+        <ConfirmModal
+          isOpen={isOpenRemoveModal}
+          title={manageCaseAccessLabels.removeCaseMemberRequestTitle(
+            `${caseMember.userFirstName} ${caseMember.userLastName}`
+          )}
+          message={manageCaseAccessLabels.removeCaseMemberRequestMessage}
+          confirmButtonText={commonLabels.removeButton}
+          confirmAction={removeCaseMemberHandler}
+          cancelAction={() => setIsOpenRemoveModal(false)}
+        />
         <Button
           data-testid={`${caseMember.userUlid}-remove-button`}
-          onClick={removeCaseMemberHandler}
+          onClick={() => setIsOpenRemoveModal(true)}
           disabled={isDisabled}
         >
           {commonLabels.removeButton}

--- a/source/dea-ui/ui/src/components/common-components/ConfirmModal.tsx
+++ b/source/dea-ui/ui/src/components/common-components/ConfirmModal.tsx
@@ -1,0 +1,46 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Modal from '@cloudscape-design/components/modal';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import { commonLabels } from '../../common/labels';
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  confirmAction: () => void;
+  confirmButtonText: string;
+  cancelAction: () => void;
+  cancelButtonText?: string;
+}
+
+export function ConfirmModal(props: ConfirmModalProps) {
+  const { isOpen, title, message, cancelAction, cancelButtonText, confirmAction, confirmButtonText } = props;
+  return (
+    <Modal
+      onDismiss={cancelAction}
+      visible={isOpen}
+      closeAriaLabel={commonLabels.closeModalAriaLabel}
+      footer={
+        <Box float="right">
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button variant="link" onClick={cancelAction}>
+              {cancelButtonText ?? commonLabels.cancelButton}
+            </Button>
+            <Button variant="primary" onClick={confirmAction}>
+              {confirmButtonText}
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+      header={title}
+    >
+      {message}
+    </Modal>
+  );
+}


### PR DESCRIPTION
*Description of changes:*

`UI`: add a confirm modal when removing a member from the case access list


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
