### PR TITLE
refactor: introduce audit job to abstract audit implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Digital Evidence Archive on AWS enables Law Enforcement organizations to ingest 
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-96.54%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-89.46%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-94.97%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-96.47%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-96.09%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.92%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-93.57%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-96.15%25-brightgreen.svg?style=flat) |
 
 
 # Getting Started

--- a/source/dea-app/README.md
+++ b/source/dea-app/README.md
@@ -5,6 +5,6 @@
 
 | Statements                                                                         | Branches                                                                      | Functions                                                                        | Lines                                                                   |
 | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-98.21%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-87.74%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-98.03%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-97.87%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.71%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.66%25-brightgreen.svg?style=flat) |
 
 This project is the routing package for `dea-backend`. It is used by `dea-backend` to generate routes for DEA API. Please refer [here](../dea-backend/README.md) for more information on how to use this project.

--- a/source/dea-app/package.json
+++ b/source/dea-app/package.json
@@ -15,16 +15,16 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
+    "acl:only": ". ../common/scripts/setEnv.sh && heft test --no-build --disable-code-coverage --test-path-pattern '.*/*e2e.acl.test.*'",
     "add-license-header": "license-check-and-add add -f license-add-config.json",
+    "audit:only": ". ../common/scripts/setEnv.sh && heft test --no-build --disable-code-coverage --test-path-pattern '.*/*e2e.audit.test.*'",
     "build": "heft build",
     "build:clean": "heft build --clean",
     "build:test": "heft test && rushx pkg-json-lint && rushx make-badges",
     "check-license-header": "license-check-and-add check -f license-add-config.json",
     "create-cognito-user": ". ../common/scripts/setEnv.sh && npx ts-node src/test/local-dev-support/create-user.ts",
     "delete-cognito-user": ". ../common/scripts/setEnv.sh && npx ts-node src/test/local-dev-support/delete-user.ts",
-    "acl:only": ". ../common/scripts/setEnv.sh && heft test --no-build --disable-code-coverage --test-path-pattern '.*/*e2e.acl.test.*'",
     "e2e:only": ". ../common/scripts/setEnv.sh && heft test --no-build --disable-code-coverage --test-path-pattern '.*/*e2e.test.*'",
-    "audit:only": ". ../common/scripts/setEnv.sh && heft test --no-build --disable-code-coverage --test-path-pattern '.*/*e2e.audit.test.*'",
     "get-user-creds": ". ../common/scripts/setEnv.sh && npx ts-node src/test/local-dev-support/get-user-creds.ts",
     "idp-test-setup": ". ../common/scripts/setEnv.sh && npx ts-node src/test/local-dev-support/idp-test-setup.ts",
     "integration:only": ". ../common/scripts/setEnv.sh && heft test --no-build --disable-code-coverage  --test-path-pattern '.*/*integration.test.*'",
@@ -57,9 +57,9 @@
     "crypto-js": "^4.1.1",
     "jsonwebtoken": "~9.0.0",
     "lodash": "^4.17.21",
+    "pkce-challenge": "^3.0.0",
     "puppeteer": "19.8.0",
-    "uuid": "^9.0.0",
-    "pkce-challenge": "^3.0.0"
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@aws-sdk/client-cloudwatch-logs": "~3.299.0",
@@ -107,7 +107,7 @@
     "ts-mockito": "~2.6.1",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.2",
-    "wait-port": "~1.0.4",
-    "ulid": "~2.3.0"
+    "ulid": "~2.3.0",
+    "wait-port": "~1.0.4"
   }
 }

--- a/source/dea-app/src/app/resources/get-case-audit.ts
+++ b/source/dea-app/src/app/resources/get-case-audit.ts
@@ -4,7 +4,7 @@
  */
 
 import { getRequiredPathParam } from '../../lambda-http-helpers';
-import { joiUuid } from '../../models/validation/joi-common';
+import { joiUlid } from '../../models/validation/joi-common';
 import { defaultProvider } from '../../persistence/schema/entities';
 import { defaultDatasetsProvider } from '../../storage/datasets';
 import { defaultCloudwatchClient } from '../audit/dea-audit-plugin';
@@ -17,14 +17,15 @@ export const getCaseAudit: DEAGatewayProxyHandler = async (
   context,
   /* the default case is handled in e2e tests */
   /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _repositoryProvider = defaultProvider,
+  repositoryProvider = defaultProvider,
   /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient
 ) => {
-  const auditId = getRequiredPathParam(event, 'auditId', joiUuid);
-  const result = await auditService.getAuditResult(auditId, cloudwatchClient);
+  const auditId = getRequiredPathParam(event, 'auditId', joiUlid);
+  const caseId = getRequiredPathParam(event, 'caseId', joiUlid);
+  const result = await auditService.getCaseAuditResult(auditId, caseId, cloudwatchClient, repositoryProvider);
 
   if (result.csvFormattedData) {
     return csvResponse(event, result.csvFormattedData);

--- a/source/dea-app/src/app/resources/get-case-file-audit.ts
+++ b/source/dea-app/src/app/resources/get-case-file-audit.ts
@@ -4,7 +4,7 @@
  */
 
 import { getRequiredPathParam } from '../../lambda-http-helpers';
-import { joiUuid } from '../../models/validation/joi-common';
+import { joiUlid } from '../../models/validation/joi-common';
 import { defaultProvider } from '../../persistence/schema/entities';
 import { defaultDatasetsProvider } from '../../storage/datasets';
 import { defaultCloudwatchClient } from '../audit/dea-audit-plugin';
@@ -17,14 +17,21 @@ export const getCaseFileAudit: DEAGatewayProxyHandler = async (
   context,
   /* the default case is handled in e2e tests */
   /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _repositoryProvider = defaultProvider,
+  repositoryProvider = defaultProvider,
   /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient
 ) => {
-  const auditId = getRequiredPathParam(event, 'auditId', joiUuid);
-  const result = await auditService.getAuditResult(auditId, cloudwatchClient);
+  const auditId = getRequiredPathParam(event, 'auditId', joiUlid);
+  const caseId = getRequiredPathParam(event, 'caseId', joiUlid);
+  const fileId = getRequiredPathParam(event, 'fileId', joiUlid);
+  const result = await auditService.getCaseFileAuditResult(
+    auditId,
+    `${caseId}${fileId}`,
+    cloudwatchClient,
+    repositoryProvider
+  );
 
   if (result.csvFormattedData) {
     return csvResponse(event, result.csvFormattedData);

--- a/source/dea-app/src/app/resources/get-system-audit.ts
+++ b/source/dea-app/src/app/resources/get-system-audit.ts
@@ -4,7 +4,7 @@
  */
 
 import { getRequiredPathParam } from '../../lambda-http-helpers';
-import { joiUuid } from '../../models/validation/joi-common';
+import { joiUlid } from '../../models/validation/joi-common';
 import { defaultProvider } from '../../persistence/schema/entities';
 import { defaultDatasetsProvider } from '../../storage/datasets';
 import { defaultCloudwatchClient } from '../audit/dea-audit-plugin';
@@ -17,14 +17,14 @@ export const getSystemAudit: DEAGatewayProxyHandler = async (
   context,
   /* the default case is handled in e2e tests */
   /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _repositoryProvider = defaultProvider,
+  repositoryProvider = defaultProvider,
   /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient
 ) => {
-  const auditId = getRequiredPathParam(event, 'auditId', joiUuid);
-  const result = await auditService.getAuditResult(auditId, cloudwatchClient);
+  const auditId = getRequiredPathParam(event, 'auditId', joiUlid);
+  const result = await auditService.getSystemAuditResult(auditId, cloudwatchClient, repositoryProvider);
 
   if (result.csvFormattedData) {
     return csvResponse(event, result.csvFormattedData);

--- a/source/dea-app/src/app/resources/get-user-audit.ts
+++ b/source/dea-app/src/app/resources/get-user-audit.ts
@@ -4,7 +4,7 @@
  */
 
 import { getRequiredPathParam } from '../../lambda-http-helpers';
-import { joiUuid } from '../../models/validation/joi-common';
+import { joiUlid } from '../../models/validation/joi-common';
 import { defaultProvider } from '../../persistence/schema/entities';
 import { defaultDatasetsProvider } from '../../storage/datasets';
 import { defaultCloudwatchClient } from '../audit/dea-audit-plugin';
@@ -17,14 +17,15 @@ export const getUserAudit: DEAGatewayProxyHandler = async (
   context,
   /* the default case is handled in e2e tests */
   /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _repositoryProvider = defaultProvider,
+  repositoryProvider = defaultProvider,
   /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient
 ) => {
-  const auditId = getRequiredPathParam(event, 'auditId', joiUuid);
-  const result = await auditService.getAuditResult(auditId, cloudwatchClient);
+  const auditId = getRequiredPathParam(event, 'auditId', joiUlid);
+  const userId = getRequiredPathParam(event, 'userId', joiUlid);
+  const result = await auditService.getUserAuditResult(auditId, userId, cloudwatchClient, repositoryProvider);
 
   if (result.csvFormattedData) {
     return csvResponse(event, result.csvFormattedData);

--- a/source/dea-app/src/app/resources/start-case-audit.ts
+++ b/source/dea-app/src/app/resources/start-case-audit.ts
@@ -30,7 +30,14 @@ export const startCaseAudit: DEAGatewayProxyHandler = async (
   const end = getQueryParam(event, 'to', now.toString(), Joi.number().integer());
   const startTime = Number.parseInt(start);
   const endTime = Number.parseInt(end);
-  const queryId = await auditService.requestAuditForCase(caseId, startTime, endTime, cloudwatchClient);
+  const queryId = await auditService.requestAuditForCase(
+    caseId,
+    startTime,
+    endTime,
+    caseId,
+    cloudwatchClient,
+    _repositoryProvider
+  );
 
   return responseOk(event, { auditId: queryId });
 };

--- a/source/dea-app/src/app/resources/start-case-file-audit.ts
+++ b/source/dea-app/src/app/resources/start-case-file-audit.ts
@@ -37,7 +37,9 @@ export const startCaseFileAudit: DEAGatewayProxyHandler = async (
     fileId,
     startTime,
     endTime,
-    cloudwatchClient
+    `${caseId}${fileId}`,
+    cloudwatchClient,
+    _repositoryProvider
   );
 
   return responseOk(event, { auditId: queryId });

--- a/source/dea-app/src/app/resources/start-system-audit.ts
+++ b/source/dea-app/src/app/resources/start-system-audit.ts
@@ -28,7 +28,12 @@ export const startSystemAudit: DEAGatewayProxyHandler = async (
   const end = getQueryParam(event, 'to', now.toString(), Joi.number().integer());
   const startTime = Number.parseInt(start);
   const endTime = Number.parseInt(end);
-  const queryId = await auditService.requestSystemAudit(startTime, endTime, cloudwatchClient);
+  const queryId = await auditService.requestSystemAudit(
+    startTime,
+    endTime,
+    cloudwatchClient,
+    _repositoryProvider
+  );
 
   return responseOk(event, { auditId: queryId });
 };

--- a/source/dea-app/src/app/resources/start-user-audit.ts
+++ b/source/dea-app/src/app/resources/start-user-audit.ts
@@ -30,7 +30,14 @@ export const startUserAudit: DEAGatewayProxyHandler = async (
   const end = getQueryParam(event, 'to', now.toString(), Joi.number().integer());
   const startTime = Number.parseInt(start);
   const endTime = Number.parseInt(end);
-  const queryId = await auditService.requestAuditForUser(userId, startTime, endTime, cloudwatchClient);
+  const queryId = await auditService.requestAuditForUser(
+    userId,
+    startTime,
+    endTime,
+    userId,
+    cloudwatchClient,
+    _repositoryProvider
+  );
 
   return responseOk(event, { auditId: queryId });
 };

--- a/source/dea-app/src/persistence/audit-job.ts
+++ b/source/dea-app/src/persistence/audit-job.ts
@@ -1,0 +1,41 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NotFoundError } from '../app/exceptions/not-found-exception';
+import { AuditType } from './schema/dea-schema';
+import { AuditJobModelRepositoryProvider } from './schema/entities';
+
+export const createAuditJob = async (
+  queryId: string,
+  auditType: AuditType,
+  resourceId: string,
+  repositoryProvider: AuditJobModelRepositoryProvider
+): Promise<string> => {
+  const newEntity = await repositoryProvider.AuditJobModel.create({
+    queryId,
+    auditType,
+    resourceId,
+  });
+
+  return newEntity.ulid;
+};
+
+export const getAuditJobQueryId = async (
+  ulid: string,
+  auditType: string,
+  resourceId: string,
+  repositoryProvider: AuditJobModelRepositoryProvider
+): Promise<string> => {
+  const sessionEntity = await repositoryProvider.AuditJobModel.get({
+    PK: `AUDIT#${ulid}#`,
+    SK: `${auditType}#${resourceId}#`,
+  });
+
+  if (!sessionEntity) {
+    throw new NotFoundError('Audit Job not found.');
+  }
+
+  return sessionEntity.queryId;
+};

--- a/source/dea-app/src/persistence/schema/dea-schema.ts
+++ b/source/dea-app/src/persistence/schema/dea-schema.ts
@@ -10,6 +10,13 @@ import { allButDisallowed, ulidRegex, filePathSafeCharsRegex } from '../../model
 
 const DEFAULT_SESSION_TTL_TIME_ADDITION_SECONDS = 43200; // 12 hours (e.g. expiry of the refresh token)
 
+export enum AuditType {
+  CASE = 'CASE',
+  CASEFILE = 'CASEFILE',
+  SYSTEM = 'SYSTEM',
+  USER = 'USER',
+}
+
 export const DeaSchema = {
   format: 'onetable:1.1.0',
   version: '0.1.0',
@@ -149,6 +156,14 @@ export const DeaSchema = {
       //managed by onetable - but included for entity generation
       created: { type: Date },
       updated: { type: Date },
+    },
+    AuditJob: {
+      PK: { type: String, value: 'AUDIT#${ulid}#', required: true },
+      SK: { type: String, value: '${auditType}#${resourceId}#' },
+      ulid: { type: String, generate: 'ulid', validate: ulidRegex, required: true },
+      queryId: { type: String, required: true },
+      resourceId: { type: String, required: true },
+      auditType: { type: String, required: true, enum: Object.keys(AuditType) },
     },
   } as const,
   params: {

--- a/source/dea-app/src/persistence/schema/entities.ts
+++ b/source/dea-app/src/persistence/schema/entities.ts
@@ -25,6 +25,9 @@ export const JobModel: Model<JobType> = deaTable.getModel('Job');
 export type UserType = Entity<typeof DeaSchema.models.User>;
 export const UserModel: Model<UserType> = deaTable.getModel('User');
 
+export type AuditJobType = Entity<typeof DeaSchema.models.AuditJob>;
+export const AuditJobModel: Model<AuditJobType> = deaTable.getModel('AuditJob');
+
 export interface CaseModelRepositoryProvider {
   CaseModel: Model<CaseType>;
 }
@@ -49,13 +52,18 @@ export interface UserModelRepositoryProvider {
   UserModel: Model<UserType>;
 }
 
+export interface AuditJobModelRepositoryProvider {
+  AuditJobModel: Model<AuditJobType>;
+}
+
 export interface ModelRepositoryProvider
   extends CaseModelRepositoryProvider,
     CaseUserModelRepositoryProvider,
     CaseFileModelRepositoryProvider,
     SessionModelRepositoryProvider,
     JobModelRepositoryProvider,
-    UserModelRepositoryProvider {
+    UserModelRepositoryProvider,
+    AuditJobModelRepositoryProvider {
   table: Table;
 }
 
@@ -67,4 +75,5 @@ export const defaultProvider: ModelRepositoryProvider = {
   SessionModel: SessionModel,
   JobModel: JobModel,
   UserModel: UserModel,
+  AuditJobModel: AuditJobModel,
 };

--- a/source/dea-app/src/test-e2e/resources/case-file-audit.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/case-file-audit.e2e.test.ts
@@ -9,7 +9,7 @@ import Joi from 'joi';
 import { AuditEventType } from '../../app/services/audit-service';
 import { Oauth2Token } from '../../models/auth';
 import { DeaCaseFile } from '../../models/case-file';
-import { joiUuid } from '../../models/validation/joi-common';
+import { joiUlid } from '../../models/validation/joi-common';
 import CognitoHelper from '../helpers/cognito-helper';
 import { testEnv } from '../helpers/settings';
 import {
@@ -136,7 +136,7 @@ describe('case file audit e2e', () => {
 
       expect(startAuditQueryResponse.status).toEqual(200);
       const auditId: string = startAuditQueryResponse.data.auditId;
-      Joi.assert(auditId, joiUuid);
+      Joi.assert(auditId, joiUlid);
 
       let retries = 5;
       let getQueryReponse = await callDeaAPIWithCreds(

--- a/source/dea-app/src/test-e2e/resources/case-file-upload.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/case-file-upload.e2e.test.ts
@@ -30,7 +30,7 @@ import {
 
 const FILE_PATH = '/food/sushi/';
 const FILE_CONTENT = 'hello world';
-const TEST_USER = 'caseFileUploadTestUser';
+const TEST_USER = `caseFileUploadTestUser${randomSuffix()}`;
 const FILE_SIZE_MB = 50;
 const DEA_API_URL = testEnv.apiUrlOutput;
 

--- a/source/dea-app/src/test-e2e/resources/system-audit.e2e.audit.test.ts
+++ b/source/dea-app/src/test-e2e/resources/system-audit.e2e.audit.test.ts
@@ -7,7 +7,7 @@ import { Credentials } from 'aws4-axios';
 import Joi from 'joi';
 import { AuditEventType } from '../../app/services/audit-service';
 import { Oauth2Token } from '../../models/auth';
-import { joiUuid } from '../../models/validation/joi-common';
+import { joiUlid } from '../../models/validation/joi-common';
 import CognitoHelper from '../helpers/cognito-helper';
 import { testEnv } from '../helpers/settings';
 import { callDeaAPIWithCreds, createCaseSuccess, deleteCase, randomSuffix } from './test-helpers';
@@ -104,7 +104,7 @@ describe('system audit e2e', () => {
 
       expect(startAuditQueryResponse.status).toEqual(200);
       const auditId: string = startAuditQueryResponse.data.auditId;
-      Joi.assert(auditId, joiUuid);
+      Joi.assert(auditId, joiUlid);
 
       let retries = 10;
       let getQueryReponse = await callDeaAPIWithCreds(

--- a/source/dea-app/src/test-e2e/resources/user-audit.e2e.audit.test.ts
+++ b/source/dea-app/src/test-e2e/resources/user-audit.e2e.audit.test.ts
@@ -7,7 +7,7 @@ import { Credentials } from 'aws4-axios';
 import Joi from 'joi';
 import { AuditEventType } from '../../app/services/audit-service';
 import { Oauth2Token } from '../../models/auth';
-import { joiUuid } from '../../models/validation/joi-common';
+import { joiUlid } from '../../models/validation/joi-common';
 import CognitoHelper from '../helpers/cognito-helper';
 import { testEnv } from '../helpers/settings';
 import {
@@ -113,7 +113,7 @@ describe('user audit e2e', () => {
 
       expect(startAuditQueryResponse.status).toEqual(200);
       const auditId: string = startAuditQueryResponse.data.auditId;
-      Joi.assert(auditId, joiUuid);
+      Joi.assert(auditId, joiUlid);
 
       let retries = 5;
       let getQueryReponse = await callDeaAPIWithCreds(

--- a/source/dea-app/src/test/app/audit-test-support.ts
+++ b/source/dea-app/src/test/app/audit-test-support.ts
@@ -1,0 +1,17 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ulid } from 'ulid';
+import { createAuditJob } from '../../persistence/audit-job';
+import { AuditType } from '../../persistence/schema/dea-schema';
+import { ModelRepositoryProvider } from '../../persistence/schema/entities';
+
+export const startAudit = async (
+  auditType: AuditType,
+  resourceId: string,
+  modelProvider: ModelRepositoryProvider
+) => {
+  return await createAuditJob(ulid(), auditType, resourceId, modelProvider);
+};

--- a/source/dea-app/src/test/app/resources/get-case-audit.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/get-case-audit.integration.test.ts
@@ -6,11 +6,20 @@
 import { CloudWatchLogsClient, GetQueryResultsCommand, QueryStatus } from '@aws-sdk/client-cloudwatch-logs';
 import { anyOfClass, anything, instance, mock, when } from 'ts-mockito';
 import { getCaseAudit } from '../../../app/resources/get-case-audit';
+import { AuditType } from '../../../persistence/schema/dea-schema';
+import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
 import { bogusUlid } from '../../../test-e2e/resources/test-helpers';
 import { dummyContext, getDummyEvent } from '../../integration-objects';
+import { getTestRepositoryProvider } from '../../persistence/local-db-table';
+import { startAudit } from '../audit-test-support';
 
 describe('start case audit', () => {
   const OLD_ENV = process.env;
+
+  let modelProvider: ModelRepositoryProvider;
+  beforeAll(async () => {
+    modelProvider = await getTestRepositoryProvider('getCaseAuditIntegration');
+  });
 
   beforeEach(() => {
     jest.resetModules();
@@ -23,6 +32,7 @@ describe('start case audit', () => {
   });
 
   it('responds with csv data', async () => {
+    const auditId = await startAudit(AuditType.CASE, bogusUlid, modelProvider);
     const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
     const clientMockInstance = instance(clientMock);
     when(clientMock.send(anyOfClass(GetQueryResultsCommand))).thenResolve({
@@ -45,16 +55,17 @@ describe('start case audit', () => {
     const event = getDummyEvent({
       pathParameters: {
         caseId: bogusUlid,
-        auditId: '11111111-1111-1111-1111-111111111111',
+        auditId,
       },
     });
-    const result = await getCaseAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    const result = await getCaseAudit(event, dummyContext, modelProvider, undefined, clientMockInstance);
 
     expect(result.statusCode).toEqual(200);
     expect(result.body).toEqual(expectedCSV);
   });
 
   it('returns status if not complete', async () => {
+    const auditId = await startAudit(AuditType.CASE, bogusUlid, modelProvider);
     const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
     const clientMockInstance = instance(clientMock);
     when(clientMock.send(anything())).thenResolve({ $metadata: {}, status: QueryStatus.Running });
@@ -62,16 +73,17 @@ describe('start case audit', () => {
     const event = getDummyEvent({
       pathParameters: {
         caseId: bogusUlid,
-        auditId: '11111111-1111-1111-1111-111111111111',
+        auditId,
       },
     });
-    const result = await getCaseAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    const result = await getCaseAudit(event, dummyContext, modelProvider, undefined, clientMockInstance);
     expect(result.statusCode).toEqual(200);
     const responseBody: { status: string } = JSON.parse(result.body);
     expect(responseBody.status).toEqual('Running');
   });
 
   it('returns complete with no data if data is not returned', async () => {
+    const auditId = await startAudit(AuditType.CASE, bogusUlid, modelProvider);
     const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
     const clientMockInstance = instance(clientMock);
     when(clientMock.send(anything())).thenResolve({ $metadata: {}, status: QueryStatus.Complete });
@@ -79,10 +91,10 @@ describe('start case audit', () => {
     const event = getDummyEvent({
       pathParameters: {
         caseId: bogusUlid,
-        auditId: '11111111-1111-1111-1111-111111111111',
+        auditId,
       },
     });
-    const result = await getCaseAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    const result = await getCaseAudit(event, dummyContext, modelProvider, undefined, clientMockInstance);
     expect(result.statusCode).toEqual(200);
     const responseBody: { status: string; csvFormattedData: string } = JSON.parse(result.body);
     expect(responseBody.status).toEqual('Complete');
@@ -90,6 +102,7 @@ describe('start case audit', () => {
   });
 
   it('returns complete with no data if data is empty', async () => {
+    const auditId = await startAudit(AuditType.CASE, bogusUlid, modelProvider);
     const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
     const clientMockInstance = instance(clientMock);
     when(clientMock.send(anything())).thenResolve({
@@ -101,10 +114,10 @@ describe('start case audit', () => {
     const event = getDummyEvent({
       pathParameters: {
         caseId: bogusUlid,
-        auditId: '11111111-1111-1111-1111-111111111111',
+        auditId,
       },
     });
-    const result = await getCaseAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    const result = await getCaseAudit(event, dummyContext, modelProvider, undefined, clientMockInstance);
     expect(result.statusCode).toEqual(200);
     const responseBody: { status: string; csvFormattedData: string } = JSON.parse(result.body);
     expect(responseBody.status).toEqual('Complete');
@@ -112,6 +125,7 @@ describe('start case audit', () => {
   });
 
   it('returns unknown status if the status is not provided', async () => {
+    const auditId = await startAudit(AuditType.CASE, bogusUlid, modelProvider);
     const clientMock: CloudWatchLogsClient = mock(CloudWatchLogsClient);
     const clientMockInstance = instance(clientMock);
     when(clientMock.send(anything())).thenResolve({ $metadata: {} });
@@ -119,10 +133,10 @@ describe('start case audit', () => {
     const event = getDummyEvent({
       pathParameters: {
         caseId: bogusUlid,
-        auditId: '11111111-1111-1111-1111-111111111111',
+        auditId,
       },
     });
-    const result = await getCaseAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    const result = await getCaseAudit(event, dummyContext, modelProvider, undefined, clientMockInstance);
     expect(result.statusCode).toEqual(200);
     const responseBody: { status: string; csvFormattedData: string } = JSON.parse(result.body);
     expect(responseBody.status).toEqual('Unknown');

--- a/source/dea-app/src/test/app/resources/start-case-audit.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/start-case-audit.integration.test.ts
@@ -4,13 +4,22 @@
  */
 
 import { CloudWatchLogsClient } from '@aws-sdk/client-cloudwatch-logs';
+import Joi from 'joi';
 import { anything, instance, mock, when } from 'ts-mockito';
 import { startCaseAudit } from '../../../app/resources/start-case-audit';
+import { joiUlid } from '../../../models/validation/joi-common';
+import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
 import { bogusUlid } from '../../../test-e2e/resources/test-helpers';
 import { dummyContext, getDummyEvent } from '../../integration-objects';
+import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 describe('start case audit', () => {
   const OLD_ENV = process.env;
+
+  let modelProvider: ModelRepositoryProvider;
+  beforeAll(async () => {
+    modelProvider = await getTestRepositoryProvider('startCaseAuditIntegration');
+  });
 
   beforeEach(() => {
     jest.resetModules();
@@ -32,10 +41,11 @@ describe('start case audit', () => {
         caseId: bogusUlid,
       },
     });
-    const result = await startCaseAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    const result = await startCaseAudit(event, dummyContext, modelProvider, undefined, clientMockInstance);
 
     expect(result.statusCode).toEqual(200);
-    expect(result.body).toContain('a_query_id');
+    const body: { auditId: string } = JSON.parse(result.body);
+    Joi.assert(body.auditId, joiUlid);
   });
 
   it('throws an error if no queryId is returned', async () => {
@@ -49,7 +59,7 @@ describe('start case audit', () => {
       },
     });
     await expect(
-      startCaseAudit(event, dummyContext, undefined, undefined, clientMockInstance)
+      startCaseAudit(event, dummyContext, modelProvider, undefined, clientMockInstance)
     ).rejects.toThrow('Unknown error starting Cloudwatch Logs Query.');
   });
 });

--- a/source/dea-app/src/test/app/resources/start-user-audit.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/start-user-audit.integration.test.ts
@@ -4,13 +4,22 @@
  */
 
 import { CloudWatchLogsClient } from '@aws-sdk/client-cloudwatch-logs';
+import Joi from 'joi';
 import { anything, instance, mock, when } from 'ts-mockito';
 import { startUserAudit } from '../../../app/resources/start-user-audit';
+import { joiUlid } from '../../../models/validation/joi-common';
+import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
 import { bogusUlid } from '../../../test-e2e/resources/test-helpers';
 import { dummyContext, getDummyEvent } from '../../integration-objects';
+import { getTestRepositoryProvider } from '../../persistence/local-db-table';
 
 describe('start user audit', () => {
   const OLD_ENV = process.env;
+
+  let modelProvider: ModelRepositoryProvider;
+  beforeAll(async () => {
+    modelProvider = await getTestRepositoryProvider('startUserAuditIntegration');
+  });
 
   beforeEach(() => {
     jest.resetModules();
@@ -32,10 +41,11 @@ describe('start user audit', () => {
         userId: bogusUlid,
       },
     });
-    const result = await startUserAudit(event, dummyContext, undefined, undefined, clientMockInstance);
+    const result = await startUserAudit(event, dummyContext, modelProvider, undefined, clientMockInstance);
 
     expect(result.statusCode).toEqual(200);
-    expect(result.body).toContain('a_query_id');
+    const body: { auditId: string } = JSON.parse(result.body);
+    Joi.assert(body.auditId, joiUlid);
   });
 
   it('throws an error if no queryId is returned', async () => {
@@ -49,7 +59,7 @@ describe('start user audit', () => {
       },
     });
     await expect(
-      startUserAudit(event, dummyContext, undefined, undefined, clientMockInstance)
+      startUserAudit(event, dummyContext, modelProvider, undefined, clientMockInstance)
     ).rejects.toThrow('Unknown error starting Cloudwatch Logs Query.');
   });
 });

--- a/source/dea-app/src/test/persistence/audit-job.unit.test.ts
+++ b/source/dea-app/src/test/persistence/audit-job.unit.test.ts
@@ -1,0 +1,53 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import Joi from 'joi';
+import { joiUlid } from '../../models/validation/joi-common';
+import * as sut from '../../persistence/audit-job';
+import { AuditType } from '../../persistence/schema/dea-schema';
+import { ModelRepositoryProvider } from '../../persistence/schema/entities';
+import { getTestRepositoryProvider } from './local-db-table';
+
+describe('audit job persistence', () => {
+  let modelProvider: ModelRepositoryProvider;
+  beforeAll(async () => {
+    modelProvider = await getTestRepositoryProvider('auditJobTestTable');
+  });
+
+  afterAll(async () => {
+    await modelProvider.table.deleteTable('DeleteTableForever');
+  });
+
+  it('should create a job record and return the ulid', async () => {
+    const queryId = 'bogusquery';
+    const resourceId = 'someResourceId';
+    const jobUlid = await sut.createAuditJob(queryId, AuditType.CASE, resourceId, modelProvider);
+    expect(jobUlid).toBeDefined();
+    Joi.assert(jobUlid, joiUlid);
+  });
+
+  it('should retrieve a query id for an existing audit job', async () => {
+    const queryId = 'bogusquery';
+    const resourceId = 'someResourceId';
+    const jobUlid = await sut.createAuditJob(queryId, AuditType.CASE, resourceId, modelProvider);
+    expect(jobUlid).toBeDefined();
+    Joi.assert(jobUlid, joiUlid);
+
+    const queryIdResponse = await sut.getAuditJobQueryId(jobUlid, AuditType.CASE, resourceId, modelProvider);
+    expect(queryIdResponse).toEqual(queryId);
+  });
+
+  it('should throw a not found error when the requested job does not exist', async () => {
+    const queryId = 'bogusquery';
+    const resourceId = 'someResourceId';
+    const jobUlid = await sut.createAuditJob(queryId, AuditType.CASE, resourceId, modelProvider);
+    expect(jobUlid).toBeDefined();
+    Joi.assert(jobUlid, joiUlid);
+
+    await expect(sut.getAuditJobQueryId(jobUlid, AuditType.USER, resourceId, modelProvider)).rejects.toThrow(
+      'Audit Job not found.'
+    );
+  });
+});

--- a/source/dea-app/src/test/persistence/local-db-table.ts
+++ b/source/dea-app/src/test/persistence/local-db-table.ts
@@ -6,12 +6,13 @@
 import { Table } from 'dynamodb-onetable';
 import { DeaSchema } from '../../persistence/schema/dea-schema';
 import { ModelRepositoryProvider } from '../../persistence/schema/entities';
+import { randomSuffix } from '../../test-e2e/resources/test-helpers';
 import { dynamoTestClient } from '../local-dynamo/setup';
 
-export const initLocalDb = async (tableName: string): Promise<Table> => {
+const initLocalDb = async (tableName: string): Promise<Table> => {
   const testTable = new Table({
     client: dynamoTestClient,
-    name: tableName,
+    name: `${tableName}${randomSuffix()}`,
     schema: DeaSchema,
     partial: false,
   });
@@ -31,5 +32,6 @@ export const getTestRepositoryProvider = async (tableName: string): Promise<Mode
     SessionModel: table.getModel('Session'),
     UserModel: table.getModel('User'),
     JobModel: table.getModel('Job'),
+    AuditJobModel: table.getModel('AuditJob'),
   };
 };

--- a/source/dea-app/src/test/persistence/user.unit.test.ts
+++ b/source/dea-app/src/test/persistence/user.unit.test.ts
@@ -3,22 +3,20 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { Paged, Table } from 'dynamodb-onetable';
+import { Paged } from 'dynamodb-onetable';
 import { DeaUser, DeaUserInput } from '../../models/user';
-import { UserModelRepositoryProvider } from '../../persistence/schema/entities';
+import { ModelRepositoryProvider } from '../../persistence/schema/entities';
 import { createUser, deleteUser, getUser, listUsers, updateUser } from '../../persistence/user';
-import { initLocalDb } from './local-db-table';
+import { getTestRepositoryProvider } from './local-db-table';
 
 describe('user persistence', () => {
-  let testTable: Table;
-  let modelProvider: UserModelRepositoryProvider;
+  let modelProvider: ModelRepositoryProvider;
   beforeAll(async () => {
-    testTable = await initLocalDb('userTestsTable');
-    modelProvider = { UserModel: testTable.getModel('User') };
+    modelProvider = await getTestRepositoryProvider('userTestsTable');
   });
 
   afterAll(async () => {
-    await testTable.deleteTable('DeleteTableForever');
+    await modelProvider.table.deleteTable('DeleteTableForever');
   });
 
   it('should create and get a user by id', async () => {
@@ -159,7 +157,7 @@ describe('user persistence', () => {
   });
 });
 
-const deleteAndVerifyUser = async (ulid: string, modelProvider: UserModelRepositoryProvider) => {
+const deleteAndVerifyUser = async (ulid: string, modelProvider: ModelRepositoryProvider) => {
   await deleteUser(ulid, modelProvider);
   const deletedUser1 = await getUser(ulid, modelProvider);
   expect(deletedUser1).toBeUndefined();

--- a/source/dea-backend/.eslintignore
+++ b/source/dea-backend/.eslintignore
@@ -5,3 +5,4 @@ temp
 cdk.out
 build
 buildLambda.js
+coverage

--- a/source/dea-backend/README.md
+++ b/source/dea-backend/README.md
@@ -6,7 +6,7 @@
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-95.83%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-90.58%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.35%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-95.77%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-98.05%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-90.9%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-90.24%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-98.02%25-brightgreen.svg?style=flat) |
 
 ## Description
 

--- a/source/dea-backend/package.json
+++ b/source/dea-backend/package.json
@@ -15,6 +15,7 @@
   "main": "lib/index.js",
   "scripts": {
     "add-license-header": "license-check-and-add add -f license-add-config.json",
+    "audit:only": "",
     "build": "heft build",
     "build:clean": "heft build --clean",
     "build:test": "heft test --verbose --test-path-pattern test && rushx make-badges",
@@ -24,7 +25,6 @@
     "cdk:synth": "cdk synth",
     "check-license-header": "license-check-and-add check -f license-add-config.json",
     "e2e:only": ". ../common/scripts/setEnv.sh && heft test --no-build --disable-code-coverage --test-path-pattern '.*/*e2e.test.*'",
-    "audit:only": "",
     "integration:only": "heft test --no-build --disable-code-coverage --test-path-pattern '.*/*integration.test.*'",
     "license-checker": "license-checker --onlyAllow 'MIT; Apache-2.0; ISC; BSD'",
     "lint": "eslint . --max-warnings=0",

--- a/source/dea-main/package.json
+++ b/source/dea-main/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "add-license-header": "license-check-and-add add -f license-add-config.json",
+    "audit:only": "",
     "build": "heft build",
     "build:clean": "heft build --clean",
     "build:test": "heft test --verbose --test-path-pattern test && rushx make-badges",
@@ -26,7 +27,6 @@
     "cdk:synth": "cdk synth",
     "check-license-header": "license-check-and-add check -f license-add-config.json",
     "e2e:only": "",
-    "audit:only": "",
     "integration:only": "heft test --no-build --disable-code-coverage --test-path-pattern '.*/*integration.test.*'",
     "license-checker": "license-checker --onlyAllow 'MIT; Apache-2.0; ISC; BSD'",
     "lint": "eslint . --max-warnings=0",

--- a/source/dea-ui/infrastructure/package.json
+++ b/source/dea-ui/infrastructure/package.json
@@ -15,6 +15,7 @@
   "main": "lib/index.js",
   "scripts": {
     "add-license-header": "license-check-and-add add -f license-add-config.json",
+    "audit:only": "",
     "build": "heft build",
     "build:clean": "heft build --clean",
     "build:test": "rushx build && rushx test && rushx make-badges",
@@ -22,7 +23,6 @@
     "cdk-deploy": "rushx build && cdk deploy --all --require-approval never --outputs-file ../ui/src/config/${STAGE}.json",
     "check-license-header": "license-check-and-add check -f license-add-config.json",
     "e2e:only": "",
-    "audit:only": "",
     "integration:only": "heft test --no-build --disable-code-coverage --test-path-pattern '.*/*integration.test.*'",
     "license-checker": "license-checker --onlyAllow 'MIT; Apache-2.0; ISC; BSD'",
     "lint": "eslint . --max-warnings=0",

--- a/source/dea-ui/ui/README.md
+++ b/source/dea-ui/ui/README.md
@@ -8,7 +8,7 @@ This is a prototype app and you should expect to modify the source code to refle
 
 | Statements                                                                                   | Branches                                                                                 | Functions                                                                                  | Lines                                                                              |
 | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-91.09%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-83.41%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-90.57%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-91.32%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-91.25%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-83.88%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-89.18%25-yellow.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-91.61%25-brightgreen.svg?style=flat) |
 
 ## Deploying code changes
 

--- a/source/dea-ui/ui/package.json
+++ b/source/dea-ui/ui/package.json
@@ -16,6 +16,7 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "add-license-header": "license-check-and-add add -f license-add-config.json",
+    "audit:only": "",
     "build": "./setNextEnv.sh && next build && next export --silent",
     "build-only": "./setNextEnv.sh && next build",
     "build:test": "rushx build && rushx test && rushx make-badges",
@@ -24,10 +25,9 @@
     "cypress:e2e": ". ../../common/scripts/setEnv.sh && cypress run --config baseUrl=${DEA_API_URL}ui",
     "cypress:headless": "cypress run",
     "cypress:test": "start-server-and-test start http-get://localhost:3000/${STAGE}/ui cypress:headless",
-    "dev:https": "(local-ssl-proxy --key localhost-key.pem --cert localhost.pem --source 3001 --target 3000 &) && rushx dev",
     "dev": ". ../../common/scripts/setEnv.sh && ./setNextEnv.sh && next dev",
+    "dev:https": "(local-ssl-proxy --key localhost-key.pem --cert localhost.pem --source 3001 --target 3000 &) && rushx dev",
     "e2e:only": "",
-    "audit:only": "",
     "export": "next build && next export",
     "integration:only": "jest --ci --testPathPattern '.*/*integration.test.*'",
     "license-checker": "license-checker --onlyAllow 'MIT; Apache-2.0; ISC; BSD'",
@@ -44,9 +44,9 @@
     "unit:only": "jest --ci '.*/*unit.test.*'"
   },
   "dependencies": {
-    "@aws/dea-app": "workspace:*",
     "@aws-sdk/client-cognito-identity": "3.299.0",
     "@aws-sdk/client-cognito-identity-provider": "3.299.0",
+    "@aws/dea-app": "workspace:*",
     "@cloudscape-design/collection-hooks": "^1.0.20",
     "@cloudscape-design/components": "^3.0.235",
     "@cloudscape-design/design-tokens": "~3.0.9",
@@ -108,6 +108,7 @@
     "jest-environment-jsdom": "~29.5.0",
     "license-check-and-add": "^4.0.5",
     "license-checker": "^25.0.1",
+    "local-ssl-proxy": "~2.0.5",
     "lodash.kebabcase": "~4.1.1",
     "nodemon": "^2.0.22",
     "npm-package-json-lint": "^6.4.0",
@@ -117,7 +118,6 @@
     "sort-package-json": "^2.4.1",
     "start-server-and-test": "~1.15.3",
     "ts-mockito": "~2.6.1",
-    "typescript": "^4.5.2",
-    "local-ssl-proxy": "~2.0.5"
+    "typescript": "^4.5.2"
   }
 }


### PR DESCRIPTION
- introduce AuditJob entity to abstract cloudwatch insights query implementation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
