### PR TITLE
ci: reuse the deploy stage across runs with in the same PR

### DIFF
--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -2,8 +2,8 @@ name: Pull Request Workflow
 
 env:
   CONFIGNAME: 'chewbacca'
-  STAGE: RUN${{github.run_number}}
-  DOMAIN_PREFIX: deatestenv${{github.run_number}}
+  STAGE: PRPIPELINE${{github.event.pull_request.number}}
+  DOMAIN_PREFIX: deatestenv${{github.event.pull_request.number}}
 
 on:
   pull_request:


### PR DESCRIPTION
- reuse the deploy stage across runs within the same PR
  - this will potentially save time on redeploys when pushing new code (e.g. pushing a test fix wont require a redeploy)