### PR TITLE
feat: add apis to start and retrieve system audit logs

### DIFF
--- a/source/common/config/chewbacca.json
+++ b/source/common/config/chewbacca.json
@@ -239,6 +239,14 @@
         {
           "path": "/users/{userId}/audit/{auditId}/csv",
           "method": "GET"
+        },
+        {
+          "path": "/system/audit",
+          "method": "POST"
+        },
+        {
+          "path": "/system/audit/{auditId}/csv",
+          "method": "GET"
         }
       ]
     },
@@ -304,6 +312,14 @@
         },
         {
           "path": "/users/{userId}/audit/{auditId}/csv",
+          "method": "GET"
+        },
+        {
+          "path": "/system/audit",
+          "method": "POST"
+        },
+        {
+          "path": "/system/audit/{auditId}/csv",
           "method": "GET"
         }
       ]

--- a/source/dea-app/README.md
+++ b/source/dea-app/README.md
@@ -5,6 +5,6 @@
 
 | Statements                                                                         | Branches                                                                      | Functions                                                                        | Lines                                                                   |
 | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-98.43%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-88.11%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-98.27%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-98.47%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-88.31%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-98.32%25-brightgreen.svg?style=flat) |
 
 This project is the routing package for `dea-backend`. It is used by `dea-backend` to generate routes for DEA API. Please refer [here](../dea-backend/README.md) for more information on how to use this project.

--- a/source/dea-app/src/app/resources/get-system-audit.ts
+++ b/source/dea-app/src/app/resources/get-system-audit.ts
@@ -1,0 +1,34 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getRequiredPathParam } from '../../lambda-http-helpers';
+import { joiUuid } from '../../models/validation/joi-common';
+import { defaultProvider } from '../../persistence/schema/entities';
+import { defaultDatasetsProvider } from '../../storage/datasets';
+import { defaultCloudwatchClient } from '../audit/dea-audit-plugin';
+import { auditService } from '../services/audit-service';
+import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { csvResponse, responseOk } from './dea-lambda-utils';
+
+export const getSystemAudit: DEAGatewayProxyHandler = async (
+  event,
+  context,
+  /* the default case is handled in e2e tests */
+  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _repositoryProvider = defaultProvider,
+  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _datasetsProvider = defaultDatasetsProvider,
+  /* istanbul ignore next */
+  cloudwatchClient = defaultCloudwatchClient
+) => {
+  const auditId = getRequiredPathParam(event, 'auditId', joiUuid);
+  const result = await auditService.getAuditResult(auditId, cloudwatchClient);
+
+  if (result.csvFormattedData) {
+    return csvResponse(event, result.csvFormattedData);
+  } else {
+    return responseOk(event, result);
+  }
+};

--- a/source/dea-app/src/app/resources/start-system-audit.ts
+++ b/source/dea-app/src/app/resources/start-system-audit.ts
@@ -1,0 +1,34 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import Joi from 'joi';
+import { getQueryParam } from '../../lambda-http-helpers';
+import { defaultProvider } from '../../persistence/schema/entities';
+import { defaultDatasetsProvider } from '../../storage/datasets';
+import { defaultCloudwatchClient } from '../audit/dea-audit-plugin';
+import { auditService } from '../services/audit-service';
+import { DEAGatewayProxyHandler } from './dea-gateway-proxy-handler';
+import { responseOk } from './dea-lambda-utils';
+
+export const startSystemAudit: DEAGatewayProxyHandler = async (
+  event,
+  context,
+  /* the default case is handled in e2e tests */
+  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _repositoryProvider = defaultProvider,
+  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _datasetsProvider = defaultDatasetsProvider,
+  /* istanbul ignore next */
+  cloudwatchClient = defaultCloudwatchClient
+) => {
+  const now = Date.now();
+  const start = getQueryParam(event, 'from', '0', Joi.number().integer());
+  const end = getQueryParam(event, 'to', now.toString(), Joi.number().integer());
+  const startTime = Number.parseInt(start);
+  const endTime = Number.parseInt(end);
+  const queryId = await auditService.requestSystemAudit(startTime, endTime, cloudwatchClient);
+
+  return responseOk(event, { auditId: queryId });
+};

--- a/source/dea-app/src/index.ts
+++ b/source/dea-app/src/index.ts
@@ -33,6 +33,7 @@ import { getLoginUrl } from './app/resources/get-login-url';
 import { getLogoutUrl } from './app/resources/get-logout-url';
 import { getMyCases } from './app/resources/get-my-cases';
 import { getScopedCaseInformation } from './app/resources/get-scoped-case-information';
+import { getSystemAudit } from './app/resources/get-system-audit';
 import { getToken } from './app/resources/get-token';
 import { getUserAudit } from './app/resources/get-user-audit';
 import { getUsers } from './app/resources/get-users';
@@ -41,6 +42,7 @@ import { listCaseFiles } from './app/resources/list-case-files';
 import { refreshToken } from './app/resources/refresh-token';
 import { revokeToken } from './app/resources/revoke-token';
 import { startCaseAudit } from './app/resources/start-case-audit';
+import { startSystemAudit } from './app/resources/start-system-audit';
 import { startUserAudit } from './app/resources/start-user-audit';
 import { updateCaseMembership } from './app/resources/update-case-membership';
 import { updateCaseStatus } from './app/resources/update-case-status';
@@ -102,6 +104,8 @@ export {
   getAvailableEndpointsForUser,
   startUserAudit,
   getUserAudit,
+  startSystemAudit,
+  getSystemAudit,
   CaseAction,
   DeaCase,
   DeaCaseFile,

--- a/source/dea-app/src/test-e2e/resources/system-audit.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/system-audit.e2e.test.ts
@@ -1,0 +1,174 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Credentials } from 'aws4-axios';
+import Joi from 'joi';
+import { AuditEventType } from '../../app/services/audit-service';
+import { Oauth2Token } from '../../models/auth';
+import { joiUuid } from '../../models/validation/joi-common';
+import CognitoHelper from '../helpers/cognito-helper';
+import { testEnv } from '../helpers/settings';
+import {
+  callDeaAPIWithCreds,
+  createCaseSuccess,
+  deleteCase,
+  getSpecificUserByFirstName,
+  randomSuffix,
+} from './test-helpers';
+
+describe('system audit e2e', () => {
+  const cognitoHelper = new CognitoHelper();
+
+  const suffix = randomSuffix(5);
+  const testUser = `systemAuditTestUser${suffix}`;
+  const testManager = `systemAuditTestManager${suffix}`;
+  const deaApiUrl = testEnv.apiUrlOutput;
+  let creds: Credentials;
+  let idToken: Oauth2Token;
+  let userUlid: string;
+  let managerCreds: Credentials;
+  let managerIdToken: Oauth2Token;
+
+  const caseIdsToDelete: string[] = [];
+
+  beforeAll(async () => {
+    // Create manager
+    await cognitoHelper.createUser(testManager, 'WorkingManager', testManager, 'TestManager');
+    [managerCreds, managerIdToken] = await cognitoHelper.getCredentialsForUser(testManager);
+
+    // Create worker
+    await cognitoHelper.createUser(testUser, 'CaseWorker', testUser, 'TestUser');
+    [creds, idToken] = await cognitoHelper.getCredentialsForUser(testUser);
+
+    // initialize the user into the DB
+    await callDeaAPIWithCreds(`${deaApiUrl}cases/my-cases`, 'GET', idToken, creds);
+    // get the user ulid
+    userUlid = (await getSpecificUserByFirstName(deaApiUrl, testUser, managerIdToken, managerCreds)).ulid;
+  }, 10000);
+
+  afterAll(async () => {
+    for (const caseId of caseIdsToDelete) {
+      await deleteCase(deaApiUrl, caseId, idToken, creds);
+    }
+    await cognitoHelper.cleanup();
+  }, 30000);
+
+  it('retrieves system actions', async () => {
+    const caseName = `auditTestCase${randomSuffix()}`;
+    const createdCase = await createCaseSuccess(
+      deaApiUrl,
+      {
+        name: caseName,
+        description: 'this is a description',
+      },
+      idToken,
+      creds
+    );
+    const caseUlid = createdCase.ulid ?? fail();
+    caseIdsToDelete.push(caseUlid);
+
+    const updateResponse = await callDeaAPIWithCreds(
+      `${deaApiUrl}cases/${caseUlid}/details`,
+      'PUT',
+      idToken,
+      creds,
+      {
+        ulid: caseUlid,
+        name: caseName,
+        description: 'An updated description',
+      }
+    );
+    expect(updateResponse.status).toEqual(200);
+
+    const getResponse = await callDeaAPIWithCreds(
+      `${deaApiUrl}cases/${caseUlid}/details`,
+      'GET',
+      idToken,
+      creds
+    );
+    expect(getResponse.status).toEqual(200);
+
+    const membershipsResponse = await callDeaAPIWithCreds(
+      `${deaApiUrl}cases/${caseUlid}/userMemberships`,
+      'GET',
+      idToken,
+      creds
+    );
+    expect(membershipsResponse.status).toEqual(200);
+
+    // allow some time so the events show up in CW logs
+    await delay(25000);
+
+    let csvData: string | undefined;
+    const queryRetries = 5;
+    while (!csvData && queryRetries > 0) {
+      const startAuditQueryResponse = await callDeaAPIWithCreds(
+        `${deaApiUrl}system/audit`,
+        'POST',
+        managerIdToken,
+        managerCreds
+      );
+
+      expect(startAuditQueryResponse.status).toEqual(200);
+      const auditId: string = startAuditQueryResponse.data.auditId;
+      Joi.assert(auditId, joiUuid);
+
+      let retries = 5;
+      let getQueryReponse = await callDeaAPIWithCreds(
+        `${deaApiUrl}system/audit/${auditId}/csv`,
+        'GET',
+        managerIdToken,
+        managerCreds
+      );
+      while (getQueryReponse.data.status && retries > 0) {
+        if (getQueryReponse.data.status === 'Complete') {
+          break;
+        }
+        --retries;
+        if (getQueryReponse.status !== 200) {
+          fail();
+        }
+        await delay(2000);
+
+        getQueryReponse = await callDeaAPIWithCreds(
+          `${deaApiUrl}users/${userUlid}/audit/${auditId}/csv`,
+          'GET',
+          managerIdToken,
+          managerCreds
+        );
+      }
+
+      const potentialCsvData: string = getQueryReponse.data;
+
+      if (
+        getQueryReponse.data &&
+        !getQueryReponse.data.status &&
+        potentialCsvData.includes(AuditEventType.UPDATE_CASE_DETAILS) &&
+        potentialCsvData.includes(AuditEventType.GET_CASE_DETAILS) &&
+        potentialCsvData.includes(AuditEventType.GET_USERS_FROM_CASE)
+      ) {
+        csvData = getQueryReponse.data;
+      }
+    }
+    expect(csvData).toContain('/cases/{caseId}/details');
+    expect(csvData).toContain(testUser);
+    expect(csvData).toContain(caseUlid);
+    expect(csvData).toContain(AuditEventType.GET_CASE_DETAILS);
+    expect(csvData).toContain(AuditEventType.UPDATE_CASE_DETAILS);
+    expect(csvData).toContain(AuditEventType.GET_USERS_FROM_CASE);
+
+    // assert system actions
+    expect(csvData).toContain('cognito-idp.amazonaws.com');
+    expect(csvData).toContain('kms.amazonaws.com');
+    expect(csvData).toContain('ssm.amazonaws.com');
+    expect(csvData).toContain('logs.amazonaws.com');
+    expect(csvData).toContain('apigateway.amazonaws.com');
+    expect(csvData).toContain('dynamodb.amazonaws.com');
+  }, 180000);
+
+  function delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+});

--- a/source/dea-app/src/test/app/resources/get-system-audit.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/get-system-audit.integration.test.ts
@@ -1,0 +1,126 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CloudWatchLogsClient, GetQueryResultsCommand, QueryStatus } from '@aws-sdk/client-cloudwatch-logs';
+import { anyOfClass, anything, instance, mock, when } from 'ts-mockito';
+import { getSystemAudit } from '../../../app/resources/get-system-audit';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
+
+describe('get system audit', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.AUDIT_LOG_GROUP_NAME = 'TESTGROUP';
+    process.env.TRAIL_LOG_GROUP_NAME = 'TESTTRAILGROUP';
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('responds with csv data', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anyOfClass(GetQueryResultsCommand))).thenResolve({
+      $metadata: {},
+      status: QueryStatus.Complete,
+      results: [
+        [
+          { field: 'fieldA', value: 'valueA' },
+          { field: 'fieldB', value: 'valueB' },
+        ],
+        [
+          { field: 'fieldA', value: 'valueA2' },
+          { field: 'fieldB', value: 'valueB2' },
+        ],
+      ],
+    });
+
+    const expectedCSV = 'fieldA, fieldB\r\nvalueA, valueB\r\nvalueA2, valueB2\r\n';
+
+    const event = getDummyEvent({
+      pathParameters: {
+        auditId: '11111111-1111-1111-1111-111111111111',
+      },
+    });
+    const result = await getSystemAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+
+    expect(result.statusCode).toEqual(200);
+    expect(result.body).toEqual(expectedCSV);
+  });
+
+  it('returns status if not complete', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({ $metadata: {}, status: QueryStatus.Running });
+
+    const event = getDummyEvent({
+      pathParameters: {
+        auditId: '11111111-1111-1111-1111-111111111111',
+      },
+    });
+    const result = await getSystemAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    expect(result.statusCode).toEqual(200);
+    const responseBody: { status: string } = JSON.parse(result.body);
+    expect(responseBody.status).toEqual('Running');
+  });
+
+  it('returns complete with no data if data is not returned', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({ $metadata: {}, status: QueryStatus.Complete });
+
+    const event = getDummyEvent({
+      pathParameters: {
+        auditId: '11111111-1111-1111-1111-111111111111',
+      },
+    });
+    const result = await getSystemAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    expect(result.statusCode).toEqual(200);
+    const responseBody: { status: string; csvFormattedData: string } = JSON.parse(result.body);
+    expect(responseBody.status).toEqual('Complete');
+    expect(responseBody.csvFormattedData).toBeUndefined();
+  });
+
+  it('returns complete with no data if data is empty', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({
+      $metadata: {},
+      status: QueryStatus.Complete,
+      results: [],
+    });
+
+    const event = getDummyEvent({
+      pathParameters: {
+        auditId: '11111111-1111-1111-1111-111111111111',
+      },
+    });
+    const result = await getSystemAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    expect(result.statusCode).toEqual(200);
+    const responseBody: { status: string; csvFormattedData: string } = JSON.parse(result.body);
+    expect(responseBody.status).toEqual('Complete');
+    expect(responseBody.csvFormattedData).toBeUndefined();
+  });
+
+  it('returns unknown status if the status is not provided', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({ $metadata: {} });
+
+    const event = getDummyEvent({
+      pathParameters: {
+        auditId: '11111111-1111-1111-1111-111111111111',
+      },
+    });
+    const result = await getSystemAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    expect(result.statusCode).toEqual(200);
+    const responseBody: { status: string; csvFormattedData: string } = JSON.parse(result.body);
+    expect(responseBody.status).toEqual('Unknown');
+    expect(responseBody.csvFormattedData).toBeUndefined();
+  });
+});

--- a/source/dea-app/src/test/app/resources/start-system-audit.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/start-system-audit.integration.test.ts
@@ -1,0 +1,47 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CloudWatchLogsClient } from '@aws-sdk/client-cloudwatch-logs';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { startSystemAudit } from '../../../app/resources/start-system-audit';
+import { dummyContext, getDummyEvent } from '../../integration-objects';
+
+describe('start system audit', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.AUDIT_LOG_GROUP_NAME = 'TESTGROUP';
+    process.env.TRAIL_LOG_GROUP_NAME = 'TESTTRAILGROUP';
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('responds with a queryId', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({ $metadata: {}, queryId: 'a_query_id' });
+
+    const event = getDummyEvent();
+    const result = await startSystemAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+
+    expect(result.statusCode).toEqual(200);
+    expect(result.body).toContain('a_query_id');
+  });
+
+  it('throws an error if no queryId is returned', async () => {
+    const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
+    const clientMockInstance = instance(clientMock);
+    when(clientMock.send(anything())).thenResolve({ $metadata: {}, queryId: undefined });
+
+    const event = getDummyEvent();
+    await expect(
+      startSystemAudit(event, dummyContext, undefined, undefined, clientMockInstance)
+    ).rejects.toThrow('Unknown error starting Cloudwatch Logs Query.');
+  });
+});

--- a/source/dea-backend/README.md
+++ b/source/dea-backend/README.md
@@ -6,7 +6,7 @@
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-96.92%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-91.11%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.46%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-96.88%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-95.83%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-90.58%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.35%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-95.77%25-brightgreen.svg?style=flat) |
 
 ## Description
 

--- a/source/dea-backend/src/constructs/dea-rest-api.ts
+++ b/source/dea-backend/src/constructs/dea-rest-api.ts
@@ -41,6 +41,7 @@ interface DeaRestApiProps {
   deaDatasetsBucketName: string;
   s3BatchDeleteCaseFileRoleArn: string;
   deaAuditLogArn: string;
+  deaTrailLogArn: string;
   kmsKey: Key;
   region: string;
   accountId: string;
@@ -65,6 +66,7 @@ export class DeaRestApiConstruct extends Construct {
       props.region,
       props.accountId,
       props.deaAuditLogArn,
+      props.deaTrailLogArn,
       props.s3BatchDeleteCaseFileRoleArn
     );
 
@@ -284,6 +286,7 @@ export class DeaRestApiConstruct extends Construct {
     region: string,
     accountId: string,
     auditLogArn: string,
+    trailLogArn: string,
     s3BatchDeleteCaseFileRoleArn: string
   ): Role {
     const basicExecutionPolicy = ManagedPolicy.fromAwsManagedPolicyName(
@@ -327,7 +330,7 @@ export class DeaRestApiConstruct extends Construct {
     role.addToPolicy(
       new PolicyStatement({
         actions: ['logs:StartQuery'],
-        resources: [auditLogArn],
+        resources: [auditLogArn, trailLogArn],
       })
     );
 

--- a/source/dea-backend/src/handlers/get-system-audit-handler.ts
+++ b/source/dea-backend/src/handlers/get-system-audit-handler.ts
@@ -1,0 +1,9 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getSystemAudit } from '@aws/dea-app/lib/app/resources/get-system-audit';
+import { createDeaHandler, NO_ACL } from './create-dea-handler';
+
+export const handler = createDeaHandler(getSystemAudit, NO_ACL);

--- a/source/dea-backend/src/handlers/request-system-audit-handler.ts
+++ b/source/dea-backend/src/handlers/request-system-audit-handler.ts
@@ -1,0 +1,9 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { startSystemAudit } from '@aws/dea-app/lib/app/resources/start-system-audit';
+import { createDeaHandler, NO_ACL } from './create-dea-handler';
+
+export const handler = createDeaHandler(startSystemAudit, NO_ACL);

--- a/source/dea-backend/src/resources/dea-route-config.ts
+++ b/source/dea-backend/src/resources/dea-route-config.ts
@@ -210,5 +210,17 @@ export const deaApiRouteConfig: ApiGatewayRouteConfig = {
       httpMethod: ApiGatewayMethod.POST,
       pathToSource: '../../src/handlers/request-user-audit-handler.ts',
     },
+    {
+      eventName: AuditEventType.GET_SYSTEM_AUDIT,
+      path: '/system/audit/{auditId}/csv',
+      httpMethod: ApiGatewayMethod.GET,
+      pathToSource: '../../src/handlers/get-system-audit-handler.ts',
+    },
+    {
+      eventName: AuditEventType.REQUEST_SYSTEM_AUDIT,
+      path: '/system/audit',
+      httpMethod: ApiGatewayMethod.POST,
+      pathToSource: '../../src/handlers/request-system-audit-handler.ts',
+    },
   ],
 };

--- a/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
+++ b/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
@@ -1241,6 +1241,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1300,6 +1303,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1361,6 +1367,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1420,6 +1429,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1481,6 +1493,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1540,6 +1555,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1601,6 +1619,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1660,6 +1681,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1721,6 +1745,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1780,6 +1807,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1841,6 +1871,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1900,6 +1933,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1961,6 +1997,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2020,6 +2059,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2081,6 +2123,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2140,6 +2185,72 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 10,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaRestApiConstructGETGetSystemAuditE4C86CC7": Object {
+      "DependsOn": Array [
+        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
+        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require access to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "ALLOWED_ORIGINS": "https://localhost:3001",
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2201,6 +2312,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2260,6 +2374,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2321,6 +2438,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2380,6 +2500,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2441,6 +2564,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2500,6 +2626,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2561,6 +2690,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2620,6 +2752,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2681,6 +2816,72 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 10,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaRestApiConstructPOSTRequestSystemAuditF9687588": Object {
+      "DependsOn": Array [
+        "DeaRestApiConstructdeabaselambdaroleDefaultPolicy8449FBB9",
+        "DeaRestApiConstructdeabaselambdarole9EA2B06B",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require access to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "ALLOWED_ORIGINS": "https://localhost:3001",
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendConstructS3DatasetsBucketDDF4C58A",
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2740,6 +2941,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2801,6 +3005,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2860,6 +3067,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2921,6 +3131,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2981,6 +3194,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -3040,6 +3256,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendConstructDeaTableB48721A0",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -3138,7 +3357,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::UsagePlan",
     },
-    "DeaRestApiConstructdeaapiDeploymentC27C6CB1a327ff0ca94311c8fd6e3f612d6b61ce": Object {
+    "DeaRestApiConstructdeaapiDeploymentC27C6CB1a82533af3ff3af8385777f64b30b40e1": Object {
       "DependsOn": Array [
         "DeaRestApiConstructdeaapiauthauthCodeOPTIONS886A6DD8",
         "DeaRestApiConstructdeaapiauthauthCodeFF00F04A",
@@ -3229,6 +3448,16 @@ Object {
         "DeaRestApiConstructdeaapicasesPOST0A7C65AB",
         "DeaRestApiConstructdeaapicasesC2FD1C2B",
         "DeaRestApiConstructdeaapiOPTIONSE2FADC9C",
+        "DeaRestApiConstructdeaapisystemauditauditIdcsvGETB3B09D3C",
+        "DeaRestApiConstructdeaapisystemauditauditIdcsvOPTIONSBC6D4692",
+        "DeaRestApiConstructdeaapisystemauditauditIdcsv3DF23375",
+        "DeaRestApiConstructdeaapisystemauditauditIdOPTIONS2EADE5A9",
+        "DeaRestApiConstructdeaapisystemauditauditIdB2530B9D",
+        "DeaRestApiConstructdeaapisystemauditOPTIONS30FFCB3F",
+        "DeaRestApiConstructdeaapisystemauditPOSTA0F7E161",
+        "DeaRestApiConstructdeaapisystemaudit2A5DAEF8",
+        "DeaRestApiConstructdeaapisystemOPTIONS2695AC39",
+        "DeaRestApiConstructdeaapisystemAD98847E",
         "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsvGET612A031C",
         "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsvOPTIONSFD04EC81",
         "DeaRestApiConstructdeaapiusersuserIdauditauditIdcsv119B9333",
@@ -3266,7 +3495,7 @@ Object {
           "Format": "{\\"stage\\":\\"$context.stage\\",\\"requestId\\":\\"$context.requestId\\",\\"integrationRequestId\\":\\"$context.integration.requestId\\",\\"status\\":\\"$context.status\\",\\"apiId\\":\\"$context.apiId\\",\\"resourcePath\\":\\"$context.resourcePath\\",\\"path\\":\\"$context.path\\",\\"resourceId\\":\\"$context.resourceId\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"userAgent\\":\\"$context.identity.userAgent\\"}",
         },
         "DeploymentId": Object {
-          "Ref": "DeaRestApiConstructdeaapiDeploymentC27C6CB1a327ff0ca94311c8fd6e3f612d6b61ce",
+          "Ref": "DeaRestApiConstructdeaapiDeploymentC27C6CB1a82533af3ff3af8385777f64b30b40e1",
         },
         "RestApiId": Object {
           "Ref": "DeaRestApiConstructdeaapi6587DDA1",
@@ -8300,6 +8529,465 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
+    "DeaRestApiConstructdeaapisystemAD98847E": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructdeaapi6587DDA1",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "system",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapisystemOPTIONS2695AC39": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapisystemAD98847E",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapisystemaudit2A5DAEF8": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapisystemAD98847E",
+        },
+        "PathPart": "audit",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapisystemauditOPTIONS30FFCB3F": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapisystemaudit2A5DAEF8",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapisystemauditPOSTA0F7E161": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "POST",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructPOSTRequestSystemAuditF9687588",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapisystemaudit2A5DAEF8",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapisystemauditPOSTApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4POSTsystemaudit92D5D91E": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructPOSTRequestSystemAuditF9687588",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/POST/system/audit",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapisystemauditPOSTApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4POSTsystemauditCB076E78": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructPOSTRequestSystemAuditF9687588",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/POST/system/audit",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapisystemauditauditIdB2530B9D": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapisystemaudit2A5DAEF8",
+        },
+        "PathPart": "{auditId}",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapisystemauditauditIdOPTIONS2EADE5A9": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapisystemauditauditIdB2530B9D",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapisystemauditauditIdcsv3DF23375": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaRestApiConstructdeaapisystemauditauditIdB2530B9D",
+        },
+        "PathPart": "csv",
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaRestApiConstructdeaapisystemauditauditIdcsvGETApiPermissionTestteststackDeaRestApiConstructdeaapi96FE45F4GETsystemauditauditIdcsv32688A4B": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetSystemAuditE4C86CC7",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/test-invoke-stage/GET/system/audit/*/csv",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapisystemauditauditIdcsvGETApiPermissionteststackDeaRestApiConstructdeaapi96FE45F4GETsystemauditauditIdcsvFC587FF9": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaRestApiConstructGETGetSystemAuditE4C86CC7",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+              },
+              "/",
+              Object {
+                "Ref": "DeaRestApiConstructdeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/system/audit/*/csv",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaRestApiConstructdeaapisystemauditauditIdcsvGETB3B09D3C": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaRestApiConstructGETGetSystemAuditE4C86CC7",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapisystemauditauditIdcsv3DF23375",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaRestApiConstructdeaapisystemauditauditIdcsvOPTIONSBC6D4692": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaRestApiConstructdeaapisystemauditauditIdcsv3DF23375",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaRestApiConstructdeaapi6587DDA1",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
     "DeaRestApiConstructdeaapiusers95152658": Object {
       "Properties": Object {
         "ParentId": Object {
@@ -9124,12 +9812,20 @@ Object {
             Object {
               "Action": "logs:StartQuery",
               "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "deaAuditLogs7B75D3F1",
-                  "Arn",
-                ],
-              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "deaAuditLogs7B75D3F1",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::GetAtt": Array [
+                    "deaTrailLogs0A0531F5",
+                    "Arn",
+                  ],
+                },
+              ],
             },
             Object {
               "Action": Array [

--- a/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
+++ b/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
@@ -63,6 +63,7 @@ describe('DeaBackend constructs', () => {
       deaDatasetsBucketName: backend.datasetsBucket.bucketName,
       s3BatchDeleteCaseFileRoleArn: deaEventHandlers.s3BatchDeleteCaseFileRole.roleArn,
       deaAuditLogArn: auditTrail.auditLogGroup.logGroupArn,
+      deaTrailLogArn: auditTrail.trailLogGroup.logGroupArn,
       kmsKey: key,
       region: stack.region,
       accountId: stack.account,
@@ -70,6 +71,7 @@ describe('DeaBackend constructs', () => {
         AUDIT_LOG_GROUP_NAME: auditTrail.auditLogGroup.logGroupName,
         TABLE_NAME: backend.deaTable.tableName,
         DATASETS_BUCKET_NAME: backend.datasetsBucket.bucketName,
+        TRAIL_LOG_GROUP_NAME: auditTrail.trailLogGroup.logGroupName,
       },
     });
 
@@ -85,8 +87,8 @@ describe('DeaBackend constructs', () => {
     });
 
     //handlers
-    const expectedLambdaCount = 34;
-    const expectedMethodCount = 67;
+    const expectedLambdaCount = 36;
+    const expectedMethodCount = 73;
     template.resourceCountIs('AWS::Lambda::Function', expectedLambdaCount);
     template.resourceCountIs('AWS::ApiGateway::Method', expectedMethodCount);
 
@@ -137,6 +139,7 @@ describe('DeaBackend constructs', () => {
       deaDatasetsBucketArn: backend.datasetsBucket.bucketArn,
       deaDatasetsBucketName: backend.datasetsBucket.bucketName,
       deaAuditLogArn: auditTrail.auditLogGroup.logGroupArn,
+      deaTrailLogArn: auditTrail.trailLogGroup.logGroupArn,
       s3BatchDeleteCaseFileRoleArn: deaEventHandlers.s3BatchDeleteCaseFileRole.roleArn,
       kmsKey: key,
       region: stack.region,
@@ -145,6 +148,7 @@ describe('DeaBackend constructs', () => {
         AUDIT_LOG_GROUP_NAME: auditTrail.auditLogGroup.logGroupName,
         TABLE_NAME: backend.deaTable.tableName,
         DATASETS_BUCKET_NAME: backend.datasetsBucket.bucketName,
+        TRAIL_LOG_GROUP_NAME: auditTrail.trailLogGroup.logGroupName,
       },
     });
 

--- a/source/dea-main/src/dea-main-stack.ts
+++ b/source/dea-main/src/dea-main-stack.ts
@@ -70,6 +70,7 @@ export class DeaMainStack extends cdk.Stack {
       deaDatasetsBucketArn: backendConstruct.datasetsBucket.bucketArn,
       deaDatasetsBucketName: backendConstruct.datasetsBucket.bucketName,
       deaAuditLogArn: auditTrail.auditLogGroup.logGroupArn,
+      deaTrailLogArn: auditTrail.trailLogGroup.logGroupArn,
       s3BatchDeleteCaseFileRoleArn: deaEventHandlers.s3BatchDeleteCaseFileRole.roleArn,
       kmsKey,
       region,
@@ -80,6 +81,7 @@ export class DeaMainStack extends cdk.Stack {
         DATASETS_BUCKET_NAME: backendConstruct.datasetsBucket.bucketName,
         DELETE_CASE_FILE_LAMBDA_ARN: deaEventHandlers.s3BatchDeleteCaseFileLambda.functionArn,
         DELETE_CASE_FILE_ROLE: deaEventHandlers.s3BatchDeleteCaseFileRole.roleArn,
+        TRAIL_LOG_GROUP_NAME: auditTrail.trailLogGroup.logGroupName,
       },
     });
 

--- a/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
+++ b/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
@@ -470,6 +470,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -541,6 +544,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -614,6 +620,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -685,6 +694,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -758,6 +770,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -829,6 +844,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -902,6 +920,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -973,6 +994,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1046,6 +1070,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1117,6 +1144,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1190,6 +1220,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1261,6 +1294,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1334,6 +1370,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1405,6 +1444,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1478,6 +1520,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1549,6 +1594,84 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewaydeabaselambdarole91512884",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 10,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaApiGatewayGETGetSystemAuditAD3F46B8": Object {
+      "DependsOn": Array [
+        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
+        "DeaApiGatewaydeabaselambdarole91512884",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require access to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "ALLOWED_ORIGINS": "https://localhost:3001",
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
+            },
+            "DELETE_CASE_FILE_LAMBDA_ARN": Object {
+              "Fn::GetAtt": Array [
+                "DeaEventHandlerss3batchdeletecasefileF6E3BAAE",
+                "Arn",
+              ],
+            },
+            "DELETE_CASE_FILE_ROLE": Object {
+              "Fn::GetAtt": Array [
+                "DeaEventHandlerss3batchdeletecasefileroleBAD7A58C",
+                "Arn",
+              ],
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1622,6 +1745,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1693,6 +1819,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1766,6 +1895,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1837,6 +1969,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -1910,6 +2045,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -1981,6 +2119,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2054,6 +2195,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2125,6 +2269,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2198,6 +2345,84 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewaydeabaselambdarole91512884",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 10,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DeaApiGatewayPOSTRequestSystemAudit1876CDAF": Object {
+      "DependsOn": Array [
+        "DeaApiGatewaydeabaselambdaroleDefaultPolicy124421D1",
+        "DeaApiGatewaydeabaselambdarole91512884",
+      ],
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W58",
+              "reason": "AWSCustomResource Lambda Function has AWSLambdaBasicExecutionRole policy attached which has the required permission to write to Cloudwatch Logs",
+            },
+            Object {
+              "id": "W92",
+              "reason": "Reserved concurrency is currently not required. Revisit in the future",
+            },
+            Object {
+              "id": "W89",
+              "reason": "The serverless application lens (https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/aws-lambda.html)               indicates lambdas should not be deployed in private VPCs unless they require access to resources also within a VPC",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[HASH REMOVED].zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "ALLOWED_ORIGINS": "https://localhost:3001",
+            "AUDIT_LOG_GROUP_NAME": Object {
+              "Ref": "deaAuditLogs7B75D3F1",
+            },
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "DATASETS_BUCKET_NAME": Object {
+              "Ref": "DeaBackendStackS3DatasetsBucket408FF954",
+            },
+            "DELETE_CASE_FILE_LAMBDA_ARN": Object {
+              "Fn::GetAtt": Array [
+                "DeaEventHandlerss3batchdeletecasefileF6E3BAAE",
+                "Arn",
+              ],
+            },
+            "DELETE_CASE_FILE_ROLE": Object {
+              "Fn::GetAtt": Array [
+                "DeaEventHandlerss3batchdeletecasefileroleBAD7A58C",
+                "Arn",
+              ],
+            },
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STAGE": "[STAGE-REMOVED]",
+            "TABLE_NAME": Object {
+              "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2269,6 +2494,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2342,6 +2570,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2413,6 +2644,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2486,6 +2720,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2558,6 +2795,9 @@ Object {
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
             },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
+            },
           },
         },
         "Handler": "index.handler",
@@ -2629,6 +2869,9 @@ Object {
             "STAGE": "[STAGE-REMOVED]",
             "TABLE_NAME": Object {
               "Ref": "DeaBackendStackDeaTableE9FE4A05",
+            },
+            "TRAIL_LOG_GROUP_NAME": Object {
+              "Ref": "deaTrailLogs0A0531F5",
             },
           },
         },
@@ -2727,7 +2970,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::UsagePlan",
     },
-    "DeaApiGatewaydeaapiDeployment99E776295fbdbd1297ea84b10255b270dc91fd56": Object {
+    "DeaApiGatewaydeaapiDeployment99E7762970eb05cd1d53047135704b9ec5580d77": Object {
       "DependsOn": Array [
         "DeaApiGatewaydeaapiauthauthCodeOPTIONS8EA9BA0F",
         "DeaApiGatewaydeaapiauthauthCodeFC92ADBD",
@@ -2818,6 +3061,16 @@ Object {
         "DeaApiGatewaydeaapicasesPOST966FABAB",
         "DeaApiGatewaydeaapicasesC01D624D",
         "DeaApiGatewaydeaapiOPTIONS098252F2",
+        "DeaApiGatewaydeaapisystemauditauditIdcsvGET6F78F58A",
+        "DeaApiGatewaydeaapisystemauditauditIdcsvOPTIONSB627E509",
+        "DeaApiGatewaydeaapisystemauditauditIdcsv14E7D7D1",
+        "DeaApiGatewaydeaapisystemauditauditIdOPTIONS4E0961DF",
+        "DeaApiGatewaydeaapisystemauditauditIdBE52065E",
+        "DeaApiGatewaydeaapisystemauditOPTIONSF92BC8D9",
+        "DeaApiGatewaydeaapisystemauditPOST7DE89403",
+        "DeaApiGatewaydeaapisystemaudit7E7C8D6B",
+        "DeaApiGatewaydeaapisystemOPTIONS6EF8E1C0",
+        "DeaApiGatewaydeaapisystem63A4B81F",
         "DeaApiGatewaydeaapiuiproxyGETD7F3590B",
         "DeaApiGatewaydeaapiuiproxyOPTIONS7D1A7859",
         "DeaApiGatewaydeaapiuiproxy57F1250D",
@@ -2876,7 +3129,7 @@ Object {
           "Format": "{\\"stage\\":\\"$context.stage\\",\\"requestId\\":\\"$context.requestId\\",\\"integrationRequestId\\":\\"$context.integration.requestId\\",\\"status\\":\\"$context.status\\",\\"apiId\\":\\"$context.apiId\\",\\"resourcePath\\":\\"$context.resourcePath\\",\\"path\\":\\"$context.path\\",\\"resourceId\\":\\"$context.resourceId\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"userAgent\\":\\"$context.identity.userAgent\\"}",
         },
         "DeploymentId": Object {
-          "Ref": "DeaApiGatewaydeaapiDeployment99E776295fbdbd1297ea84b10255b270dc91fd56",
+          "Ref": "DeaApiGatewaydeaapiDeployment99E7762970eb05cd1d53047135704b9ec5580d77",
         },
         "RestApiId": Object {
           "Ref": "DeaApiGatewaydeaapi822A9228",
@@ -7910,6 +8163,465 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
+    "DeaApiGatewaydeaapisystem63A4B81F": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewaydeaapi822A9228",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "system",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapisystemOPTIONS6EF8E1C0": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapisystem63A4B81F",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapisystemaudit7E7C8D6B": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapisystem63A4B81F",
+        },
+        "PathPart": "audit",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapisystemauditOPTIONSF92BC8D9": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapisystemaudit7E7C8D6B",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapisystemauditPOST7DE89403": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "POST",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayPOSTRequestSystemAudit1876CDAF",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapisystemaudit7E7C8D6B",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapisystemauditPOSTApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9POSTsystemaudit9CEA872E": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPOSTRequestSystemAudit1876CDAF",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/POST/system/audit",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapisystemauditPOSTApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9POSTsystemauditE2A490DF": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayPOSTRequestSystemAudit1876CDAF",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/POST/system/audit",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapisystemauditauditIdBE52065E": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapisystemaudit7E7C8D6B",
+        },
+        "PathPart": "{auditId}",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapisystemauditauditIdOPTIONS4E0961DF": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapisystemauditauditIdBE52065E",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapisystemauditauditIdcsv14E7D7D1": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "DeaApiGatewaydeaapisystemauditauditIdBE52065E",
+        },
+        "PathPart": "csv",
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "DeaApiGatewaydeaapisystemauditauditIdcsvGET6F78F58A": Object {
+      "Properties": Object {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DeaApiGatewayGETGetSystemAuditAD3F46B8",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapisystemauditauditIdcsv14E7D7D1",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "DeaApiGatewaydeaapisystemauditauditIdcsvGETApiPermissionDeaMainStackDeaApiGatewaydeaapi25A632E9GETsystemauditauditIdcsv830DFC59": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetSystemAuditAD3F46B8",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/",
+              Object {
+                "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+              },
+              "/GET/system/audit/*/csv",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapisystemauditauditIdcsvGETApiPermissionTestDeaMainStackDeaApiGatewaydeaapi25A632E9GETsystemauditauditIdcsvD0028623": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "DeaApiGatewayGETGetSystemAuditAD3F46B8",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "DeaApiGatewaydeaapi822A9228",
+              },
+              "/test-invoke-stage/GET/system/audit/*/csv",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DeaApiGatewaydeaapisystemauditauditIdcsvOPTIONSB627E509": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": Object {
+          "IntegrationResponses": Array [
+            Object {
+              "ResponseParameters": Object {
+                "method.response.header.Access-Control-Allow-Credentials": "'true'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,CSRF-Token,x-amz-security-token,set-cookie'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://localhost:3001'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": Object {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": Array [
+          Object {
+            "ResponseParameters": Object {
+              "method.response.header.Access-Control-Allow-Credentials": true,
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": Object {
+          "Ref": "DeaApiGatewaydeaapisystemauditauditIdcsv14E7D7D1",
+        },
+        "RestApiId": Object {
+          "Ref": "DeaApiGatewaydeaapi822A9228",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
     "DeaApiGatewaydeaapiui838E08AB": Object {
       "Properties": Object {
         "ParentId": Object {
@@ -9667,12 +10379,20 @@ Object {
             Object {
               "Action": "logs:StartQuery",
               "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "deaAuditLogs7B75D3F1",
-                  "Arn",
-                ],
-              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "deaAuditLogs7B75D3F1",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::GetAtt": Array [
+                    "deaTrailLogs0A0531F5",
+                    "Arn",
+                  ],
+                },
+              ],
             },
             Object {
               "Action": Array [
@@ -11710,6 +12430,62 @@ Object {
                     ],
                   ],
                 },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/POST/system/audit",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/GET/system/audit/*/csv",
+                    ],
+                  ],
+                },
               ],
             },
           ],
@@ -11731,7 +12507,7 @@ Object {
         "Name": "/dea/us-east-1/[STAGE-REMOVED]-EvidenceManager-actions",
         "Tier": "Standard",
         "Type": "StringList",
-        "Value": "/cases/{caseId}/actionsGET,/cases/{caseId}/userMembershipsGET,/auth/{authCode}/tokenPOST,/auth/loginUrlGET,/auth/logoutUrlGET,/auth/refreshTokenPOST,/auth/revokeTokenPOST,/auth/credentials/{idToken}/exchangeGET,/usersGET,/cases/all-casesGET,/availableEndpointsGET,/cases/{caseId}/scopedInformationGET,/cases/{caseId}/ownerPOST,/users/{userId}/auditPOST,/users/{userId}/audit/{auditId}/csvGET",
+        "Value": "/cases/{caseId}/actionsGET,/cases/{caseId}/userMembershipsGET,/auth/{authCode}/tokenPOST,/auth/loginUrlGET,/auth/logoutUrlGET,/auth/refreshTokenPOST,/auth/revokeTokenPOST,/auth/credentials/{idToken}/exchangeGET,/usersGET,/cases/all-casesGET,/availableEndpointsGET,/cases/{caseId}/scopedInformationGET,/cases/{caseId}/ownerPOST,/users/{userId}/auditPOST,/users/{userId}/audit/{auditId}/csvGET,/system/auditPOST,/system/audit/{auditId}/csvGET",
       },
       "Type": "AWS::SSM::Parameter",
     },
@@ -13273,6 +14049,62 @@ Object {
                     ],
                   ],
                 },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/POST/system/audit",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/GET/system/audit/*/csv",
+                    ],
+                  ],
+                },
               ],
             },
           ],
@@ -13294,7 +14126,7 @@ Object {
         "Name": "/dea/us-east-1/[STAGE-REMOVED]-WorkingManager-actions",
         "Tier": "Standard",
         "Type": "StringList",
-        "Value": "/casesPOST,/cases/{caseId}/detailsGET,/cases/{caseId}/detailsPUT,/cases/{caseId}/detailsDELETE,/cases/{caseId}/actionsGET,/cases/{caseId}/userMembershipsGET,/cases/{caseId}/userMembershipsPOST,/cases/{caseId}/users/{userId}/membershipsPUT,/cases/{caseId}/users/{userId}/membershipsDELETE,/auth/{authCode}/tokenPOST,/auth/loginUrlGET,/auth/logoutUrlGET,/auth/refreshTokenPOST,/auth/revokeTokenPOST,/auth/credentials/{idToken}/exchangeGET,/usersGET,/cases/{caseId}/filesPOST,/cases/{caseId}/filesGET,/cases/{caseId}/files/{fileId}/contentsPUT,/cases/{caseId}/files/{fileId}/infoGET,/cases/{caseId}/files/{fileId}/contentsGET,/cases/my-casesGET,/cases/all-casesGET,/cases/{caseId}/audit/{auditId}/csvGET,/cases/{caseId}/auditPOST,/availableEndpointsGET,/cases/{caseId}/scopedInformationGET,/cases/{caseId}/ownerPOST,/users/{userId}/auditPOST,/users/{userId}/audit/{auditId}/csvGET",
+        "Value": "/casesPOST,/cases/{caseId}/detailsGET,/cases/{caseId}/detailsPUT,/cases/{caseId}/detailsDELETE,/cases/{caseId}/actionsGET,/cases/{caseId}/userMembershipsGET,/cases/{caseId}/userMembershipsPOST,/cases/{caseId}/users/{userId}/membershipsPUT,/cases/{caseId}/users/{userId}/membershipsDELETE,/auth/{authCode}/tokenPOST,/auth/loginUrlGET,/auth/logoutUrlGET,/auth/refreshTokenPOST,/auth/revokeTokenPOST,/auth/credentials/{idToken}/exchangeGET,/usersGET,/cases/{caseId}/filesPOST,/cases/{caseId}/filesGET,/cases/{caseId}/files/{fileId}/contentsPUT,/cases/{caseId}/files/{fileId}/infoGET,/cases/{caseId}/files/{fileId}/contentsGET,/cases/my-casesGET,/cases/all-casesGET,/cases/{caseId}/audit/{auditId}/csvGET,/cases/{caseId}/auditPOST,/availableEndpointsGET,/cases/{caseId}/scopedInformationGET,/cases/{caseId}/ownerPOST,/users/{userId}/auditPOST,/users/{userId}/audit/{auditId}/csvGET,/system/auditPOST,/system/audit/{auditId}/csvGET",
       },
       "Type": "AWS::SSM::Parameter",
     },
@@ -14207,6 +15039,62 @@ Object {
                         "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
                       },
                       "/POST/users/*/audit",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/GET/system/audit/*/csv",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapi822A9228",
+                      },
+                      "/",
+                      Object {
+                        "Ref": "DeaApiGatewaydeaapiDeploymentStage[STAGE-REMOVED][HASH REMOVED]",
+                      },
+                      "/POST/system/audit",
                     ],
                   ],
                 },


### PR DESCRIPTION
*Description of changes:*

Api endpoints for system audit logs retrievals:

`/system/audit` to start an audit request.
`/system/audit/{auditId}/csv` which will respond with the status of the query or the results in csv format.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
