### PR TITLE
refactor: use underscores to indicate unused properties

### DIFF
--- a/source/dea-app/.eslintrc.js
+++ b/source/dea-app/.eslintrc.js
@@ -1,7 +1,5 @@
-// This is a workaround for https://github.com/eslint/eslint/issues/3458
-require('@rushstack/eslint-config/patch/modern-module-resolution');
-
 module.exports = {
+  root: true,
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
@@ -34,6 +32,7 @@ module.exports = {
     curly: ['error'],
     '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/await-thenable': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
   },
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'security', 'import'],

--- a/source/dea-app/src/app/audit/dea-audit-writer.ts
+++ b/source/dea-app/src/app/audit/dea-audit-writer.ts
@@ -25,17 +25,17 @@ const lambdaName = getRequiredEnv('AWS_LAMBDA_FUNCTION_NAME', 'NO_LAMBDA_NAME_FO
 const auditLogGroup = getRequiredEnv('AUDIT_LOG_GROUP_NAME', 'NO_AUDIT_LOG_GROUP');
 
 export default class DeaAuditWriter implements Writer {
-  private _isLogStreamReady: Promise<CreateLogGroupCommandOutput> | undefined;
-  private _logStreamName: string;
+  private isLogStreamReady: Promise<CreateLogGroupCommandOutput> | undefined;
+  private logStreamName: string;
 
   public constructor(private cloudwatchClient: CloudWatchLogsClient) {
-    this._logStreamName = `${lambdaName}-${ulid()}`.replaceAll(':', '');
+    this.logStreamName = `${lambdaName}-${ulid()}`.replaceAll(':', '');
     if (auditLogGroup !== 'NO_AUDIT_LOG_GROUP') {
       const createLogStreamCommand = new CreateLogStreamCommand({
         logGroupName: auditLogGroup,
-        logStreamName: this._logStreamName,
+        logStreamName: this.logStreamName,
       });
-      this._isLogStreamReady = this.cloudwatchClient.send(createLogStreamCommand);
+      this.isLogStreamReady = this.cloudwatchClient.send(createLogStreamCommand);
     }
   }
 
@@ -56,10 +56,10 @@ export default class DeaAuditWriter implements Writer {
   }
 
   public async write(metadata: Metadata, auditEntry: AuditEntry): Promise<void> {
-    await this._isLogStreamReady;
+    await this.isLogStreamReady;
     const putLogsCommand = new PutLogEventsCommand({
       logGroupName: auditLogGroup,
-      logStreamName: this._logStreamName,
+      logStreamName: this.logStreamName,
       logEvents: [{ timestamp: now(), message: JSON.stringify(auditEntry) }],
     });
 

--- a/source/dea-app/src/app/resources/get-case-audit.ts
+++ b/source/dea-app/src/app/resources/get-case-audit.ts
@@ -16,9 +16,9 @@ export const getCaseAudit: DEAGatewayProxyHandler = async (
   event,
   context,
   /* the default case is handled in e2e tests */
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
   repositoryProvider = defaultProvider,
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient

--- a/source/dea-app/src/app/resources/get-case-file-audit.ts
+++ b/source/dea-app/src/app/resources/get-case-file-audit.ts
@@ -16,9 +16,9 @@ export const getCaseFileAudit: DEAGatewayProxyHandler = async (
   event,
   context,
   /* the default case is handled in e2e tests */
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
   repositoryProvider = defaultProvider,
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient

--- a/source/dea-app/src/app/resources/get-system-audit.ts
+++ b/source/dea-app/src/app/resources/get-system-audit.ts
@@ -16,9 +16,9 @@ export const getSystemAudit: DEAGatewayProxyHandler = async (
   event,
   context,
   /* the default case is handled in e2e tests */
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
   repositoryProvider = defaultProvider,
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient

--- a/source/dea-app/src/app/resources/get-user-audit.ts
+++ b/source/dea-app/src/app/resources/get-user-audit.ts
@@ -16,9 +16,9 @@ export const getUserAudit: DEAGatewayProxyHandler = async (
   event,
   context,
   /* the default case is handled in e2e tests */
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
   repositoryProvider = defaultProvider,
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient

--- a/source/dea-app/src/app/resources/get-users.ts
+++ b/source/dea-app/src/app/resources/get-users.ts
@@ -31,9 +31,8 @@ export const getUsers: DEAGatewayProxyHandler = async (
   );
 
   return responseOk(event, {
-    //intentionally unused tokenId - this removes it during the map operation
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    users: pageOfUsers.map(({ tokenId, ...user }) => user),
+    //remove tokenId
+    users: pageOfUsers.map(({ tokenId: _, ...user }) => user),
     total: pageOfUsers.count,
     next: getNextToken(pageOfUsers.next),
   });

--- a/source/dea-app/src/app/resources/start-case-audit.ts
+++ b/source/dea-app/src/app/resources/start-case-audit.ts
@@ -17,9 +17,9 @@ export const startCaseAudit: DEAGatewayProxyHandler = async (
   event,
   context,
   /* the default case is handled in e2e tests */
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _repositoryProvider = defaultProvider,
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
+  repositoryProvider = defaultProvider,
+  /* istanbul ignore next */
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient
@@ -36,7 +36,7 @@ export const startCaseAudit: DEAGatewayProxyHandler = async (
     endTime,
     caseId,
     cloudwatchClient,
-    _repositoryProvider
+    repositoryProvider
   );
 
   return responseOk(event, { auditId: queryId });

--- a/source/dea-app/src/app/resources/start-case-file-audit.ts
+++ b/source/dea-app/src/app/resources/start-case-file-audit.ts
@@ -17,9 +17,9 @@ export const startCaseFileAudit: DEAGatewayProxyHandler = async (
   event,
   context,
   /* the default case is handled in e2e tests */
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _repositoryProvider = defaultProvider,
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
+  repositoryProvider = defaultProvider,
+  /* istanbul ignore next */
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient
@@ -39,7 +39,7 @@ export const startCaseFileAudit: DEAGatewayProxyHandler = async (
     endTime,
     `${caseId}${fileId}`,
     cloudwatchClient,
-    _repositoryProvider
+    repositoryProvider
   );
 
   return responseOk(event, { auditId: queryId });

--- a/source/dea-app/src/app/resources/start-system-audit.ts
+++ b/source/dea-app/src/app/resources/start-system-audit.ts
@@ -16,9 +16,9 @@ export const startSystemAudit: DEAGatewayProxyHandler = async (
   event,
   context,
   /* the default case is handled in e2e tests */
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _repositoryProvider = defaultProvider,
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
+  repositoryProvider = defaultProvider,
+  /* istanbul ignore next */
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient
@@ -32,7 +32,7 @@ export const startSystemAudit: DEAGatewayProxyHandler = async (
     startTime,
     endTime,
     cloudwatchClient,
-    _repositoryProvider
+    repositoryProvider
   );
 
   return responseOk(event, { auditId: queryId });

--- a/source/dea-app/src/app/resources/start-user-audit.ts
+++ b/source/dea-app/src/app/resources/start-user-audit.ts
@@ -17,9 +17,9 @@ export const startUserAudit: DEAGatewayProxyHandler = async (
   event,
   context,
   /* the default case is handled in e2e tests */
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _repositoryProvider = defaultProvider,
-  /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /* istanbul ignore next */
+  repositoryProvider = defaultProvider,
+  /* istanbul ignore next */
   _datasetsProvider = defaultDatasetsProvider,
   /* istanbul ignore next */
   cloudwatchClient = defaultCloudwatchClient
@@ -36,7 +36,7 @@ export const startUserAudit: DEAGatewayProxyHandler = async (
     endTime,
     userId,
     cloudwatchClient,
-    _repositoryProvider
+    repositoryProvider
   );
 
   return responseOk(event, { auditId: queryId });

--- a/source/dea-app/src/app/services/audit-service.ts
+++ b/source/dea-app/src/app/services/audit-service.ts
@@ -231,7 +231,7 @@ export class DeaAuditService extends AuditService {
     return this.write(event);
   }
 
-  private async _startAuditQuery(
+  private async startAuditQuery(
     start: number,
     end: number,
     cloudwatchClient: CloudWatchLogsClient,
@@ -274,7 +274,7 @@ export class DeaAuditService extends AuditService {
   ) {
     const auditLogGroups = [getRequiredEnv('AUDIT_LOG_GROUP_NAME'), getRequiredEnv('TRAIL_LOG_GROUP_NAME')];
     const filterPredicate = `caseId = "${caseId}" or (@message like '"PK":"CASE#${caseId}#"' and @message like '"SK":"CASE#"')`;
-    return this._startAuditQuery(
+    return this.startAuditQuery(
       start,
       end,
       cloudwatchClient,
@@ -298,7 +298,7 @@ export class DeaAuditService extends AuditService {
     const s3Key = getS3KeyForCaseFile(caseId, fileId);
     const auditLogGroups = [getRequiredEnv('AUDIT_LOG_GROUP_NAME'), getRequiredEnv('TRAIL_LOG_GROUP_NAME')];
     const filterPredicate = `(caseId = "${caseId}" and fileId = "${fileId}") or (@message like '"PK":"CASE#${caseId}#"' and @message like '"SK":"FILE#${fileId}#"') or (@message like "${s3Key}")`;
-    return this._startAuditQuery(
+    return this.startAuditQuery(
       start,
       end,
       cloudwatchClient,
@@ -320,7 +320,7 @@ export class DeaAuditService extends AuditService {
   ) {
     const auditLogGroups = [getRequiredEnv('AUDIT_LOG_GROUP_NAME')];
     const filterPredicate = `actorIdentity.userUlid = '${userUlid}'`;
-    return this._startAuditQuery(
+    return this.startAuditQuery(
       start,
       end,
       cloudwatchClient,
@@ -339,7 +339,7 @@ export class DeaAuditService extends AuditService {
     repositoryProvider: ModelRepositoryProvider
   ) {
     const systemLogGroups = [getRequiredEnv('AUDIT_LOG_GROUP_NAME'), getRequiredEnv('TRAIL_LOG_GROUP_NAME')];
-    return this._startAuditQuery(
+    return this.startAuditQuery(
       start,
       end,
       cloudwatchClient,
@@ -427,7 +427,7 @@ export class DeaAuditService extends AuditService {
     ) {
       return {
         status: QueryStatus.Complete,
-        csvFormattedData: this._formatResults(getResultsResponse.results),
+        csvFormattedData: this.formatResults(getResultsResponse.results),
       };
     } else {
       return {
@@ -437,7 +437,7 @@ export class DeaAuditService extends AuditService {
     }
   }
 
-  private _formatResults(results: ResultField[][]): string {
+  private formatResults(results: ResultField[][]): string {
     const separator = ', ';
     const newline = '\r\n';
     let csvData = '';

--- a/source/dea-app/src/persistence/case-file.ts
+++ b/source/dea-app/src/persistence/case-file.ts
@@ -20,8 +20,7 @@ export const initiateCaseFileUpload = async (
   repositoryProvider: ModelRepositoryProvider
 ): Promise<DeaCaseFileResult> => {
   // strip out chunkSizeBytes before saving in dynamo-db
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { chunkSizeBytes, ...deaCaseFile } = uploadDTO;
+  const { chunkSizeBytes: _, ...deaCaseFile } = uploadDTO;
   const newEntity = await repositoryProvider.CaseFileModel.create({
     ...deaCaseFile,
     isFile: true,

--- a/source/dea-app/src/test-e2e/auth/auth.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/auth/auth.e2e.test.ts
@@ -45,8 +45,7 @@ describe('API authentication', () => {
   });
 
   it('should have the DEARole field in the id Token', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [creds, idToken] = await cognitoHelper.getCredentialsForUser(testUser);
+    const [_creds, idToken] = await cognitoHelper.getCredentialsForUser(testUser);
 
     const payload = await getTokenPayload(idToken.id_token, region);
     expect(payload['custom:DEARole']).toStrictEqual('AuthTestGroup');

--- a/source/dea-app/src/test-e2e/resources/case-file-upload.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/case-file-upload.e2e.test.ts
@@ -170,7 +170,6 @@ describe('Test case file APIs', () => {
   });
 });
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function createCase(idToken: Oauth2Token, creds: Credentials): Promise<DeaCase> {
   const caseName = `CASE with files_${randomSuffix()}`;
   return await createCaseSuccess(

--- a/source/dea-app/src/test/cognito-token-helpers.integration.test.ts
+++ b/source/dea-app/src/test/cognito-token-helpers.integration.test.ts
@@ -31,8 +31,8 @@ describe('cognito helpers integration test', () => {
 
     const payload = await getTokenPayload(id_token, region);
 
-    expect(payload.iss).toStrictEqual('https://' + cognitoHelper._idpUrl);
-    expect(payload.aud).toStrictEqual(cognitoHelper._userPoolClientId);
+    expect(payload.iss).toStrictEqual('https://' + cognitoHelper.idpUrl);
+    expect(payload.aud).toStrictEqual(cognitoHelper.userPoolClientId);
     expect(refresh_token).toBeTruthy();
     expect(payload.token_use).toStrictEqual('id');
   });

--- a/source/dea-backend/.eslintrc.js
+++ b/source/dea-backend/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
     curly: ['error'],
     '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/await-thenable': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
   },
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'security', 'import'],

--- a/source/dea-backend/src/constructs/dea-audit-trail.ts
+++ b/source/dea-backend/src/constructs/dea-audit-trail.ts
@@ -27,9 +27,9 @@ export class DeaAuditTrail extends Construct {
   public constructor(scope: Construct, stackName: string, props: DeaAuditProps) {
     super(scope, stackName);
 
-    this.auditLogGroup = this._createLogGroup(scope, 'deaAuditLogs', props.kmsKey);
-    this.trailLogGroup = this._createLogGroup(scope, 'deaTrailLogs', props.kmsKey);
-    this.auditTrail = this._createAuditTrail(
+    this.auditLogGroup = this.createLogGroup(scope, 'deaAuditLogs', props.kmsKey);
+    this.trailLogGroup = this.createLogGroup(scope, 'deaTrailLogs', props.kmsKey);
+    this.auditTrail = this.createAuditTrail(
       scope,
       this.trailLogGroup,
       props.kmsKey,
@@ -39,7 +39,7 @@ export class DeaAuditTrail extends Construct {
     props.kmsKey.grantEncrypt(new ServicePrincipal('cloudtrail.amazonaws.com'));
   }
 
-  private _createAuditTrail(
+  private createAuditTrail(
     scope: Construct,
     trailLogGroup: LogGroup,
     kmsKey: Key,
@@ -94,7 +94,7 @@ export class DeaAuditTrail extends Construct {
     return trail;
   }
 
-  private _createLogGroup(scope: Construct, id: string, kmsKey: Key) {
+  private createLogGroup(scope: Construct, id: string, kmsKey: Key) {
     return new LogGroup(scope, id, {
       encryptionKey: kmsKey,
       retention: deaConfig.retentionDays(),

--- a/source/dea-backend/src/constructs/dea-backend-stack.ts
+++ b/source/dea-backend/src/constructs/dea-backend-stack.ts
@@ -34,11 +34,11 @@ export class DeaBackendConstruct extends Construct {
   public constructor(scope: Construct, id: string, props: IBackendStackProps) {
     super(scope, id);
 
-    this.deaTable = this._createDeaTable(props.kmsKey);
+    this.deaTable = this.createDeaTable(props.kmsKey);
     const datasetsPrefix = 'dea-datasets-access-log';
     const prefixes = props.accessLogsPrefixes.concat([datasetsPrefix]);
-    this.accessLogsBucket = this._createAccessLogsBucket(`DeaS3AccessLogs`, prefixes);
-    this.datasetsBucket = this._createDatasetsBucket(
+    this.accessLogsBucket = this.createAccessLogsBucket(`DeaS3AccessLogs`, prefixes);
+    this.datasetsBucket = this.createDatasetsBucket(
       props.kmsKey,
       this.accessLogsBucket,
       `DeaS3Datasets`,
@@ -46,7 +46,7 @@ export class DeaBackendConstruct extends Construct {
     );
   }
 
-  private _createDeaTable(key: Key): Table {
+  private createDeaTable(key: Key): Table {
     const deaTable = new Table(this, 'DeaTable', {
       billingMode: BillingMode.PAY_PER_REQUEST,
       partitionKey: { name: 'PK', type: AttributeType.STRING },
@@ -75,7 +75,7 @@ export class DeaBackendConstruct extends Construct {
     return deaTable;
   }
 
-  private _createAccessLogsBucket(
+  private createAccessLogsBucket(
     bucketNameOutput: Readonly<string>,
     accessLogPrefixes: ReadonlyArray<string>
   ): Bucket {
@@ -127,7 +127,7 @@ export class DeaBackendConstruct extends Construct {
     return s3AccessLogsBucket;
   }
 
-  private _createDatasetsBucket(
+  private createDatasetsBucket(
     key: Readonly<Key>,
     accessLogBucket: Readonly<Bucket>,
     bucketNameOutput: Readonly<string>,
@@ -139,7 +139,7 @@ export class DeaBackendConstruct extends Construct {
       encryption: BucketEncryption.KMS,
       encryptionKey: key,
       enforceSSL: true,
-      lifecycleRules: this._getLifeCycleRules(),
+      lifecycleRules: this.getLifeCycleRules(),
       publicReadAccess: false,
       removalPolicy: deaConfig.retainPolicy(),
       autoDeleteObjects: deaConfig.isTestStack(),
@@ -167,7 +167,7 @@ export class DeaBackendConstruct extends Construct {
     return datasetsBucket;
   }
 
-  private _getLifeCycleRules(): LifecycleRule[] {
+  private getLifeCycleRules(): LifecycleRule[] {
     const deleteIncompleteUploadsRule: LifecycleRule = {
       abortIncompleteMultipartUploadAfter: Duration.days(1),
       enabled: true,

--- a/source/dea-backend/src/constructs/dea-event-handlers.ts
+++ b/source/dea-backend/src/constructs/dea-event-handlers.ts
@@ -32,14 +32,14 @@ export class DeaEventHandlers extends Construct {
   public constructor(scope: Construct, stackName: string, props: DeaEventHandlerProps) {
     super(scope, stackName);
 
-    const s3BatchDeleteCaseFileRole = this._createS3BatchDeleteCaseFileRole(
+    const s3BatchDeleteCaseFileRole = this.createS3BatchDeleteCaseFileRole(
       's3-batch-delete-case-file-handler-role',
       props.deaTableArn,
       props.deaDatasetsBucketArn,
       props.kmsKey.keyArn
     );
 
-    this.s3BatchDeleteCaseFileLambda = this._createLambda(
+    this.s3BatchDeleteCaseFileLambda = this.createLambda(
       `s3_batch_delete_case_file`,
       'S3BatchDeleteCaseFileLambda',
       '../../src/handlers/s3-batch-delete-case-file-handler.ts',
@@ -47,14 +47,14 @@ export class DeaEventHandlers extends Construct {
       s3BatchDeleteCaseFileRole
     );
 
-    const statusHandlerRole = this._createS3BatchStatusChangeHandlerRole(
+    const statusHandlerRole = this.createS3BatchStatusChangeHandlerRole(
       's3-batch-status-change-handler-role',
       props.deaTableArn,
       props.deaDatasetsBucketArn,
       props.kmsKey.keyArn
     );
 
-    const s3BatchJobStatusChangeHandlerLambda = this._createLambda(
+    const s3BatchJobStatusChangeHandlerLambda = this.createLambda(
       `s3_batch_status_handler`,
       'S3BatchJobStatusChangeLambda',
       '../../src/handlers/s3-batch-job-status-change-handler.ts',
@@ -62,13 +62,13 @@ export class DeaEventHandlers extends Construct {
       statusHandlerRole
     );
 
-    this.s3BatchDeleteCaseFileRole = this._createS3BatchRole(props.deaDatasetsBucketArn);
+    this.s3BatchDeleteCaseFileRole = this.createS3BatchRole(props.deaDatasetsBucketArn);
 
     // create event bridge rule
-    this._createEventBridgeRuleForS3BatchJobs(s3BatchJobStatusChangeHandlerLambda);
+    this.createEventBridgeRuleForS3BatchJobs(s3BatchJobStatusChangeHandlerLambda);
   }
 
-  private _createEventBridgeRuleForS3BatchJobs(targetLambda: NodejsFunction) {
+  private createEventBridgeRuleForS3BatchJobs(targetLambda: NodejsFunction) {
     new Rule(this, 'S3BatchJobStatusChangeRule', {
       enabled: true,
       eventPattern: {
@@ -82,7 +82,7 @@ export class DeaEventHandlers extends Construct {
     });
   }
 
-  private _createLambda(
+  private createLambda(
     id: string,
     cfnExportName: string,
     pathToSource: string,
@@ -116,7 +116,7 @@ export class DeaEventHandlers extends Construct {
     return lambda;
   }
 
-  private _createS3BatchRole(datasetsBucketArn: string): Role {
+  private createS3BatchRole(datasetsBucketArn: string): Role {
     const role = new Role(this, 's3-batch-delete-case-file-role', {
       assumedBy: new ServicePrincipal('batchoperations.s3.amazonaws.com'),
     });
@@ -138,7 +138,7 @@ export class DeaEventHandlers extends Construct {
     return role;
   }
 
-  private _createS3BatchDeleteCaseFileRole(
+  private createS3BatchDeleteCaseFileRole(
     id: string,
     tableArn: string,
     datasetsBucketArn: string,
@@ -188,7 +188,7 @@ export class DeaEventHandlers extends Construct {
     return role;
   }
 
-  private _createS3BatchStatusChangeHandlerRole(
+  private createS3BatchStatusChangeHandlerRole(
     id: string,
     tableArn: string,
     datasetsBucketArn: string,

--- a/source/dea-backend/src/constructs/dea-rest-api.ts
+++ b/source/dea-backend/src/constructs/dea-rest-api.ts
@@ -63,7 +63,7 @@ export class DeaRestApiConstruct extends Construct {
 
     this.apiEndpointArns = new Map<string, string>();
 
-    this.lambdaBaseRole = this._createLambdaBaseRole(
+    this.lambdaBaseRole = this.createLambdaBaseRole(
       props.kmsKey.keyArn,
       props.deaTableArn,
       props.deaDatasetsBucketArn,
@@ -74,7 +74,7 @@ export class DeaRestApiConstruct extends Construct {
       props.s3BatchDeleteCaseFileRoleArn
     );
 
-    this.authLambdaRole = this._createAuthLambdaRole(props.region, props.accountId);
+    this.authLambdaRole = this.createAuthLambdaRole(props.region, props.accountId);
 
     props.kmsKey.addToResourcePolicy(
       new PolicyStatement({
@@ -125,12 +125,12 @@ export class DeaRestApiConstruct extends Construct {
       },
     });
 
-    this._configureApiGateway(deaApiRouteConfig, props.lambdaEnv);
+    this.configureApiGateway(deaApiRouteConfig, props.lambdaEnv);
 
-    this._updateBucketCors(this.deaRestApi, props.deaDatasetsBucketName);
+    this.updateBucketCors(this.deaRestApi, props.deaDatasetsBucketName);
   }
 
-  private _updateBucketCors(restApi: RestApi, bucketName: Readonly<string>) {
+  private updateBucketCors(restApi: RestApi, bucketName: Readonly<string>) {
     const allowedOrigins = deaConfig.deaAllowedOriginsList();
     allowedOrigins.push(`https://${Fn.parseDomainName(restApi.url)}`);
 
@@ -162,7 +162,7 @@ export class DeaRestApiConstruct extends Construct {
     updateCors.node.addDependency(restApi);
   }
 
-  private _configureApiGateway(routeConfig: ApiGatewayRouteConfig, lambdaEnv: LambdaEnvironment): void {
+  private configureApiGateway(routeConfig: ApiGatewayRouteConfig, lambdaEnv: LambdaEnvironment): void {
     const plan = this.deaRestApi.addUsagePlan('DEA Usage Plan', {
       name: 'dea-usage-plan',
       throttle: {
@@ -194,11 +194,11 @@ export class DeaRestApiConstruct extends Construct {
       // otherwise it is a DEA execution API, which needs the
       // full set of permissions
       const lambdaRole = route.authMethod ? this.authLambdaRole : this.lambdaBaseRole;
-      this._addMethod(this.deaRestApi, route, lambdaRole, lambdaEnv);
+      this.addMethod(this.deaRestApi, route, lambdaRole, lambdaEnv);
     });
   }
 
-  private _addMethod(api: RestApi, route: ApiGatewayRoute, role: Role, lambdaEnv: LambdaEnvironment): void {
+  private addMethod(api: RestApi, route: ApiGatewayRoute, role: Role, lambdaEnv: LambdaEnvironment): void {
     const urlParts = route.path.split('/').filter((str) => str);
     let parent = api.root;
     urlParts.forEach((part, index) => {
@@ -208,7 +208,7 @@ export class DeaRestApiConstruct extends Construct {
       }
 
       if (index === urlParts.length - 1) {
-        const lambda = this._createLambda(
+        const lambda = this.createLambda(
           `${route.httpMethod}_${route.eventName}`,
           role,
           route.pathToSource,
@@ -258,7 +258,7 @@ export class DeaRestApiConstruct extends Construct {
     });
   }
 
-  private _createLambda(
+  private createLambda(
     id: string,
     role: Role,
     pathToSource: string,
@@ -313,7 +313,7 @@ export class DeaRestApiConstruct extends Construct {
     return lambda;
   }
 
-  private _createLambdaBaseRole(
+  private createLambdaBaseRole(
     kmsKeyArn: string,
     tableArn: string,
     datasetsBucketArn: string,
@@ -401,7 +401,7 @@ export class DeaRestApiConstruct extends Construct {
     return role;
   }
 
-  private _createAuthLambdaRole(region: string, accountId: string): Role {
+  private createAuthLambdaRole(region: string, accountId: string): Role {
     const STAGE = deaConfig.stage();
 
     const basicExecutionPolicy = ManagedPolicy.fromAwsManagedPolicyName(

--- a/source/dea-backend/src/handlers/create-dea-handler.ts
+++ b/source/dea-backend/src/handlers/create-dea-handler.ts
@@ -40,9 +40,7 @@ export const createDeaHandler = (
   const wrappedHandler: DEAGatewayProxyHandler = async (event: APIGatewayProxyEvent, context: Context) => {
     const auditEvent = initialAuditEvent(event);
     try {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { 'x-amz-security-token': _h, 'X-Amz-Security-Token': _h1, ...debugHeaders } = event.headers;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { headers: _, multiValueHeaders: _1, ...debugEvent } = event;
       logger.debug(`Headers`, { Data: JSON.stringify(debugHeaders, null, 2) });
       logger.debug(`Event`, { Data: JSON.stringify(debugEvent, null, 2) });

--- a/source/dea-backend/src/test/handlers/exception-handlers.unit.test.ts
+++ b/source/dea-backend/src/test/handlers/exception-handlers.unit.test.ts
@@ -36,8 +36,8 @@ describe('exception handlers', () => {
   afterAll(() => {
     process.env = OLD_ENV;
   });
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const preExecutionChecks = async (event: APIGatewayProxyEvent, context: Context) => {
+
+  const preExecutionChecks = async (_event: APIGatewayProxyEvent, _context: Context) => {
     return;
   };
 

--- a/source/dea-main/.eslintrc.js
+++ b/source/dea-main/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
     curly: ['error'],
     '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/await-thenable': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
   },
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'security', 'import'],

--- a/source/dea-main/src/dea-main-stack.ts
+++ b/source/dea-main/src/dea-main-stack.ts
@@ -36,7 +36,7 @@ export class DeaMainStack extends cdk.Stack {
     super(scope, id, props);
 
     // Create KMS key to pass into backend and UI
-    const kmsKey = this._createEncryptionKey();
+    const kmsKey = this.createEncryptionKey();
 
     const uiAccessLogPrefix = 'dea-ui-access-log';
     // DEA Backend Construct
@@ -115,14 +115,14 @@ export class DeaMainStack extends cdk.Stack {
     // ======================================
     // Suppress CFN issues with dea-main stack as the primary node here since we cannot access
     // resource node directly in the ui or backend construct
-    this._uiStackConstructNagSuppress();
+    this.uiStackConstructNagSuppress();
 
     // These are resources that will be configured in a future story. Please remove these suppressions or modify them to the specific resources as needed
     // when we tackle the particular story. Details in function below
-    this._apiGwAuthNagSuppresions();
+    this.apiGwAuthNagSuppresions();
   }
 
-  private _uiStackConstructNagSuppress(): void {
+  private uiStackConstructNagSuppress(): void {
     const cdkLambda = this.node.findChild('Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C').node
       .defaultChild;
     if (cdkLambda instanceof CfnFunction) {
@@ -139,7 +139,7 @@ export class DeaMainStack extends cdk.Stack {
     }
   }
 
-  private _createEncryptionKey(): Key {
+  private createEncryptionKey(): Key {
     const mainKeyPolicy = new PolicyDocument({
       statements: [
         new PolicyStatement({
@@ -179,7 +179,7 @@ export class DeaMainStack extends cdk.Stack {
     return key;
   }
 
-  private _apiGwAuthNagSuppresions(): void {
+  private apiGwAuthNagSuppresions(): void {
     // Nag suppress on all authorizationType related warnings until our Auth implementation is complete
     const apiGwMethodArray = [];
     // Backend API GW

--- a/source/dea-ui/infrastructure/.eslintrc.js
+++ b/source/dea-ui/infrastructure/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
     curly: ['error'],
     '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/await-thenable': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
   },
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'security', 'import'],

--- a/source/dea-ui/infrastructure/src/dea-ui-stack.ts
+++ b/source/dea-ui/infrastructure/src/dea-ui-stack.ts
@@ -43,7 +43,7 @@ export class DeaUiConstruct extends Construct {
       objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
     });
 
-    this._addS3TLSSigV4BucketPolicy(bucket);
+    this.addS3TLSSigV4BucketPolicy(bucket);
 
     // eslint-disable-next-line no-new
     new BucketDeployment(this, 'artifact-deployment-bucket', {
@@ -57,49 +57,49 @@ export class DeaUiConstruct extends Construct {
 
     bucket.grantReadWrite(executeRole);
 
-    this._routeHandler(props, bucket, executeRole);
+    this.routeHandler(props, bucket, executeRole);
   }
 
-  private _routeHandler(props: IUiStackProps, bucket: Bucket, executeRole: Role) {
+  private routeHandler(props: IUiStackProps, bucket: Bucket, executeRole: Role) {
     // Integrate API with S3 bucket
 
     // /ui - homepage
     const uiResource = props.restApi.root.addResource('ui');
-    const rootS3Integration = this._getS3Integration('index.html', bucket, executeRole);
-    uiResource.addMethod('GET', rootS3Integration, this._getMethodOptions());
+    const rootS3Integration = this.getS3Integration('index.html', bucket, executeRole);
+    uiResource.addMethod('GET', rootS3Integration, this.getMethodOptions());
 
     // /Login
     const loginResource = uiResource.addResource('login');
-    const loginS3Integration = this._getS3Integration('login.html', bucket, executeRole);
-    loginResource.addMethod('GET', loginS3Integration, this._getMethodOptions());
+    const loginS3Integration = this.getS3Integration('login.html', bucket, executeRole);
+    loginResource.addMethod('GET', loginS3Integration, this.getMethodOptions());
 
     // /case-detail
     const caseDetailResource = uiResource.addResource('case-detail');
-    const caseDetailS3Integration = this._getS3Integration('case-detail.html', bucket, executeRole);
-    caseDetailResource.addMethod('GET', caseDetailS3Integration, this._getMethodOptions());
+    const caseDetailS3Integration = this.getS3Integration('case-detail.html', bucket, executeRole);
+    caseDetailResource.addMethod('GET', caseDetailS3Integration, this.getMethodOptions());
 
     // /create-cases
     const createCasesResource = uiResource.addResource('create-cases');
-    const createCasesS3Integration = this._getS3Integration('create-cases.html', bucket, executeRole);
-    createCasesResource.addMethod('GET', createCasesS3Integration, this._getMethodOptions());
+    const createCasesS3Integration = this.getS3Integration('create-cases.html', bucket, executeRole);
+    createCasesResource.addMethod('GET', createCasesS3Integration, this.getMethodOptions());
 
     // /upload-file
     const uploadFilesResource = uiResource.addResource('upload-files');
-    const uploadFilesS3Integration = this._getS3Integration('upload-files.html', bucket, executeRole);
-    uploadFilesResource.addMethod('GET', uploadFilesS3Integration, this._getMethodOptions());
+    const uploadFilesS3Integration = this.getS3Integration('upload-files.html', bucket, executeRole);
+    uploadFilesResource.addMethod('GET', uploadFilesS3Integration, this.getMethodOptions());
 
     // /auth-test page
     const authTestResource = uiResource.addResource('auth-test');
-    const authTestIntegration = this._getS3Integration('auth-test.html', bucket, executeRole);
-    authTestResource.addMethod('GET', authTestIntegration, this._getMethodOptions());
+    const authTestIntegration = this.getS3Integration('auth-test.html', bucket, executeRole);
+    authTestResource.addMethod('GET', authTestIntegration, this.getMethodOptions());
 
     // GET to /{proxy+}
     const proxy = uiResource.addProxy({ anyMethod: false });
-    const proxyS3Integration = this._getS3Integration('{proxy}', bucket, executeRole);
-    proxy.addMethod('GET', proxyS3Integration, this._getMethodOptions());
+    const proxyS3Integration = this.getS3Integration('{proxy}', bucket, executeRole);
+    proxy.addMethod('GET', proxyS3Integration, this.getMethodOptions());
   }
 
-  private _getS3Integration(path: string, bucket: Bucket, executeRole: Role): AwsIntegration {
+  private getS3Integration(path: string, bucket: Bucket, executeRole: Role): AwsIntegration {
     return new AwsIntegration({
       service: 's3',
       integrationHttpMethod: 'GET',
@@ -131,7 +131,7 @@ export class DeaUiConstruct extends Construct {
     });
   }
 
-  private _getMethodOptions(): MethodOptions {
+  private getMethodOptions(): MethodOptions {
     return {
       requestParameters: {
         'method.request.path.proxy': true,
@@ -159,7 +159,7 @@ export class DeaUiConstruct extends Construct {
     };
   }
 
-  private _addS3TLSSigV4BucketPolicy(s3Bucket: Bucket): void {
+  private addS3TLSSigV4BucketPolicy(s3Bucket: Bucket): void {
     s3Bucket.addToResourcePolicy(
       new PolicyStatement({
         sid: 'Deny requests that do not use TLS/HTTPS',

--- a/source/dea-ui/ui/.eslintrc.js
+++ b/source/dea-ui/ui/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
     curly: ['error'],
     '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/await-thenable': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
   },
   overrides: [
     // Only uses Testing Library lint rules in test files

--- a/source/dea-ui/ui/src/context/NotificationsContext.tsx
+++ b/source/dea-ui/ui/src/context/NotificationsContext.tsx
@@ -16,12 +16,10 @@ export interface INotificationsProps {
 
 const defaultAppNotification: INotificationsProps = {
   notifications: [],
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  pushNotification: (type: FlashbarProps.Type, content: string) => {
+  pushNotification: (_type: FlashbarProps.Type, _content: string) => {
     /*do nothing*/
   },
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  dismissNotification: (id: string) => {
+  dismissNotification: (_id: string) => {
     /*do nothing*/
   },
 };


### PR DESCRIPTION
Open discussion:
- modern style guides recommend against using underscores to indicate private fields
  - remove underscore prefix from private fields
- it has become common practice to use underscores to indicate unused parameters
  - add no-unused-vars ignore patterns for underscore prefix
  - remove all no-unused-vars ignore lines
  - use prefix for intentionally unused params

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
