### PR TITLE
feat: add apis to start and retrieve user audit logs

### DIFF
--- a/source/common/config/chewbacca.json
+++ b/source/common/config/chewbacca.json
@@ -231,6 +231,14 @@
         {
           "path": "/cases/{caseId}/owner",
           "method": "POST"
+        },
+        {
+          "path": "/users/{userId}/audit",
+          "method": "POST"
+        },
+        {
+          "path": "/users/{userId}/audit/{auditId}/csv",
+          "method": "GET"
         }
       ]
     },
@@ -289,6 +297,14 @@
         {
           "path": "/cases/{caseId}/owner",
           "method": "POST"
+        },
+        {
+          "path": "/users/{userId}/audit",
+          "method": "POST"
+        },
+        {
+          "path": "/users/{userId}/audit/{auditId}/csv",
+          "method": "GET"
         }
       ]
     },

--- a/source/dea-app/README.md
+++ b/source/dea-app/README.md
@@ -5,6 +5,6 @@
 
 | Statements                                                                         | Branches                                                                      | Functions                                                                        | Lines                                                                   |
 | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-98.39%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-87.98%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-98.23%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-98.43%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-88.11%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-98.27%25-brightgreen.svg?style=flat) |
 
 This project is the routing package for `dea-backend`. It is used by `dea-backend` to generate routes for DEA API. Please refer [here](../dea-backend/README.md) for more information on how to use this project.

--- a/source/dea-app/src/app/resources/get-user-audit.ts
+++ b/source/dea-app/src/app/resources/get-user-audit.ts
@@ -1,0 +1,34 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getRequiredPathParam } from '../../lambda-http-helpers';
+import { joiUuid } from '../../models/validation/joi-common';
+import { defaultProvider } from '../../persistence/schema/entities';
+import { defaultDatasetsProvider } from '../../storage/datasets';
+import { defaultCloudwatchClient } from '../audit/dea-audit-plugin';
+import { auditService } from '../services/audit-service';
+import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { csvResponse, responseOk } from './dea-lambda-utils';
+
+export const getUserAudit: DEAGatewayProxyHandler = async (
+  event,
+  context,
+  /* the default case is handled in e2e tests */
+  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _repositoryProvider = defaultProvider,
+  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _datasetsProvider = defaultDatasetsProvider,
+  /* istanbul ignore next */
+  cloudwatchClient = defaultCloudwatchClient
+) => {
+  const auditId = getRequiredPathParam(event, 'auditId', joiUuid);
+  const result = await auditService.getAuditResult(auditId, cloudwatchClient);
+
+  if (result.csvFormattedData) {
+    return csvResponse(event, result.csvFormattedData);
+  } else {
+    return responseOk(event, result);
+  }
+};

--- a/source/dea-app/src/app/resources/start-user-audit.ts
+++ b/source/dea-app/src/app/resources/start-user-audit.ts
@@ -1,0 +1,36 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import Joi from 'joi';
+import { getQueryParam, getRequiredPathParam } from '../../lambda-http-helpers';
+import { joiUlid } from '../../models/validation/joi-common';
+import { defaultProvider } from '../../persistence/schema/entities';
+import { defaultDatasetsProvider } from '../../storage/datasets';
+import { defaultCloudwatchClient } from '../audit/dea-audit-plugin';
+import { auditService } from '../services/audit-service';
+import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
+
+export const startUserAudit: DEAGatewayProxyHandler = async (
+  event,
+  context,
+  /* the default case is handled in e2e tests */
+  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _repositoryProvider = defaultProvider,
+  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _datasetsProvider = defaultDatasetsProvider,
+  /* istanbul ignore next */
+  cloudwatchClient = defaultCloudwatchClient
+) => {
+  const now = Date.now();
+  const userId = getRequiredPathParam(event, 'userId', joiUlid);
+  const start = getQueryParam(event, 'from', '0', Joi.number().integer());
+  const end = getQueryParam(event, 'to', now.toString(), Joi.number().integer());
+  const startTime = Number.parseInt(start);
+  const endTime = Number.parseInt(end);
+  const queryId = await auditService.requestAuditForUser(userId, startTime, endTime, cloudwatchClient);
+
+  return responseOk(event, { auditId: queryId });
+};

--- a/source/dea-app/src/index.ts
+++ b/source/dea-app/src/index.ts
@@ -3,13 +3,13 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { ForbiddenError, FORBIDDEN_ERROR_NAME } from './app/exceptions/forbidden-exception';
-import { NotFoundError, NOT_FOUND_ERROR_NAME } from './app/exceptions/not-found-exception';
+import { FORBIDDEN_ERROR_NAME, ForbiddenError } from './app/exceptions/forbidden-exception';
+import { NOT_FOUND_ERROR_NAME, NotFoundError } from './app/exceptions/not-found-exception';
 import {
-  ReauthenticationError,
   REAUTHENTICATION_ERROR_NAME,
+  ReauthenticationError,
 } from './app/exceptions/reauthentication-exception';
-import { ValidationError, VALIDATION_ERROR_NAME } from './app/exceptions/validation-exception';
+import { VALIDATION_ERROR_NAME, ValidationError } from './app/exceptions/validation-exception';
 import { completeCaseFileUpload } from './app/resources/complete-case-file-upload';
 import { createCaseMembership } from './app/resources/create-case-membership';
 import { createCases } from './app/resources/create-cases';
@@ -30,12 +30,14 @@ import { getLogoutUrl } from './app/resources/get-logout-url';
 import { getMyCases } from './app/resources/get-my-cases';
 import { getScopedCaseInformation } from './app/resources/get-scoped-case-information';
 import { getToken } from './app/resources/get-token';
+import { getUserAudit } from './app/resources/get-user-audit';
 import { getUsers } from './app/resources/get-users';
 import { initiateCaseFileUpload } from './app/resources/initiate-case-file-upload';
 import { listCaseFiles } from './app/resources/list-case-files';
 import { refreshToken } from './app/resources/refresh-token';
 import { revokeToken } from './app/resources/revoke-token';
 import { startCaseAudit } from './app/resources/start-case-audit';
+import { startUserAudit } from './app/resources/start-user-audit';
 import { updateCaseMembership } from './app/resources/update-case-membership';
 import { updateCaseStatus } from './app/resources/update-case-status';
 import { updateCases } from './app/resources/update-cases';
@@ -94,6 +96,8 @@ export {
   getTestAuditService,
   getDummyEvent,
   getAvailableEndpointsForUser,
+  startUserAudit,
+  getUserAudit,
   CaseAction,
   DeaCase,
   DeaCaseFile,

--- a/source/dea-app/src/test-e2e/resources/user-audit.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/user-audit.e2e.test.ts
@@ -1,0 +1,167 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Credentials } from 'aws4-axios';
+import Joi from 'joi';
+import { AuditEventType } from '../../app/services/audit-service';
+import { Oauth2Token } from '../../models/auth';
+import { joiUuid } from '../../models/validation/joi-common';
+import CognitoHelper from '../helpers/cognito-helper';
+import { testEnv } from '../helpers/settings';
+import {
+  callDeaAPIWithCreds,
+  createCaseSuccess,
+  deleteCase,
+  getSpecificUserByFirstName,
+  randomSuffix,
+} from './test-helpers';
+
+describe('user audit e2e', () => {
+  const cognitoHelper = new CognitoHelper();
+
+  const suffix = randomSuffix(5);
+  const testUser = `userAuditTestUser${suffix}`;
+  const testManager = `userAuditTestManager${suffix}`;
+  const deaApiUrl = testEnv.apiUrlOutput;
+  let creds: Credentials;
+  let idToken: Oauth2Token;
+  let userUlid: string;
+  let managerCreds: Credentials;
+  let managerIdToken: Oauth2Token;
+
+  const caseIdsToDelete: string[] = [];
+
+  beforeAll(async () => {
+    // Create manager
+    await cognitoHelper.createUser(testManager, 'WorkingManager', testManager, 'TestManager');
+    [managerCreds, managerIdToken] = await cognitoHelper.getCredentialsForUser(testManager);
+
+    // Create worker
+    await cognitoHelper.createUser(testUser, 'CaseWorker', testUser, 'TestUser');
+    [creds, idToken] = await cognitoHelper.getCredentialsForUser(testUser);
+
+    // initialize the user into the DB
+    await callDeaAPIWithCreds(`${deaApiUrl}cases/my-cases`, 'GET', idToken, creds);
+    // get the user ulid
+    userUlid = (await getSpecificUserByFirstName(deaApiUrl, testUser, managerIdToken, managerCreds)).ulid;
+  }, 10000);
+
+  afterAll(async () => {
+    for (const caseId of caseIdsToDelete) {
+      await deleteCase(deaApiUrl, caseId, idToken, creds);
+    }
+    await cognitoHelper.cleanup();
+  }, 30000);
+
+  it('retrieves actions taken against a user', async () => {
+    const caseName = `auditTestCase${randomSuffix()}`;
+    const createdCase = await createCaseSuccess(
+      deaApiUrl,
+      {
+        name: caseName,
+        description: 'this is a description',
+      },
+      idToken,
+      creds
+    );
+    const caseUlid = createdCase.ulid ?? fail();
+    caseIdsToDelete.push(caseUlid);
+
+    const updateResponse = await callDeaAPIWithCreds(
+      `${deaApiUrl}cases/${caseUlid}/details`,
+      'PUT',
+      idToken,
+      creds,
+      {
+        ulid: caseUlid,
+        name: caseName,
+        description: 'An updated description',
+      }
+    );
+    expect(updateResponse.status).toEqual(200);
+
+    const getResponse = await callDeaAPIWithCreds(
+      `${deaApiUrl}cases/${caseUlid}/details`,
+      'GET',
+      idToken,
+      creds
+    );
+    expect(getResponse.status).toEqual(200);
+
+    const membershipsResponse = await callDeaAPIWithCreds(
+      `${deaApiUrl}cases/${caseUlid}/userMemberships`,
+      'GET',
+      idToken,
+      creds
+    );
+    expect(membershipsResponse.status).toEqual(200);
+
+    // allow some time so the events show up in CW logs
+    await delay(25000);
+
+    let csvData: string | undefined;
+    const queryRetries = 5;
+    while (!csvData && queryRetries > 0) {
+      const startAuditQueryResponse = await callDeaAPIWithCreds(
+        `${deaApiUrl}users/${userUlid}/audit`,
+        'POST',
+        managerIdToken,
+        managerCreds
+      );
+
+      expect(startAuditQueryResponse.status).toEqual(200);
+      const auditId: string = startAuditQueryResponse.data.auditId;
+      Joi.assert(auditId, joiUuid);
+
+      let retries = 5;
+      let getQueryReponse = await callDeaAPIWithCreds(
+        `${deaApiUrl}users/${userUlid}/audit/${auditId}/csv`,
+        'GET',
+        managerIdToken,
+        managerCreds
+      );
+      while (getQueryReponse.data.status && retries > 0) {
+        if (getQueryReponse.data.status === 'Complete') {
+          break;
+        }
+        --retries;
+        if (getQueryReponse.status !== 200) {
+          fail();
+        }
+        await delay(2000);
+
+        getQueryReponse = await callDeaAPIWithCreds(
+          `${deaApiUrl}users/${userUlid}/audit/${auditId}/csv`,
+          'GET',
+          managerIdToken,
+          managerCreds
+        );
+      }
+
+      const potentialCsvData: string = getQueryReponse.data;
+
+      if (
+        getQueryReponse.data &&
+        !getQueryReponse.data.status &&
+        potentialCsvData.includes(AuditEventType.UPDATE_CASE_DETAILS) &&
+        potentialCsvData.includes(AuditEventType.GET_CASE_DETAILS) &&
+        potentialCsvData.includes(AuditEventType.GET_USERS_FROM_CASE)
+      ) {
+        csvData = getQueryReponse.data;
+      }
+    }
+
+    expect(csvData).toContain('/cases/{caseId}/details');
+    expect(csvData).toContain(testUser);
+    expect(csvData).toContain(caseUlid);
+    expect(csvData).toContain(AuditEventType.GET_CASE_DETAILS);
+    expect(csvData).toContain(AuditEventType.UPDATE_CASE_DETAILS);
+    expect(csvData).toContain(AuditEventType.GET_USERS_FROM_CASE);
+  }, 180000);
+
+  function delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+});

--- a/source/dea-app/src/test/app/resources/get-user-audit.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/get-user-audit.integration.test.ts
@@ -1,0 +1,131 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CloudWatchLogsClient, GetQueryResultsCommand, QueryStatus } from '@aws-sdk/client-cloudwatch-logs';
+import { anyOfClass, anything, instance, mock, when } from 'ts-mockito';
+import { getUserAudit } from '../../../app/resources/get-user-audit';
+import { bogusUlid } from '../../../test-e2e/resources/test-helpers';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
+
+describe('get user audit', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.AUDIT_LOG_GROUP_NAME = 'TESTGROUP';
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('responds with csv data', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anyOfClass(GetQueryResultsCommand))).thenResolve({
+      $metadata: {},
+      status: QueryStatus.Complete,
+      results: [
+        [
+          { field: 'fieldA', value: 'valueA' },
+          { field: 'fieldB', value: 'valueB' },
+        ],
+        [
+          { field: 'fieldA', value: 'valueA2' },
+          { field: 'fieldB', value: 'valueB2' },
+        ],
+      ],
+    });
+
+    const expectedCSV = 'fieldA, fieldB\r\nvalueA, valueB\r\nvalueA2, valueB2\r\n';
+
+    const event = getDummyEvent({
+      pathParameters: {
+        caseId: bogusUlid,
+        auditId: '11111111-1111-1111-1111-111111111111',
+      },
+    });
+    const result = await getUserAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+
+    expect(result.statusCode).toEqual(200);
+    expect(result.body).toEqual(expectedCSV);
+  });
+
+  it('returns status if not complete', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({ $metadata: {}, status: QueryStatus.Running });
+
+    const event = getDummyEvent({
+      pathParameters: {
+        userId: bogusUlid,
+        auditId: '11111111-1111-1111-1111-111111111111',
+      },
+    });
+    const result = await getUserAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    expect(result.statusCode).toEqual(200);
+    const responseBody: { status: string } = JSON.parse(result.body);
+    expect(responseBody.status).toEqual('Running');
+  });
+
+  it('returns complete with no data if data is not returned', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({ $metadata: {}, status: QueryStatus.Complete });
+
+    const event = getDummyEvent({
+      pathParameters: {
+        userId: bogusUlid,
+        auditId: '11111111-1111-1111-1111-111111111111',
+      },
+    });
+    const result = await getUserAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    expect(result.statusCode).toEqual(200);
+    const responseBody: { status: string; csvFormattedData: string } = JSON.parse(result.body);
+    expect(responseBody.status).toEqual('Complete');
+    expect(responseBody.csvFormattedData).toBeUndefined();
+  });
+
+  it('returns complete with no data if data is empty', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({
+      $metadata: {},
+      status: QueryStatus.Complete,
+      results: [],
+    });
+
+    const event = getDummyEvent({
+      pathParameters: {
+        userId: bogusUlid,
+        auditId: '11111111-1111-1111-1111-111111111111',
+      },
+    });
+    const result = await getUserAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    expect(result.statusCode).toEqual(200);
+    const responseBody: { status: string; csvFormattedData: string } = JSON.parse(result.body);
+    expect(responseBody.status).toEqual('Complete');
+    expect(responseBody.csvFormattedData).toBeUndefined();
+  });
+
+  it('returns unknown status if the status is not provided', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({ $metadata: {} });
+
+    const event = getDummyEvent({
+      pathParameters: {
+        userId: bogusUlid,
+        auditId: '11111111-1111-1111-1111-111111111111',
+      },
+    });
+    const result = await getUserAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    expect(result.statusCode).toEqual(200);
+    const responseBody: { status: string; csvFormattedData: string } = JSON.parse(result.body);
+    expect(responseBody.status).toEqual('Unknown');
+    expect(responseBody.csvFormattedData).toBeUndefined();
+  });
+});

--- a/source/dea-app/src/test/app/resources/start-user-audit.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/start-user-audit.integration.test.ts
@@ -1,0 +1,55 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CloudWatchLogsClient } from '@aws-sdk/client-cloudwatch-logs';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { startUserAudit } from '../../../app/resources/start-user-audit';
+import { bogusUlid } from '../../../test-e2e/resources/test-helpers';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
+
+describe('start user audit', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.AUDIT_LOG_GROUP_NAME = 'TESTGROUP';
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('responds with a queryId', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({ $metadata: {}, queryId: 'a_query_id' });
+
+    const event = getDummyEvent({
+      pathParameters: {
+        userId: bogusUlid,
+      },
+    });
+    const result = await startUserAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+
+    expect(result.statusCode).toEqual(200);
+    expect(result.body).toContain('a_query_id');
+  });
+
+  it('throws an error if no queryId is returned', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({ $metadata: {}, queryId: undefined });
+
+    const event = getDummyEvent({
+      pathParameters: {
+        userId: bogusUlid,
+      },
+    });
+    await expect(
+      startUserAudit(event, dummyContext, undefined, undefined, clientMockInstance)
+    ).rejects.toThrow('Unknown error starting Cloudwatch Logs Query.');
+  });
+});

--- a/source/dea-backend/README.md
+++ b/source/dea-backend/README.md
@@ -6,7 +6,7 @@
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-97.94%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-90.36%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.25%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.91%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-96.86%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-90.36%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.25%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-96.82%25-brightgreen.svg?style=flat) |
 
 ## Description
 

--- a/source/dea-backend/src/handlers/get-user-audit-handler.ts
+++ b/source/dea-backend/src/handlers/get-user-audit-handler.ts
@@ -1,0 +1,9 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getUserAudit } from '@aws/dea-app/lib/app/resources/get-user-audit';
+import { createDeaHandler, NO_ACL } from './create-dea-handler';
+
+export const handler = createDeaHandler(getUserAudit, NO_ACL);

--- a/source/dea-backend/src/handlers/request-user-audit-handler.ts
+++ b/source/dea-backend/src/handlers/request-user-audit-handler.ts
@@ -1,0 +1,9 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { startUserAudit } from '@aws/dea-app/lib/app/resources/start-user-audit';
+import { createDeaHandler, NO_ACL } from './create-dea-handler';
+
+export const handler = createDeaHandler(startUserAudit, NO_ACL);

--- a/source/dea-backend/src/resources/dea-route-config.ts
+++ b/source/dea-backend/src/resources/dea-route-config.ts
@@ -198,5 +198,17 @@ export const deaApiRouteConfig: ApiGatewayRouteConfig = {
       httpMethod: ApiGatewayMethod.POST,
       pathToSource: '../../src/handlers/create-case-owner-handler.ts',
     },
+    {
+      eventName: AuditEventType.GET_USER_AUDIT,
+      path: '/users/{userId}/audit/{auditId}/csv',
+      httpMethod: ApiGatewayMethod.GET,
+      pathToSource: '../../src/handlers/get-user-audit-handler.ts',
+    },
+    {
+      eventName: AuditEventType.REQUEST_USER_AUDIT,
+      path: '/users/{userId}/audit',
+      httpMethod: ApiGatewayMethod.POST,
+      pathToSource: '../../src/handlers/request-user-audit-handler.ts',
+    },
   ],
 };

--- a/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
+++ b/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
@@ -2156,6 +2156,66 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
+    "DeaRestApiConstructGETGetUserAudit8C04FC39": Object {
+      "DependsOn": Array [
+        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
+        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require access to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "ALLOWED_ORIGINS": "https://localhost:3001",
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 10,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
     "DeaRestApiConstructGETGetUsersFromCase05D0A5BE": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
@@ -2636,6 +2696,66 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
+    "DeaRestApiConstructPOSTRequestUserAudit18A97521": Object {
+      "DependsOn": Array [
+        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
+        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require access to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "ALLOWED_ORIGINS": "https://localhost:3001",
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 10,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
     "DeaRestApiConstructPOSTRevokeAuthToken4994A05B": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
@@ -3018,7 +3138,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::UsagePlan",
     },
-    "DeaRestApiConstructdeaapiDeploymentC27C6CB13aaa56a7d9b72942713172dab0212d07": Object {
+    "DeaRestApiConstructdeaapiDeploymentC27C6CB1a327ff0ca94311c8fd6e3f612d6b61ce": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeaapiauthauthCodeOPTIONS886A6DD8",
         "DeaRestApiConstructdeaapiauthauthCodeFF00F04A",
@@ -3109,6 +3229,16 @@ Object {
         "DeaRestApiConstructdeaapicasesPOST0A7C65AB",
         "DeaRestApiConstructdeaapicasesC2FD1C2B",
         "DeaRestApiConstructdeaapiOPTIONSE2FADC9C",
+        "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsvGET612A031C",
+        "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsvOPTIONSFD04EC81",
+        "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsv119B9333",
+        "DeaRestApiConstructdeaapiusersuserIdauditauditIdOPTIONS3652E037",
+        "DeaRestApiConstructdeaapiusersuserIdauditauditId63841CC8",
+        "DeaRestApiConstructdeaapiusersuserIdauditOPTIONSEE6E3674",
+        "DeaRestApiConstructdeaapiusersuserIdauditPOST04D75563",
+        "DeaRestApiConstructdeaapiusersuserIdaudit60684DFA",
+        "DeaRestApiConstructdeaapiusersuserIdOPTIONS66B09E53",
+        "DeaRestApiConstructdeaapiusersuserIdB57BE8EB",
         "DeaRestApiConstructdeaapiusersGET45E97005",
         "DeaRestApiConstructdeaapiusersOPTIONS8F715BE6",
         "DeaRestApiConstructdeaapiusers95152658",
@@ -3136,7 +3266,7 @@ Object {
           "Format": "{\\"stage\\":\\"$context.stage\\",\\"requestId\\":\\"$context.requestId\\",\\"integrationRequestId\\":\\"$context.integration.requestId\\",\\"status\\":\\"$context.status\\",\\"apiId\\":\\"$context.apiId\\",\\"resourcePath\\":\\"$context.resourcePath\\",\\"path\\":\\"$context.path\\",\\"resourceId\\":\\"$context.resourceId\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"userAgent\\":\\"$context.identity.userAgent\\"}",
         },
         "DeploymentId": Object {
-          "Ref": "DeaRestApiConstructdeaapiDeploymentC27C6CB13aaa56a7d9b72942713172dab0212d07",
+          "Ref": "DeaRestApiConstructdeaapiDeploymentC27C6CB1a327ff0ca94311c8fd6e3f612d6b61ce",
         },
         "RestApiId": Object {
           "Ref": "DeaRestApiConstructdeaapi6587DDA1",
@@ -8345,6 +8475,462 @@ Object {
         ],
         "ResourceId": Object {
           "Ref": "DeaRestApiConstructdeaapiusers95152658",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdB57BE8EB": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapiusers95152658",
+        },
+        "PathPart": "{userId}",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdOPTIONS66B09E53": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiusersuserIdB57BE8EB",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdaudit60684DFA": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapiusersuserIdB57BE8EB",
+        },
+        "PathPart": "audit",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdauditOPTIONSEE6E3674": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiusersuserIdaudit60684DFA",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdauditPOST04D75563": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "POST",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructPOSTRequestUserAudit18A97521",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiusersuserIdaudit60684DFA",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdauditPOSTApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4POSTusersuserIdaudit6194CA37": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructPOSTRequestUserAudit18A97521",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/POST/users/*/audit",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdauditPOSTApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4POSTusersuserIdaudit3F85C343": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructPOSTRequestUserAudit18A97521",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/POST/users/*/audit",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdauditauditId63841CC8": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapiusersuserIdaudit60684DFA",
+        },
+        "PathPart": "{auditId}",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdauditauditIdOPTIONS3652E037": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiusersuserIdauditauditId63841CC8",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsv119B9333": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapiusersuserIdauditauditId63841CC8",
+        },
+        "PathPart": "csv",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsvGET612A031C": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructGETGetUserAudit8C04FC39",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsv119B9333",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsvGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETusersuserIdauditauditIdcsv84743A25": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetUserAudit8C04FC39",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/GET/users/*/audit/*/csv",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsvGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETusersuserIdauditauditIdcsv64381123": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetUserAudit8C04FC39",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/users/*/audit/*/csv",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsvOPTIONSFD04EC81": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsv119B9333",
         },
         "RestApiId": Object {
           "Ref": "DeaRestApiConstructdeaapi6587DDA1",

--- a/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
+++ b/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
@@ -85,8 +85,8 @@ describe('DeaBackend constructs', () => {
     });
 
     //handlers
-    const expectedLambdaCount = 32;
-    const expectedMethodCount = 61;
+    const expectedLambdaCount = 34;
+    const expectedMethodCount = 67;
     template.resourceCountIs('AWS::Lambda::Function', expectedLambdaCount);
     template.resourceCountIs('AWS::ApiGateway::Method', expectedMethodCount);
 

--- a/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
+++ b/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
@@ -1565,6 +1565,78 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
+    "DeaApiGatewayGETGetUserAudit98646799": Object {
+      "DependsOn": Array [
+        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
+        "DeaApiGatewaydeabaselambdarole91512884",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require access to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "ALLOWED_ORIGINS": "https://localhost:3001",
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
+            },
+            "DELETE_CASE_FILE_LAMBDA_ARN": Object {
+              "Fn::GetAtt": Array [
+                "DeaEventHandlerss3batchdeletecasefileF6E3BAAE",
+                "Arn",
+              ],
+            },
+            "DELETE_CASE_FILE_ROLE": Object {
+              "Fn::GetAtt": Array [
+                "DeaEventHandlerss3batchdeletecasefileroleBAD7A58C",
+                "Arn",
+              ],
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewaydeabaselambdarole91512884",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 10,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
     "DeaApiGatewayGETGetUsersFromCaseDF0ABA41": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
@@ -2141,6 +2213,78 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
+    "DeaApiGatewayPOSTRequestUserAudit56ED13A5": Object {
+      "DependsOn": Array [
+        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
+        "DeaApiGatewaydeabaselambdarole91512884",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require access to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "ALLOWED_ORIGINS": "https://localhost:3001",
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
+            },
+            "DELETE_CASE_FILE_LAMBDA_ARN": Object {
+              "Fn::GetAtt": Array [
+                "DeaEventHandlerss3batchdeletecasefileF6E3BAAE",
+                "Arn",
+              ],
+            },
+            "DELETE_CASE_FILE_ROLE": Object {
+              "Fn::GetAtt": Array [
+                "DeaEventHandlerss3batchdeletecasefileroleBAD7A58C",
+                "Arn",
+              ],
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewaydeabaselambdarole91512884",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 10,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
     "DeaApiGatewayPOSTRevokeAuthTokenFC739416": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
@@ -2583,7 +2727,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::UsagePlan",
     },
-    "DeaApiGatewaydeaapiDeployment99E77629e5d855c2941b09d6af509f47706b55ad": Object {
+    "DeaApiGatewaydeaapiDeployment99E776295fbdbd1297ea84b10255b270dc91fd56": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeaapiauthauthCodeOPTIONS8EA9BA0F",
         "DeaApiGatewaydeaapiauthauthCodeFC92ADBD",
@@ -2695,6 +2839,16 @@ Object {
         "DeaApiGatewaydeaapiuiuploadfilesGET18F68E99",
         "DeaApiGatewaydeaapiuiuploadfilesOPTIONS447589BB",
         "DeaApiGatewaydeaapiuiuploadfilesD316EB71",
+        "DeaApiGatewaydeaapiusersuserIdauditauditIdcsvGETCE4980FD",
+        "DeaApiGatewaydeaapiusersuserIdauditauditIdcsvOPTIONSBB3692CC",
+        "DeaApiGatewaydeaapiusersuserIdauditauditIdcsvF855DE4D",
+        "DeaApiGatewaydeaapiusersuserIdauditauditIdOPTIONSCD66D9A6",
+        "DeaApiGatewaydeaapiusersuserIdauditauditId319420ED",
+        "DeaApiGatewaydeaapiusersuserIdauditOPTIONSDD803370",
+        "DeaApiGatewaydeaapiusersuserIdauditPOST9A50C105",
+        "DeaApiGatewaydeaapiusersuserIdaudit446C5798",
+        "DeaApiGatewaydeaapiusersuserIdOPTIONSFD82C006",
+        "DeaApiGatewaydeaapiusersuserIdC25AB5D9",
         "DeaApiGatewaydeaapiusersGETDBF3AD6C",
         "DeaApiGatewaydeaapiusersOPTIONS330C13A7",
         "DeaApiGatewaydeaapiusersCC765E55",
@@ -2722,7 +2876,7 @@ Object {
           "Format": "{\\"stage\\":\\"$context.stage\\",\\"requestId\\":\\"$context.requestId\\",\\"integrationRequestId\\":\\"$context.integration.requestId\\",\\"status\\":\\"$context.status\\",\\"apiId\\":\\"$context.apiId\\",\\"resourcePath\\":\\"$context.resourcePath\\",\\"path\\":\\"$context.path\\",\\"resourceId\\":\\"$context.resourceId\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"userAgent\\":\\"$context.identity.userAgent\\"}",
         },
         "DeploymentId": Object {
-          "Ref": "DeaApiGatewaydeaapiDeployment99E77629e5d855c2941b09d6af509f47706b55ad",
+          "Ref": "DeaApiGatewaydeaapiDeployment99E776295fbdbd1297ea84b10255b270dc91fd56",
         },
         "RestApiId": Object {
           "Ref": "DeaApiGatewaydeaapi822A9228",
@@ -8871,6 +9025,462 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
+    "DeaApiGatewaydeaapiusersuserIdC25AB5D9": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapiusersCC765E55",
+        },
+        "PathPart": "{userId}",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapiusersuserIdOPTIONSFD82C006": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiusersuserIdC25AB5D9",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiusersuserIdaudit446C5798": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapiusersuserIdC25AB5D9",
+        },
+        "PathPart": "audit",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapiusersuserIdauditOPTIONSDD803370": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiusersuserIdaudit446C5798",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiusersuserIdauditPOST9A50C105": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "POST",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayPOSTRequestUserAudit56ED13A5",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiusersuserIdaudit446C5798",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiusersuserIdauditPOSTApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9POSTusersuserIdaudit0BD35E2E": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPOSTRequestUserAudit56ED13A5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/POST/users/*/audit",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiusersuserIdauditPOSTApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9POSTusersuserIdaudit147E063E": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPOSTRequestUserAudit56ED13A5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/POST/users/*/audit",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiusersuserIdauditauditId319420ED": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapiusersuserIdaudit446C5798",
+        },
+        "PathPart": "{auditId}",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapiusersuserIdauditauditIdOPTIONSCD66D9A6": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiusersuserIdauditauditId319420ED",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiusersuserIdauditauditIdcsvF855DE4D": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapiusersuserIdauditauditId319420ED",
+        },
+        "PathPart": "csv",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapiusersuserIdauditauditIdcsvGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETusersuserIdauditauditIdcsv96605EA3": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetUserAudit98646799",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/users/*/audit/*/csv",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiusersuserIdauditauditIdcsvGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETusersuserIdauditauditIdcsv935E851F": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetUserAudit98646799",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/GET/users/*/audit/*/csv",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapiusersuserIdauditauditIdcsvGETCE4980FD": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayGETGetUserAudit98646799",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiusersuserIdauditauditIdcsvF855DE4D",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapiusersuserIdauditauditIdcsvOPTIONSBB3692CC": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapiusersuserIdauditauditIdcsvF855DE4D",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
     "DeaApiGatewaydeaauthlambdarole4F5CC393": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
@@ -11044,6 +11654,62 @@ Object {
                     ],
                   ],
                 },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/POST/users/*/audit",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/GET/users/*/audit/*/csv",
+                    ],
+                  ],
+                },
               ],
             },
           ],
@@ -11065,7 +11731,7 @@ Object {
         "Name": "/dea/us-east-1/[STAGE-REMOVED]-EvidenceManager-actions",
         "Tier": "Standard",
         "Type": "StringList",
-        "Value": "/cases/{caseId}/actionsGET,/cases/{caseId}/userMembershipsGET,/auth/{authCode}/tokenPOST,/auth/loginUrlGET,/auth/logoutUrlGET,/auth/refreshTokenPOST,/auth/revokeTokenPOST,/auth/credentials/{idToken}/exchangeGET,/usersGET,/cases/all-casesGET,/availableEndpointsGET,/cases/{caseId}/scopedInformationGET,/cases/{caseId}/ownerPOST",
+        "Value": "/cases/{caseId}/actionsGET,/cases/{caseId}/userMembershipsGET,/auth/{authCode}/tokenPOST,/auth/loginUrlGET,/auth/logoutUrlGET,/auth/refreshTokenPOST,/auth/revokeTokenPOST,/auth/credentials/{idToken}/exchangeGET,/usersGET,/cases/all-casesGET,/availableEndpointsGET,/cases/{caseId}/scopedInformationGET,/cases/{caseId}/ownerPOST,/users/{userId}/auditPOST,/users/{userId}/audit/{auditId}/csvGET",
       },
       "Type": "AWS::SSM::Parameter",
     },
@@ -12551,6 +13217,62 @@ Object {
                     ],
                   ],
                 },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/POST/users/*/audit",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/GET/users/*/audit/*/csv",
+                    ],
+                  ],
+                },
               ],
             },
           ],
@@ -12572,7 +13294,7 @@ Object {
         "Name": "/dea/us-east-1/[STAGE-REMOVED]-WorkingManager-actions",
         "Tier": "Standard",
         "Type": "StringList",
-        "Value": "/casesPOST,/cases/{caseId}/detailsGET,/cases/{caseId}/detailsPUT,/cases/{caseId}/detailsDELETE,/cases/{caseId}/actionsGET,/cases/{caseId}/userMembershipsGET,/cases/{caseId}/userMembershipsPOST,/cases/{caseId}/users/{userId}/membershipsPUT,/cases/{caseId}/users/{userId}/membershipsDELETE,/auth/{authCode}/tokenPOST,/auth/loginUrlGET,/auth/logoutUrlGET,/auth/refreshTokenPOST,/auth/revokeTokenPOST,/auth/credentials/{idToken}/exchangeGET,/usersGET,/cases/{caseId}/filesPOST,/cases/{caseId}/filesGET,/cases/{caseId}/files/{fileId}/contentsPUT,/cases/{caseId}/files/{fileId}/infoGET,/cases/{caseId}/files/{fileId}/contentsGET,/cases/my-casesGET,/cases/all-casesGET,/cases/{caseId}/audit/{auditId}/csvGET,/cases/{caseId}/auditPOST,/availableEndpointsGET,/cases/{caseId}/scopedInformationGET,/cases/{caseId}/ownerPOST",
+        "Value": "/casesPOST,/cases/{caseId}/detailsGET,/cases/{caseId}/detailsPUT,/cases/{caseId}/detailsDELETE,/cases/{caseId}/actionsGET,/cases/{caseId}/userMembershipsGET,/cases/{caseId}/userMembershipsPOST,/cases/{caseId}/users/{userId}/membershipsPUT,/cases/{caseId}/users/{userId}/membershipsDELETE,/auth/{authCode}/tokenPOST,/auth/loginUrlGET,/auth/logoutUrlGET,/auth/refreshTokenPOST,/auth/revokeTokenPOST,/auth/credentials/{idToken}/exchangeGET,/usersGET,/cases/{caseId}/filesPOST,/cases/{caseId}/filesGET,/cases/{caseId}/files/{fileId}/contentsPUT,/cases/{caseId}/files/{fileId}/infoGET,/cases/{caseId}/files/{fileId}/contentsGET,/cases/my-casesGET,/cases/all-casesGET,/cases/{caseId}/audit/{auditId}/csvGET,/cases/{caseId}/auditPOST,/availableEndpointsGET,/cases/{caseId}/scopedInformationGET,/cases/{caseId}/ownerPOST,/users/{userId}/auditPOST,/users/{userId}/audit/{auditId}/csvGET",
       },
       "Type": "AWS::SSM::Parameter",
     },
@@ -13429,6 +14151,62 @@ Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
                       "/POST/cases/*/owner",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/GET/users/*/audit/*/csv",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/POST/users/*/audit",
                     ],
                   ],
                 },


### PR DESCRIPTION
*Description of changes:*
Two privileged endpoints for user audit logs retrievals:
* `/users/{userId}/audit` to start an audit request.
* `/users/{userId}/audit/{auditId}/csv` which will respond with the status of the query or the results in `csv` format.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
