### PR TITLE
fix: remove inputed value from validation messages on GetAuthenticationToken endpoint

### DIFF
--- a/source/dea-app/src/models/validation/joi-common.ts
+++ b/source/dea-app/src/models/validation/joi-common.ts
@@ -99,7 +99,9 @@ export const ttlJoi = Joi.number().min(1500000000).max(5000000000).required();
 export const jti = Joi.string().pattern(jtiRegex).required().messages(customMessages);
 
 // https://github.com/odomojuli/RegExAPI
-export const authCode = Joi.string().regex(/^[A-Za-z0-9-_]+$/);
+export const authCode = Joi.string()
+  .regex(/^[A-Za-z0-9-_]+$/)
+  .messages(customMessages);
 
 // FileSize should be a positive integer less than 5 TB
 export const safeFileSize = Joi.number()


### PR DESCRIPTION
*Description of changes:*
* remove inputed value from validation messages on GetAuthenticationToken endpoint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
