### PR TITLE
fix: handle Throttling errors for concurrent item-level write transaction requests from DynamoDB.

### DIFF
--- a/source/dea-backend/src/handlers/create-dea-handler.ts
+++ b/source/dea-backend/src/handlers/create-dea-handler.ts
@@ -81,11 +81,9 @@ export const createDeaHandler = (
     } catch (error) {
       logger.error('Error', { Body: JSON.stringify(error) });
       if (typeof error === 'object') {
-        if ('name' in error) {
-          const errorHandler = exceptionHandlers.get(error.name);
-          if (errorHandler) {
-            return errorHandler(error, event);
-          }
+        const errorHandler = exceptionHandlers.get(getErrorName(error));
+        if (errorHandler) {
+          return errorHandler(error, event);
         }
       }
 
@@ -100,6 +98,17 @@ export const createDeaHandler = (
     }
   };
   return wrappedHandler;
+};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getErrorName = (error: any): string => {
+  // OneTableError's code property has the underline DynamoDB error name https://doc.onetable.io/api/errors/
+  if ('code' in error) {
+    return error.code;
+  }
+  if ('name' in error) {
+    return error.name;
+  }
+  return '';
 };
 
 const initialAuditEvent = (event: APIGatewayProxyEvent): CJISAuditEventBody => {

--- a/source/dea-backend/src/handlers/exception-handlers.ts
+++ b/source/dea-backend/src/handlers/exception-handlers.ts
@@ -17,6 +17,10 @@ const AWS_CLIENT_INVALID_PARAMETER_NAME = 'InvalidParameterException';
 const AWS_THROTTLING_ERROR_NAME = 'ThrottlingException';
 // Exception name thrown from CloudWatch when the quota limit is exceeded.
 const AWS_LIMITED_EXCEEDED_ERROR_NAME = 'LimitExceededException';
+// DynamoDB https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html
+// Exception thrown during concurrent item-level requests(i.e Throttling from DynamoDB)
+const AWS_DYNAMODB_TRANSACTION_CANCELED_ERROR_NAME = 'TransactionCanceledException';
+
 // If you have a new error case that you want to support, create a new Class that extends Error
 // and add a handler here that responds with an appropriate status code.
 
@@ -75,7 +79,7 @@ const throttlingErrorHandler: ExceptionHandler = async (error, event) => {
   logger.error('ThrottlingError', error);
   return withAllowedOrigin(event, {
     statusCode: 429,
-    body: error.message,
+    body: 'Too Many Requests',
   });
 };
 
@@ -92,3 +96,4 @@ exceptionHandlers.set(AWS_CLIENT_INVALID_PARAMETER_NAME, validationErrorHandler)
 exceptionHandlers.set(REAUTHENTICATION_ERROR_NAME, reauthenticationErrorHandler);
 exceptionHandlers.set(AWS_THROTTLING_ERROR_NAME, throttlingErrorHandler);
 exceptionHandlers.set(AWS_LIMITED_EXCEEDED_ERROR_NAME, throttlingErrorHandler);
+exceptionHandlers.set(AWS_DYNAMODB_TRANSACTION_CANCELED_ERROR_NAME, throttlingErrorHandler);

--- a/source/dea-backend/src/test/handlers/exception-handlers.unit.test.ts
+++ b/source/dea-backend/src/test/handlers/exception-handlers.unit.test.ts
@@ -201,11 +201,11 @@ describe('exception handlers', () => {
     const actual = await sut(dummyEvent, dummyContext);
     expect(actual).toEqual({
       statusCode: 429,
-      body: 'Rate exceeded',
+      body: 'Too Many Requests',
     });
   });
 
-  it('should handle Throttling errors from CW', async () => {
+  it('should handle Throttling errors from CloudWatch', async () => {
     const sut = createDeaHandler(
       async () => {
         const throttlingException = new Error('Limit exceeded');
@@ -220,7 +220,27 @@ describe('exception handlers', () => {
     const actual = await sut(dummyEvent, dummyContext);
     expect(actual).toEqual({
       statusCode: 429,
-      body: 'Limit exceeded',
+      body: 'Too Many Requests',
+    });
+  });
+
+  it('should handle Throttling errors from DynamoDB', async () => {
+    const sut = createDeaHandler(
+      async () => {
+        const transactionCanceledException = new Error('Transaction cancelled');
+        transactionCanceledException.name = 'TransactionCanceledException';
+        throw transactionCanceledException;
+      },
+      NO_ACL,
+      preExecutionChecks,
+      testAuditService.service
+    );
+
+    const actual = await sut(dummyEvent, dummyContext);
+
+    expect(actual).toEqual({
+      statusCode: 429,
+      body: 'Too Many Requests',
     });
   });
 });


### PR DESCRIPTION
*Description of changes:*

* handle Throttling errors for concurrent item-level write transaction requests from DynamoDB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
