### PR TITLE
fix: return a 400 error on token endpoints for all invalid input cases

### DIFF
--- a/source/dea-app/src/app/services/auth-service.ts
+++ b/source/dea-app/src/app/services/auth-service.ts
@@ -228,6 +228,9 @@ export const exchangeAuthorizationCode = async (
     logger.error(
       `Unable to exchange authorization code: ${response.statusText} : ${JSON.stringify(response.data)}`
     );
+    if (response.status === 400) {
+      throw new ValidationError('Bad Request.');
+    }
     throw new Error(`Request failed with status code ${response.status}`);
   }
 
@@ -264,6 +267,9 @@ export const useRefreshToken = async (refreshToken: string): Promise<[Oauth2Toke
 
   if (response.status !== 200) {
     logger.error(`Unable to use refresh token for new id token: ${response.statusText}`);
+    if (response.status === 400) {
+      throw new ValidationError('Bad Request.');
+    }
     throw new Error(`Request failed with status code ${response.status}`);
   }
 
@@ -307,6 +313,9 @@ export const revokeRefreshToken = async (refreshToken: string) => {
 
   if (response.status !== 200) {
     logger.error(`Unable to revoke refresh code: ${response.statusText}`);
+    if (response.status === 400) {
+      throw new ValidationError('Bad Request.');
+    }
     throw new Error(`Request failed with status code ${response.status}`);
   }
 

--- a/source/dea-app/src/test/app/resources/get-token.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/get-token.integration.test.ts
@@ -71,7 +71,7 @@ describe('get-token', () => {
     }
   }, 20000);
 
-  it('should throw an error if the authorization code is not valid', async () => {
+  it('should throw a validation error if the authorization code is not valid', async () => {
     const event = getDummyEvent({
       body: JSON.stringify({
         codeVerifier: pkceStrings.code_verifier,
@@ -81,7 +81,29 @@ describe('get-token', () => {
       },
     });
 
-    await expect(getToken(event, dummyContext)).rejects.toThrow('Request failed with status code 400');
+    await expect(getToken(event, dummyContext)).rejects.toThrow(ValidationError);
+  });
+
+  it('should throw a validation error if the codeVerifier is not valid', async () => {
+    const authTestUrl = cognitoParams.callbackUrl.replace('/login', '/auth-test');
+    const authCode = await getAuthorizationCode(
+      cognitoParams.cognitoDomainUrl,
+      authTestUrl,
+      testUser,
+      cognitoHelper.testPassword,
+      pkceStrings.code_challenge
+    );
+
+    const event = getDummyEvent({
+      body: JSON.stringify({
+        codeVerifier: 'DUMMYCODE_VERIFIER',
+      }),
+      pathParameters: {
+        authCode: authCode,
+      },
+    });
+
+    await expect(getToken(event, dummyContext)).rejects.toThrow(ValidationError);
   });
 
   it('should throw an error if the path param is missing', async () => {

--- a/source/dea-app/src/test/app/resources/refresh-token.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/refresh-token.integration.test.ts
@@ -2,6 +2,7 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
+import { ValidationError } from '../../../app/exceptions/validation-exception';
 import { runPreExecutionChecks } from '../../../app/resources/dea-lambda-utils';
 import { getToken } from '../../../app/resources/get-token';
 import { refreshToken } from '../../../app/resources/refresh-token';
@@ -10,7 +11,7 @@ import { getSessionsForUser } from '../../../app/services/session-service';
 import { Oauth2Token } from '../../../models/auth';
 import { ModelRepositoryProvider } from '../../../persistence/schema/entities';
 import { getSession } from '../../../persistence/session';
-import { getAuthorizationCode, getPkceStrings, PkceStrings } from '../../../test-e2e/helpers/auth-helper';
+import { PkceStrings, getAuthorizationCode, getPkceStrings } from '../../../test-e2e/helpers/auth-helper';
 import CognitoHelper from '../../../test-e2e/helpers/cognito-helper';
 import { randomSuffix } from '../../../test-e2e/resources/test-helpers';
 import {
@@ -132,5 +133,67 @@ describe('refresh-token', () => {
     expect(session2?.updated).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(session2?.updated?.getTime()).toBeGreaterThan(session2!.created!.getTime());
+  }, 40000);
+
+  it('should throw a validation error if the refreshToken is not valid', async () => {
+    const authTestUrl = cognitoParams.callbackUrl.replace('/login', '/auth-test');
+
+    const authCode = await getAuthorizationCode(
+      cognitoParams.cognitoDomainUrl,
+      authTestUrl,
+      testUser,
+      cognitoHelper.testPassword,
+      pkceStrings.code_challenge
+    );
+
+    const event = getDummyEvent({
+      body: JSON.stringify({
+        codeVerifier: pkceStrings.code_verifier,
+      }),
+      pathParameters: {
+        authCode: authCode,
+      },
+      headers: {
+        'callback-override': authTestUrl,
+      },
+    });
+
+    const response = await getToken(event, dummyContext);
+    expect(response.statusCode).toEqual(200);
+
+    if (!response.body) {
+      fail();
+    }
+
+    // Override the refresh_token with id_token value.
+    const jsonBody = JSON.parse(response.body);
+    const idToken: Oauth2Token = {
+      id_token: jsonBody.idToken,
+      refresh_token: jsonBody.idToken,
+      expires_in: jsonBody.expiresIn,
+    };
+    const cookie = `idToken=${JSON.stringify(idToken)}`;
+
+    const dummyEvent = getDummyEvent({
+      headers: {
+        cookie,
+      },
+    });
+    const auditEvent = getDummyAuditEvent();
+
+    // call runLambdaPrechecks to add session to database
+    await runPreExecutionChecks(dummyEvent, dummyContext, auditEvent, repositoryProvider);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const userUlid = dummyEvent.headers['userUlid']!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const tokenId = dummyEvent.headers['tokenId']!;
+
+    // assert session exists
+    const session = await getSession(userUlid, tokenId, repositoryProvider);
+    expect(session).toBeDefined();
+    expect(session?.isRevoked).toBeFalsy();
+
+    await expect(refreshToken(dummyEvent, dummyContext, repositoryProvider)).rejects.toThrow(ValidationError);
   }, 40000);
 });

--- a/source/dea-app/src/test/services/auth-service.integration.test.ts
+++ b/source/dea-app/src/test/services/auth-service.integration.test.ts
@@ -4,6 +4,7 @@
  */
 
 import Joi from 'joi';
+import { ValidationError } from '../../app/exceptions/validation-exception';
 import {
   CognitoSsmParams,
   exchangeAuthorizationCode,
@@ -14,7 +15,7 @@ import {
   useRefreshToken,
 } from '../../app/services/auth-service';
 import { Oauth2TokenSchema } from '../../models/validation/auth';
-import { getAuthorizationCode, getPkceStrings, PkceStrings } from '../../test-e2e/helpers/auth-helper';
+import { PkceStrings, getAuthorizationCode, getPkceStrings } from '../../test-e2e/helpers/auth-helper';
 import CognitoHelper from '../../test-e2e/helpers/cognito-helper';
 import { randomSuffix } from '../../test-e2e/resources/test-helpers';
 
@@ -105,7 +106,7 @@ describe('auth service', () => {
   }, 40000);
 
   it('revoke token should fail when trying to revoke id Token', async () => {
-    await expect(revokeRefreshToken(idToken)).rejects.toThrow('Request failed with status code 400');
+    await expect(revokeRefreshToken(idToken)).rejects.toThrow(ValidationError);
   }, 40000);
 
   it('successfully obtain new id token using refresh token. Revoking the token should prevent future use for the refresh token', async () => {
@@ -117,14 +118,14 @@ describe('auth service', () => {
     expect(revokeResponse).toEqual(200);
 
     // try to use the refresh token again and it should fail
-    await expect(useRefreshToken(refreshToken)).rejects.toThrow('Request failed with status code 400');
+    await expect(useRefreshToken(refreshToken)).rejects.toThrow(ValidationError);
   }, 60000);
 
   it('should throw an error if the authorization code is not valid', async () => {
     const dummyAuthCode = 'DUMMY_AUTH_CODE';
     const dummyCodeVerifier = 'DUMMY_PKCE_VERIFIER';
     await expect(exchangeAuthorizationCode(dummyAuthCode, dummyCodeVerifier)).rejects.toThrow(
-      'Request failed with status code 400'
+      ValidationError
     );
   }, 40000);
 
@@ -132,7 +133,7 @@ describe('auth service', () => {
     const dummyIdToken = 'DUMMY_ID_TOKEN';
     const dummyCodeChallenge = 'DUMMY_CODE_CHALLENGE';
     await expect(exchangeAuthorizationCode(dummyIdToken, dummyCodeChallenge)).rejects.toThrow(
-      'Request failed with status code 400'
+      ValidationError
     );
   }, 40000);
 });


### PR DESCRIPTION
*Description of changes:*

Return a 400 error for all invalid input cases on token endpoints:
* `get-token`
* `refresh-token`
* `revoke-token`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
