### PR TITLE
fix: override Joi default's messages to remove the inputted value from the message

### DIFF
--- a/source/dea-app/src/app/services/case-service.ts
+++ b/source/dea-app/src/app/services/case-service.ts
@@ -36,7 +36,7 @@ export const createCases = async (
         (reason: { Code: string }) => reason.Code === 'ConditionalCheckFailed'
       );
       if (oneTableError.code === 'TransactionCanceledException' && conditionalcheckfailed) {
-        throw new ValidationError(`Case with name "${deaCase.name}" is already in use`);
+        throw new ValidationError(`Case name is already in use`);
       }
     }
     throw error;

--- a/source/dea-app/src/models/validation/joi-common.ts
+++ b/source/dea-app/src/models/validation/joi-common.ts
@@ -10,6 +10,15 @@ import { CaseStatus } from '../case-status';
 export const ONE_MB = 1024 * 1024;
 export const ONE_TB = 1024 * 1024 * 1024 * 1024;
 
+// Override the default messages to get rid of the inputted value from the message.
+const genericPatternMessage = '{{#label}} fails to match the pattern';
+const customMessages = {
+  'string.pattern.base': genericPatternMessage,
+  'string.pattern.name': genericPatternMessage,
+  'string.pattern.invert.base': genericPatternMessage,
+  'string.pattern.invert.name': genericPatternMessage,
+};
+
 export const allButDisallowed = new RegExp('^[^\\<>/]+$');
 
 export const filenameSafeCharsRegex = new RegExp('^[^/\\0]+$');
@@ -24,25 +33,40 @@ export const ulidRegex = new RegExp('^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$');
 
 export const jtiRegex = new RegExp('^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$');
 
-export const s3Identifier = Joi.string().pattern(htmlSafeCharsRegex);
+export const s3Identifier = Joi.string().pattern(htmlSafeCharsRegex).messages(customMessages);
 
-export const joiUlid = Joi.string().pattern(ulidRegex);
+export const joiUlid = Joi.string().pattern(ulidRegex).messages(customMessages);
 
 export const joiUuid = Joi.string().uuid();
 
-export const sha256Hash = Joi.string().pattern(new RegExp('^[a-fA-F0-9]{64}$'));
+export const sha256Hash = Joi.string().pattern(new RegExp('^[a-fA-F0-9]{64}$')).messages(customMessages);
 
-export const safeName = Joi.string().pattern(allButDisallowed).required().min(3).max(50);
+export const safeName = Joi.string()
+  .pattern(allButDisallowed)
+  .required()
+  .min(3)
+  .max(50)
+  .messages(customMessages);
 
-export const safeTag = Joi.string().pattern(allButDisallowed).min(2).max(200);
-export const safeReason = Joi.string().pattern(allButDisallowed).min(2).max(250);
-export const safeDetails = Joi.string().pattern(allButDisallowed).min(2).max(250);
+export const safeTag = Joi.string().pattern(allButDisallowed).min(2).max(200).messages(customMessages);
+export const safeReason = Joi.string().pattern(allButDisallowed).min(2).max(250).messages(customMessages);
+export const safeDetails = Joi.string().pattern(allButDisallowed).min(2).max(250).messages(customMessages);
 
-export const fileName = Joi.string().pattern(filenameSafeCharsRegex).required().max(255).required();
+export const fileName = Joi.string()
+  .pattern(filenameSafeCharsRegex)
+  .required()
+  .max(255)
+  .required()
+  .messages(customMessages);
 
-export const filePath = Joi.string().pattern(filePathSafeCharsRegex).required().min(1).required();
+export const filePath = Joi.string()
+  .pattern(filePathSafeCharsRegex)
+  .required()
+  .min(1)
+  .required()
+  .messages(customMessages);
 
-export const contentType = Joi.string().pattern(htmlSafeCharsRegex);
+export const contentType = Joi.string().pattern(htmlSafeCharsRegex).messages(customMessages);
 
 export const caseStatus = Joi.string().valid(...Object.keys(CaseStatus));
 
@@ -54,7 +78,12 @@ export const loginUrlRegex = Joi.string().uri();
 
 export const caseFileStatus = Joi.string().valid(...Object.keys(CaseFileStatus));
 
-export const safeDescription = Joi.string().pattern(allButDisallowed).max(200).min(3).optional();
+export const safeDescription = Joi.string()
+  .pattern(allButDisallowed)
+  .max(200)
+  .min(3)
+  .optional()
+  .messages(customMessages);
 
 export const paginationLimit = Joi.number().min(1).max(100).optional();
 
@@ -62,7 +91,7 @@ export const base64String = Joi.string().base64().required();
 
 export const ttlJoi = Joi.number().min(1500000000).max(5000000000).required();
 
-export const jti = Joi.string().pattern(jtiRegex).required();
+export const jti = Joi.string().pattern(jtiRegex).required().messages(customMessages);
 
 // https://github.com/odomojuli/RegExAPI
 export const authCode = Joi.string().regex(/^[A-Za-z0-9-_]+$/);

--- a/source/dea-app/src/test-e2e/resources/create-cases.e2e.test.ts
+++ b/source/dea-app/src/test-e2e/resources/create-cases.e2e.test.ts
@@ -77,6 +77,6 @@ describe('create cases api', () => {
       description: 'any description',
     });
     expect(response.status).toEqual(400);
-    expect(response.data).toBe(`Case with name "${caseName}" is already in use`);
+    expect(response.data).toBe('Case name is already in use');
   }, 30000);
 });

--- a/source/dea-app/src/test/app/resources/create-cases.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/create-cases.integration.test.ts
@@ -107,7 +107,7 @@ describe('create cases resource', () => {
     });
     event.headers['userUlid'] = user.ulid;
     await expect(createCases(event, dummyContext, repositoryProvider)).rejects.toThrow(
-      `Case with name "${name}" is already in use`
+      'Case name is already in use'
     );
   });
 


### PR DESCRIPTION
*Description of changes:*

Enforce best practices about validation messages returned. Don't include the inputted value in the validation message.

#### Sample
Create Case - Use Case : user inputs `<div>` in case name text input.
*Before this PR*
```
'name' with value '<div>' fails to match the required pattern: /^[^\<>/]+$/
```
*After this PR*
```
'name' fails to match the required pattern
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
