### PR TITLE
refactor: specify policy for kms key

### DIFF
--- a/source/dea-backend/src/constructs/dea-rest-api.ts
+++ b/source/dea-backend/src/constructs/dea-rest-api.ts
@@ -97,7 +97,7 @@ export class DeaRestApiConstruct extends Construct {
           new ArnPrincipal(this.authLambdaRole.roleArn),
         ],
         resources: ['*'],
-        sid: 'main-key-share-statement',
+        sid: 'lambda-roles-key-share-statement',
       })
     );
 

--- a/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
+++ b/source/dea-backend/src/test/infra/__snapshots__/dea-backend-constructs.unit.test.ts.snap
@@ -1186,6 +1186,7 @@ Object {
                 "dynamodb:PutItem",
                 "dynamodb:Query",
                 "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
               ],
               "Effect": "Allow",
               "Resource": Object {
@@ -11856,6 +11857,38 @@ Object {
               "Action": Array [
                 "kms:Encrypt*",
                 "kms:Decrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Array [
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "DeaEventHandlerss3batchdeletecasefileroleBAD7A58C",
+                      "Arn",
+                    ],
+                  },
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "DeaEventHandlerss3batchdeletecasefilehandlerrole23FFF03E",
+                      "Arn",
+                    ],
+                  },
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "DeaEventHandlerss3batchstatuschangehandlerrole897AED05",
+                      "Arn",
+                    ],
+                  },
+                ],
+              },
+              "Resource": "*",
+              "Sid": "dea-event-handlers-key-share-statement",
+            },
+            Object {
+              "Action": Array [
+                "kms:Encrypt*",
+                "kms:Decrypt*",
                 "kms:ReEncrypt*",
                 "kms:GenerateDataKey*",
                 "kms:Describe*",
@@ -11878,7 +11911,7 @@ Object {
                 ],
               },
               "Resource": "*",
-              "Sid": "main-key-share-statement",
+              "Sid": "lambda-roles-key-share-statement",
             },
           ],
           "Version": "2012-10-17",

--- a/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
+++ b/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
@@ -17092,6 +17092,7 @@ Object {
                 "dynamodb:PutItem",
                 "dynamodb:Query",
                 "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
               ],
               "Effect": "Allow",
               "Resource": Object {
@@ -17829,28 +17830,7 @@ Object {
               ],
               "Effect": "Allow",
               "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-                "Service": Array [
-                  "logs.us-east-1.amazonaws.com",
-                  "lambda.us-east-1.amazonaws.com",
-                  "cloudformation.amazonaws.com",
-                  "dynamodb.amazonaws.com",
-                ],
+                "Service": "logs.us-east-1.amazonaws.com",
               },
               "Resource": "*",
               "Sid": "main-key-share-statement",
@@ -17880,6 +17860,37 @@ Object {
               "Sid": "Allow management",
             },
             Object {
+              "Action": "kms:Decrypt*",
+              "Condition": Object {
+                "ForAnyValue:StringEquals": Object {
+                  "aws:CalledVia": Array [
+                    "dynamodb.amazonaws.com",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": "*",
+              "Sid": "cfn-key-share-statement",
+            },
+            Object {
               "Action": Array [
                 "kms:Encrypt",
                 "kms:ReEncrypt*",
@@ -17890,6 +17901,38 @@ Object {
                 "Service": "cloudtrail.amazonaws.com",
               },
               "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "kms:Encrypt*",
+                "kms:Decrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Array [
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "DeaEventHandlerss3batchdeletecasefileroleBAD7A58C",
+                      "Arn",
+                    ],
+                  },
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "DeaEventHandlerss3batchdeletecasefilehandlerrole23FFF03E",
+                      "Arn",
+                    ],
+                  },
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "DeaEventHandlerss3batchstatuschangehandlerrole897AED05",
+                      "Arn",
+                    ],
+                  },
+                ],
+              },
+              "Resource": "*",
+              "Sid": "dea-event-handlers-key-share-statement",
             },
             Object {
               "Action": Array [
@@ -17917,7 +17960,7 @@ Object {
                 ],
               },
               "Resource": "*",
-              "Sid": "main-key-share-statement",
+              "Sid": "lambda-roles-key-share-statement",
             },
             Object {
               "Action": Array [


### PR DESCRIPTION
- specify application and event handler roles in kms policy
- allow dynamodb within the account to call decrypt (dynamodb construction makes a decrypt call)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
