### PR TITLE
fix: remove improper cfnparam usage

### DIFF
--- a/source/dea-backend/src/constructs/dea-auth.ts
+++ b/source/dea-backend/src/constructs/dea-auth.ts
@@ -410,7 +410,7 @@ export class DeaAuth extends Construct {
       domainPrefix = cognitoPrefixParam.valueAsString;
     }
 
-    const newDomain = new UserPoolDomain(this, domainPrefix, {
+    const newDomain = new UserPoolDomain(this, 'dea-user-pool-domain', {
       userPool,
       cognitoDomain: {
         domainPrefix,

--- a/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
+++ b/source/dea-backend/src/test/infra/dea-backend-constructs.unit.test.ts
@@ -193,10 +193,10 @@ describe('DeaBackend constructs', () => {
       kmsKey: key,
     });
 
-    // throws due to unassigned parameter
-    expect(() => {
-      Template.fromStack(stack);
-    }).toThrow('ID components may not include unresolved tokens');
+    const template = Template.fromStack(stack);
+    template.hasParameter('*', {
+      Type: 'String',
+    });
   });
 
   it('synthesizes without Delete Case Handler when `deletionAllowed` Flag is NOT set', () => {

--- a/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
+++ b/source/dea-main/src/test/__snapshots__/dea-main-stack.unit.test.ts.snap
@@ -20832,7 +20832,7 @@ Object {
     "DeaAuthConstructDEAUserPoolCognitoDomain472B1BE4": Object {
       "Properties": Object {
         "Domain": Object {
-          "Ref": "DeaAuthConstruct[DOMAIN-REMOVED][HASH REMOVED]",
+          "Ref": "DeaAuthConstructdeauserpooldomain945A7AE8",
         },
         "UserPoolId": Object {
           "Ref": "DeaAuthConstructDEAUserPool522C8769",
@@ -23733,7 +23733,7 @@ Object {
       },
       "Type": "AWS::IAM::ManagedPolicy",
     },
-    "DeaAuthConstruct[DOMAIN-REMOVED][HASH REMOVED]": Object {
+    "DeaAuthConstructdeauserpooldomain945A7AE8": Object {
       "Properties": Object {
         "Domain": "[DOMAIN-REMOVED]",
         "UserPoolId": Object {
@@ -24795,7 +24795,7 @@ Object {
             Array [
               "https://",
               Object {
-                "Ref": "DeaAuthConstruct[DOMAIN-REMOVED][HASH REMOVED]",
+                "Ref": "DeaAuthConstructdeauserpooldomain945A7AE8",
               },
               ".auth-fips.us-east-1.amazoncognito.com",
             ],


### PR DESCRIPTION
- objects that are resolved at deploy time can't be used as identifiers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
