### PR TITLE
refactor: rename buttons on upload form for clarity

### DIFF
--- a/source/dea-ui/ui/README.md
+++ b/source/dea-ui/ui/README.md
@@ -8,7 +8,7 @@ This is a prototype app and you should expect to modify the source code to refle
 
 | Statements                                                                                   | Branches                                                                                 | Functions                                                                                  | Lines                                                                              |
 | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-91.77%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-84.51%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-90.05%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-92.13%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-91.77%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-84.51%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-90.05%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-92.14%25-brightgreen.svg?style=flat) |
 
 ## Deploying code changes
 

--- a/source/dea-ui/ui/__tests__/pages/upload-files.unit.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/upload-files.unit.test.tsx
@@ -48,12 +48,12 @@ describe('UploadFiles page', () => {
     expect(breadcrumbLinks[1].getElement()).toHaveTextContent(breadcrumbLabels.caseDetailsLabel);
     expect(breadcrumbLinks[2].getElement()).toHaveTextContent(breadcrumbLabels.uploadFilesAndFoldersLabel);
   });
-  it('responds to cancel', () => {
+  it('responds to done', () => {
     render(<Home />);
 
-    const cancelButton = screen.getByText(commonLabels.cancelButton);
+    const doneButton = screen.getByText(commonLabels.doneButton);
 
-    const btn = wrapper(cancelButton);
+    const btn = wrapper(doneButton);
     btn.click();
     expect(push).toHaveBeenCalledWith(`/case-detail?caseId=${CASE_ID}`);
   });
@@ -88,7 +88,7 @@ describe('UploadFiles page', () => {
     }
     wrappedReason.setInputValue('reason');
 
-    const uploadButton = screen.getByText(commonLabels.uploadButton);
+    const uploadButton = screen.getByText(commonLabels.uploadAndSaveButton);
     const uploadButtonWrapper = wrapper(uploadButton);
     uploadButtonWrapper.click();
 

--- a/source/dea-ui/ui/src/common/labels.tsx
+++ b/source/dea-ui/ui/src/common/labels.tsx
@@ -8,9 +8,11 @@ import { AppLayoutProps, SelectProps } from '@cloudscape-design/components';
 
 export const commonLabels = {
   cancelButton: 'Cancel',
+  doneButton: 'Done',
   submitButton: 'Submit',
   createButton: 'Create',
   uploadButton: 'Upload',
+  uploadAndSaveButton: 'Upload and save',
   activateButton: 'Activate',
   deactivateButton: 'Deactivate',
   addButton: 'Add',

--- a/source/dea-ui/ui/src/components/upload-files/UploadFilesForm.tsx
+++ b/source/dea-ui/ui/src/components/upload-files/UploadFilesForm.tsx
@@ -198,7 +198,7 @@ function UploadFilesForm(props: UploadFilesProps): JSX.Element {
     }
   }
 
-  function onCancelHandler() {
+  function onDoneHandler() {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     router.push(`/case-detail?caseId=${props.caseId}`);
   }
@@ -267,8 +267,8 @@ function UploadFilesForm(props: UploadFilesProps): JSX.Element {
       </Form>
 
       <SpaceBetween direction="horizontal" size="xs">
-        <Button formAction="none" variant="link" data-testid="upload-file-cancel" onClick={onCancelHandler}>
-          {commonLabels.cancelButton}
+        <Button formAction="none" variant="link" onClick={onDoneHandler}>
+          {commonLabels.doneButton}
         </Button>
         <Button
           variant="primary"
@@ -277,7 +277,7 @@ function UploadFilesForm(props: UploadFilesProps): JSX.Element {
           onClick={onSubmitHandler}
           disabled={uploadInProgress || !validateFields()}
         >
-          {commonLabels.uploadButton}
+          {commonLabels.uploadAndSaveButton}
         </Button>
         {uploadInProgress ? <Spinner size="big" variant="disabled" /> : null}
       </SpaceBetween>


### PR DESCRIPTION
On upload form:
- relabel 'cancel' to 'done'
- relabel
<img width="991" alt="Screenshot 2023-05-22 at 6 54 50 PM" src="https://github.com/aws-solutions/digital-evidence-archive-on-aws/assets/16548582/2eaa92de-2365-46b1-b772-2cb9e844ecbc">
 'upload' to 'upload and save'


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
