### PR TITLE
chore(dea-ui): run https proxy in background and rushx dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ At this point you can run an https proxy for localhost.
 > In dea-ui/ui
 
 ```sh
-rushx httpsproxy
+rushx dev:https
 ```
 
 Now `https://localhost:3001` will proxy requests to `localhost:3000`
 
-Keep the proxy running in a separate tab or process, and then run `rushx dev` as you normally would. use `https://localhost:3001/{stage}/ui` to access the front end
+The proxy will launch the applicacion in backgound and there is no need to run `rushx dev` as you normally would. use `https://localhost:3001/{stage}/ui` to access the front end
 
 ---
 ## CDK Policy Customization

--- a/source/dea-ui/ui/README.md
+++ b/source/dea-ui/ui/README.md
@@ -18,7 +18,7 @@ Navigate to DEA root directory and follow instructions in [README](../../../READ
 
 First, run the https proxy so your cookies will work:
 ```sh
-rushx httpsproxy
+rushx dev:https
 ```
 In a separate tab or process, run the development server:
 

--- a/source/dea-ui/ui/package.json
+++ b/source/dea-ui/ui/package.json
@@ -24,7 +24,7 @@
     "cypress:e2e": ". ../../common/scripts/setEnv.sh && cypress run --config baseUrl=${DEA_API_URL}ui",
     "cypress:headless": "cypress run",
     "cypress:test": "start-server-and-test start http-get://localhost:3000/${STAGE}/ui cypress:headless",
-    "httpsproxy": "(local-ssl-proxy --key localhost-key.pem --cert localhost.pem --source 3001 --target 3000 &) && rushx dev",
+    "dev:https": "(local-ssl-proxy --key localhost-key.pem --cert localhost.pem --source 3001 --target 3000 &) && rushx dev",
     "dev": ". ../../common/scripts/setEnv.sh && ./setNextEnv.sh && next dev",
     "e2e:only": "jest --ci --coverage '.*/*e2e.test.*'",
     "export": "next build && next export",


### PR DESCRIPTION
Runs https proxy in background and rushx dev in the foreground

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
