### PR TITLE
feat: add UI integration to start and retrieve system audit logs

### DIFF
--- a/source/dea-ui/ui/README.md
+++ b/source/dea-ui/ui/README.md
@@ -8,7 +8,7 @@ This is a prototype app and you should expect to modify the source code to refle
 
 | Statements                                                                                   | Branches                                                                                 | Functions                                                                                  | Lines                                                                              |
 | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-92.66%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.26%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.34%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-92.79%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-93.11%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.85%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.49%25-brightgreen.svg?style=flat) |
 
 ## Deploying code changes
 

--- a/source/dea-ui/ui/__tests__/components/navigation.integration.test.tsx
+++ b/source/dea-ui/ui/__tests__/components/navigation.integration.test.tsx
@@ -1,0 +1,128 @@
+import wrapper from '@cloudscape-design/components/test-utils/dom';
+import '@testing-library/jest-dom';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Axios from 'axios';
+import { navigationLabels } from '../../src/common/labels';
+import BaseLayout from '../../src/components/BaseLayout';
+
+afterEach(cleanup);
+
+jest.mock('axios');
+const mockedAxios = Axios as jest.Mocked<typeof Axios>;
+
+const useRouter = jest.spyOn(require('next/router'), 'useRouter');
+const router = {
+  push: jest.fn(),
+};
+useRouter.mockReturnValue(router);
+
+global.fetch = jest.fn(() => Promise.resolve({ blob: () => Promise.resolve('foo') }));
+global.window.URL.createObjectURL = jest.fn(() => {});
+HTMLAnchorElement.prototype.click = jest.fn();
+
+let csvCall = -1;
+let failingCall = -1;
+
+const csvResult = [{ status: 'Running' }, { status: 'Running' }, 'csvresults'];
+const failingCsvResult = [{ status: 'Running' }, { status: 'Running' }, { status: 'Cancelled' }];
+
+describe('Navigation', () => {
+  it('downloads system audit logs', async () => {
+    mockedAxios.create.mockReturnThis();
+    mockedAxios.request.mockImplementation((eventObj) => {
+      if (eventObj.url === 'https://localhostsystem/audit') {
+        return Promise.resolve({
+          data: { auditId: 'audit-id' },
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      } else if (eventObj.url === 'https://localhostsystem/audit/audit-id/csv') {
+        return Promise.resolve({
+          data: csvResult[++csvCall],
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      } else {
+        //availableEndpoints
+        return Promise.resolve({
+          data: {
+            endpoints: ['/system/auditPOST'],
+          },
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      }
+    });
+
+    const baseLayout = render(<BaseLayout children={undefined} breadcrumbs={[]} />);
+    expect(baseLayout).toBeTruthy();
+
+    const downloadSystemLogsLink = await screen.findByText(navigationLabels.systemAuditLogsLabel);
+    fireEvent.click(downloadSystemLogsLink);
+
+    // assert spinner component
+    const sideNavigation = wrapper(baseLayout.container).findSideNavigation()!;
+    expect(sideNavigation).toBeTruthy();
+    await waitFor(() => expect(wrapper(sideNavigation.getElement()).findSpinner()).toBeTruthy());
+    await waitFor(() => expect(wrapper(sideNavigation.getElement()).findSpinner()).toBeFalsy(), {
+      timeout: 4000,
+    });
+  });
+
+  it('recovers from a from a csv download failure', async () => {
+    mockedAxios.create.mockReturnThis();
+    mockedAxios.request.mockImplementation((eventObj) => {
+      if (eventObj.url === 'https://localhostsystem/audit') {
+        return Promise.resolve({
+          data: { auditId: 'audit-id' },
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      } else if (eventObj.url === 'https://localhostsystem/audit/audit-id/csv') {
+        return Promise.resolve({
+          data: failingCsvResult[++failingCall],
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      } else {
+        //availableEndpoints
+        return Promise.resolve({
+          data: {
+            endpoints: ['/system/auditPOST'],
+          },
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {},
+        });
+      }
+    });
+
+    const baseLayout = render(<BaseLayout children={undefined} breadcrumbs={[]} />);
+    expect(baseLayout).toBeTruthy();
+
+    const downloadSystemLogsLink = await screen.findByText(navigationLabels.systemAuditLogsLabel);
+    fireEvent.click(downloadSystemLogsLink);
+
+    // assert spinner component
+    const sideNavigation = wrapper(baseLayout.container).findSideNavigation()!;
+    expect(sideNavigation).toBeTruthy();
+    await waitFor(() => expect(wrapper(sideNavigation.getElement()).findSpinner()).toBeTruthy());
+    await waitFor(() => expect(wrapper(sideNavigation.getElement()).findSpinner()).toBeFalsy(), {
+      timeout: 4000,
+    });
+    // error notification is visible
+    const notificationsWrapper = wrapper(baseLayout.container).findFlashbar()!;
+    expect(notificationsWrapper).toBeTruthy();
+  });
+});

--- a/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
@@ -4,7 +4,7 @@ import { act, cleanup, fireEvent, getByRole, render, screen, waitFor } from '@te
 import userEvent from '@testing-library/user-event';
 import { fail } from 'assert';
 import Axios from 'axios';
-import { auditLogLabels, caseDetailLabels, commonLabels } from '../../src/common/labels';
+import { auditLogLabels, caseDetailLabels } from '../../src/common/labels';
 import { NotificationsProvider } from '../../src/context/NotificationsContext';
 import CaseDetailsPage from '../../src/pages/case-detail';
 

--- a/source/dea-ui/ui/src/api/cases.tsx
+++ b/source/dea-ui/ui/src/api/cases.tsx
@@ -41,11 +41,11 @@ enum QueryStatus {
 }
 
 const progressStatus = [QueryStatus.Running, QueryStatus.Scheduled]
-export interface DeaCaseAuditStatus {
+export interface DeaAuditStatus {
   status: QueryStatus;
 }
 
-export interface DeaCaseAuditStartResponse {
+export interface DeaAuditStartResponse {
   auditId: string;
 }
 
@@ -142,11 +142,11 @@ export const getCaseAuditCSV = async (caseId: string): Promise<string> => {
 }
 
 export const startCaseAuditQuery = async (caseId: string): Promise<string> => {
-  const data: DeaCaseAuditStartResponse = await httpApiPost(`cases/${caseId}/audit`, undefined);
+  const data: DeaAuditStartResponse = await httpApiPost(`cases/${caseId}/audit`, undefined);
   return data.auditId;
 }
 
-export const retrieveCaseAuditResult = async (caseId: string, auditId: string): Promise<string | DeaCaseAuditStatus> => {
+export const retrieveCaseAuditResult = async (caseId: string, auditId: string): Promise<string | DeaAuditStatus> => {
   return await httpApiGet(`cases/${caseId}/audit/${auditId}/csv`, undefined);
 }
 
@@ -158,3 +158,28 @@ export const useGetCaseActions = (id: string): DeaSingleResult<CaseUser | undefi
   const { data, error } = useSWR(() => `cases/${id}/actions`, httpApiGet<CaseUser>);
   return { data, isLoading: !data && !error };
 };
+
+export const getSystemAuditCSV = async (): Promise<string> => {
+  const auditId = await startSystemAuditQuery();
+  let auditResponse = await retrieveSystemAuditResult(auditId);
+  let maxRetries = 60;
+  while (typeof(auditResponse) !== 'string') {
+    if (!progressStatus.includes(auditResponse.status) ||
+        maxRetries === 0) {
+      throw new Error(`Audit request was empty or experienced a failure. Status: ${auditResponse.status}`);
+    }
+    --maxRetries;
+    await delay(1000);
+    auditResponse = await retrieveSystemAuditResult(auditId);
+  }
+  return auditResponse;
+}
+
+export const startSystemAuditQuery = async (): Promise<string> => {
+  const data: DeaAuditStartResponse = await httpApiPost(`system/audit`, undefined);
+  return data.auditId;
+}
+
+export const retrieveSystemAuditResult = async (auditId: string): Promise<string | DeaAuditStatus> => {
+  return await httpApiGet(`system/audit/${auditId}/csv`, undefined);
+}

--- a/source/dea-ui/ui/src/common/labels.tsx
+++ b/source/dea-ui/ui/src/common/labels.tsx
@@ -121,7 +121,7 @@ export const auditLogLabels = {
   emptyAuditLabel: 'No audit',
   noDisplayAuditLabel: 'No audit to display.',
   loadingLabel: 'loading audit log',
-  errorLabel: 'Error downloading case audit. Audit query is empty or encountered an error or cancellation.',
+  errorLabel: 'Error downloading audit logs. Audit query is empty or encountered an error or cancellation.',
 };
 
 export const manageCaseAccessLabels = {
@@ -244,4 +244,11 @@ export const breadcrumbLabels = {
   caseDetailsLabel: 'Case Details',
   manageCaseLabel: 'Manage Case',
   uploadFilesAndFoldersLabel: 'Upload folders/files',
+};
+
+export const navigationLabels = {
+  documentationLabel: 'Documentation',
+  myCasesLabel: 'My Cases',
+  allSystemCasesLabel: 'All System Cases',
+  systemAuditLogsLabel: 'Download System Audit Log',
 };

--- a/source/dea-ui/ui/src/components/Navigation.tsx
+++ b/source/dea-ui/ui/src/components/Navigation.tsx
@@ -3,11 +3,14 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { Spinner } from '@cloudscape-design/components';
+import { Icon, Spinner } from '@cloudscape-design/components';
 import SideNavigation, { SideNavigationProps } from '@cloudscape-design/components/side-navigation';
 import { useRouter } from 'next/router';
-import * as React from 'react';
+import { useState } from 'react';
 import { useAvailableEndpoints } from '../api/auth';
+import { getSystemAuditCSV } from '../api/cases';
+import { auditLogLabels, navigationLabels } from '../common/labels';
+import { useNotifications } from '../context/NotificationsContext';
 
 export interface NavigationProps {
   initialHref?: string;
@@ -17,16 +20,18 @@ export interface NavigationProps {
 
 const MY_CASES_ENDPOINT = '/cases/my-casesGET';
 const ALL_CASES_ENDPOINT = '/cases/all-casesGET';
+const SYSTEM_AUDIT_ENDPOINT = '/system/auditPOST';
 
 export default function Navigation({ initialHref, header }: NavigationProps): JSX.Element {
   const defaultNavHeader: SideNavigationProps.Header = {
     text: 'Digital Evidence Archive',
     href: '#/',
   };
-
   const router = useRouter();
 
-  const [activeHref, setActiveHref] = React.useState(initialHref);
+  const [activeHref, setActiveHref] = useState(initialHref);
+  const [downloadInProgress, setDownloadInProgress] = useState(false);
+  const { pushNotification } = useNotifications();
 
   const availableEndpoints = useAvailableEndpoints();
   if (availableEndpoints.isLoading) {
@@ -35,37 +40,63 @@ export default function Navigation({ initialHref, header }: NavigationProps): JS
 
   const navItems: SideNavigationProps.Item[] = [];
   if (availableEndpoints.data?.includes(MY_CASES_ENDPOINT)) {
-    navItems.push({ type: 'link', text: 'My Cases', href: '/' });
+    navItems.push({ type: 'link', text: navigationLabels.myCasesLabel, href: '/' });
   }
 
   if (availableEndpoints.data?.includes(ALL_CASES_ENDPOINT)) {
-    navItems.push({ type: 'link', text: 'All System Cases', href: '/all-cases' });
+    navItems.push({ type: 'link', text: navigationLabels.allSystemCasesLabel, href: '/all-cases' });
   }
+
+  const downloadSystemAudit = async () => {
+    setDownloadInProgress(true);
+    try {
+      const csv = await getSystemAuditCSV();
+      const blob = new Blob([csv], { type: 'text/csv' });
+      const fileUrl = window.URL.createObjectURL(blob);
+      const alink = document.createElement('a');
+      alink.href = fileUrl;
+      alink.download = `System_Audit_${new Date().toLocaleString()}`;
+      alink.click();
+    } catch (e) {
+      pushNotification('error', auditLogLabels.errorLabel);
+    } finally {
+      setDownloadInProgress(false);
+    }
+  };
 
   navItems.push(
     { type: 'divider' },
     {
       type: 'link',
-      text: 'Documentation',
+      text: navigationLabels.documentationLabel,
       href: 'https://example.com',
-      external: true,
-    },
-    {
-      type: 'link',
-      text: 'Download System Audit Log',
-      href: '#',
       external: true,
     }
   );
+
+  if (availableEndpoints.data?.includes(SYSTEM_AUDIT_ENDPOINT)) {
+    navItems.push({
+      type: 'link',
+      text: navigationLabels.systemAuditLogsLabel,
+      href: '#',
+      info: downloadInProgress ? <Spinner /> : <Icon name="download" />,
+    });
+  }
 
   return (
     <SideNavigation
       data-testid="sideNavigation"
       activeHref={activeHref}
       header={header ?? defaultNavHeader}
-      onFollow={(event) => {
+      onFollow={async (event) => {
         if (!event.detail.external) {
           event.preventDefault();
+          if (event.detail.text === navigationLabels.systemAuditLogsLabel) {
+            if (downloadInProgress) {
+              return;
+            }
+            await downloadSystemAudit();
+          }
           setActiveHref(event.detail.href);
           void router.push(event.detail.href);
         }


### PR DESCRIPTION
*Description of changes:*
 `UI` integration to start and retrieve system audit logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
