### PR TITLE
fix: use case detail label in upload breadcrumb

### DIFF
--- a/source/dea-ui/ui/__tests__/pages/upload-files.unit.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/upload-files.unit.test.tsx
@@ -45,7 +45,7 @@ describe('UploadFiles page', () => {
     const breadcrumbLinks = breadcrumbWrapper?.findBreadcrumbLinks()!;
     expect(breadcrumbLinks.length).toEqual(3);
     expect(breadcrumbLinks[0].getElement()).toHaveTextContent(breadcrumbLabels.homePageLabel);
-    expect(breadcrumbLinks[1].getElement()).toHaveTextContent(`${breadcrumbLabels.caseLabel} ${CASE_ID}`);
+    expect(breadcrumbLinks[1].getElement()).toHaveTextContent(breadcrumbLabels.caseDetailsLabel);
     expect(breadcrumbLinks[2].getElement()).toHaveTextContent(breadcrumbLabels.uploadFilesAndFoldersLabel);
   });
   it('responds to cancel', () => {

--- a/source/dea-ui/ui/src/pages/upload-files/index.tsx
+++ b/source/dea-ui/ui/src/pages/upload-files/index.tsx
@@ -19,6 +19,7 @@ const Home: NextPage = () => {
   const router = useRouter();
   const { settings } = useSettings();
   const { caseId, filePath } = router.query;
+
   if (!caseId || typeof caseId !== 'string' || !filePath || typeof filePath !== 'string') {
     return <h1>{commonLabels.notFoundLabel}</h1>;
   }
@@ -29,7 +30,7 @@ const Home: NextPage = () => {
       href: `/${settings.stage}/ui`,
     },
     {
-      text: `${breadcrumbLabels.caseLabel} ${caseId}`,
+      text: breadcrumbLabels.caseDetailsLabel,
       href: `/${settings.stage}/ui/case-detail?caseId=${caseId}`,
     },
     {


### PR DESCRIPTION
- in file upload page display "case detail" in the breadcrumb rather than the case ulid


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
