### PR TITLE
fix: avoid 500 http errors while revoking previous sessions

### DIFF
--- a/source/dea-app/src/app/services/session-service.ts
+++ b/source/dea-app/src/app/services/session-service.ts
@@ -137,13 +137,21 @@ export const markSessionAsRevoked = async (
     logger.info('No session to revoke for user ' + userUlid);
   } else {
     logger.info('Revoking session for user ' + userUlid + '...');
-    await SessionPersistence.updateSession(
-      {
-        ...maybeSession,
-        isRevoked: true,
-      },
-      repositoryProvider
-    );
+    try {
+      await SessionPersistence.updateSession(
+        {
+          ...maybeSession,
+          isRevoked: true,
+        },
+        repositoryProvider
+      );
+    } catch (error) {
+      if ('code' in error && error.code === 'TransactionCanceledException') {
+        logger.debug(`Revoking session already in progress, moving on...`);
+      } else {
+        throw error;
+      }
+    }
   }
 };
 


### PR DESCRIPTION
*Description of changes:*

* avoid 500 http errors while marking previous sessions as revoked on multiple concurrently requests with the same `idToken`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
