### PR TITLE
refactor: fetch all records to enable client side pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Digital Evidence Archive on AWS enables Law Enforcement organizations to ingest 
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-95.99%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-86.66%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-93.67%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-96.05%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-95.46%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.1%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-93.5%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-95.44%25-brightgreen.svg?style=flat) |
 
 
 # Getting Started

--- a/source/dea-app/README.md
+++ b/source/dea-app/README.md
@@ -4,6 +4,6 @@
 
 | Statements                                                                         | Branches                                                                      | Functions                                                                        | Lines                                                                   |
 | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-97.84%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.19%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.64%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-97.55%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-84.43%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.32%25-brightgreen.svg?style=flat) |
 
 This project is the routing package for `dea-backend`. It is used by `dea-backend` to generate routes for DEA API. Please refer [here](../dea-backend/README.md) for more information on how to use this project.

--- a/source/dea-app/src/models/validation/joi-common.ts
+++ b/source/dea-app/src/models/validation/joi-common.ts
@@ -85,7 +85,7 @@ export const safeDescription = Joi.string()
   .optional()
   .messages(customMessages);
 
-export const paginationLimit = Joi.number().min(1).max(100).optional();
+export const paginationLimit = Joi.number().min(1).max(10000).optional();
 
 export const base64String = Joi.string().base64().required();
 

--- a/source/dea-backend/README.md
+++ b/source/dea-backend/README.md
@@ -6,7 +6,7 @@
 
 | Statements                                                                               | Branches                                                                             | Functions                                                                              | Lines                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| ![Statements](https://img.shields.io/badge/statements-93.76%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.24%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-85.29%25-yellow.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.67%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-94.53%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-86.36%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-85.71%25-yellow.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-94.59%25-brightgreen.svg?style=flat) |
 
 ## Description
 

--- a/source/dea-ui/infrastructure/README.md
+++ b/source/dea-ui/infrastructure/README.md
@@ -4,7 +4,7 @@
 
 | Statements                                                                                   | Branches                                                                                 | Functions                                                                                  | Lines                                                                              |
 | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-100%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-100%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-100%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-93.33%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-0%25-red.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.33%25-brightgreen.svg?style=flat) |
 
 ## Description
 

--- a/source/dea-ui/ui/README.md
+++ b/source/dea-ui/ui/README.md
@@ -8,7 +8,7 @@ This is a prototype app and you should expect to modify the source code to refle
 
 | Statements                                                                                   | Branches                                                                                 | Functions                                                                                  | Lines                                                                              |
 | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-92.22%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.45%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-90.24%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-92.46%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-92.88%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-85.45%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.48%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.11%25-brightgreen.svg?style=flat) |
 
 ## Deploying code changes
 

--- a/source/dea-ui/ui/__tests__/pages/all-cases.integration.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/all-cases.integration.test.tsx
@@ -21,7 +21,7 @@ describe('All Cases Dashboard', () => {
   it('renders a list of cases', async () => {
     mockedAxios.create.mockReturnThis();
     mockedAxios.request.mockImplementation((eventObj) => {
-      if (eventObj.url?.endsWith('all-cases')) {
+      if (eventObj.url?.includes('all-cases')) {
         return Promise.resolve({
           data: {
             cases: [

--- a/source/dea-ui/ui/__tests__/pages/case-detail-fail-download.integration.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/case-detail-fail-download.integration.test.tsx
@@ -157,7 +157,7 @@ mockedAxios.request.mockImplementation((eventObj) => {
       headers: {},
       config: {},
     });
-  } else if (eventObj.url?.endsWith('files?filePath=/')) {
+  } else if (eventObj.url?.includes('files?filePath=/')) {
     return Promise.resolve({
       data: mockFilesRoot,
       status: 200,

--- a/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/case-detail.integration.test.tsx
@@ -235,7 +235,7 @@ mockedAxios.request.mockImplementation((eventObj) => {
       headers: {},
       config: {},
     });
-  } else if (eventObj.url?.endsWith('files?filePath=/food/')) {
+  } else if (eventObj.url?.includes('files?filePath=/food/')) {
     return Promise.resolve({
       data: mockFilesFood,
       status: 200,
@@ -243,7 +243,7 @@ mockedAxios.request.mockImplementation((eventObj) => {
       headers: {},
       config: {},
     });
-  } else if (eventObj.url?.endsWith('files?filePath=/')) {
+  } else if (eventObj.url?.includes('files?filePath=/')) {
     return Promise.resolve({
       data: mockFilesRoot,
       status: 200,

--- a/source/dea-ui/ui/__tests__/pages/manage-case.integration.test.tsx
+++ b/source/dea-ui/ui/__tests__/pages/manage-case.integration.test.tsx
@@ -65,7 +65,7 @@ describe('Manage Case Page', () => {
           headers: {},
           config: {},
         });
-      } else if (eventObj.url?.endsWith('users?nameBeginsWith=')) {
+      } else if (eventObj.url?.includes('users?nameBeginsWith=')) {
         // get users
         return Promise.resolve({
           data: mockedUsers,
@@ -147,7 +147,7 @@ describe('Manage Case Page', () => {
           headers: {},
           config: {},
         });
-      } else if (eventObj.url?.endsWith('users?nameBeginsWith=')) {
+      } else if (eventObj.url?.includes('users?nameBeginsWith=')) {
         // get users
         return Promise.resolve({
           data: mockedUsers,

--- a/source/dea-ui/ui/src/api/cases.tsx
+++ b/source/dea-ui/ui/src/api/cases.tsx
@@ -54,13 +54,13 @@ interface CaseListReponse {
 }
 
 export const useListAllCases = (): DeaListResult<DeaCaseDTO> => {
-  const { data, error } = useSWR(() => `cases/all-cases`, httpApiGet<CaseListReponse> );
+  const { data, error } = useSWR(() => `cases/all-cases?limit=10000`, httpApiGet<CaseListReponse> );
   const cases: DeaCaseDTO[] = data?.cases ?? [];
   return { data: cases, isLoading: !data && !error };
 };
 
 export const useListMyCases = (): DeaListResult<DeaCaseDTO> => {
-  const { data, error, mutate } = useSWR(() => `cases/my-cases`, (httpApiGet<CaseListReponse>) );
+  const { data, error, mutate } = useSWR(() => `cases/my-cases?limit=10000`, (httpApiGet<CaseListReponse>) );
   const cases: DeaCaseDTO[] = data?.cases ?? [];
   return { data: cases, isLoading: !data && !error, mutate };
 };
@@ -89,7 +89,7 @@ export const updateCase = async (editCaseForm: EditCaseForm): Promise<void> => {
 };
 
 export const useListCaseFiles = (id: string, filePath = '/'): DeaListResult<DeaCaseFile> => {
-  const { data, error } = useSWR(() => `cases/${id}/files?filePath=${filePath}`, httpApiGet<{files: DeaCaseFile[]}>);
+  const { data, error } = useSWR(() => `cases/${id}/files?filePath=${filePath}&limit=10000`, httpApiGet<{files: DeaCaseFile[]}>);
   const caseFiles: DeaCaseFile[] = data?.files ?? [];
   return { data: caseFiles, isLoading: !error && !data };
 };
@@ -111,7 +111,7 @@ export const restoreFile = async (apiInput: RestoreFileForm): Promise<void> => {
 };
 
 export const useGetUsers = (nameBeginsWith: string): DeaListResult<DeaUser> => {
-  const { data, error } = useSWR(() => `users?nameBeginsWith=${nameBeginsWith}`, httpApiGet<{users: DeaUser[]}>);
+  const { data, error } = useSWR(() => `users?nameBeginsWith=${nameBeginsWith}&limit=10000`, httpApiGet<{users: DeaUser[]}>);
   const users: DeaUser[] = data?.users ?? [];
   return { data: users, isLoading: !data && !error };
 };

--- a/source/dea-ui/ui/src/common/labels.tsx
+++ b/source/dea-ui/ui/src/common/labels.tsx
@@ -127,7 +127,7 @@ export const fileOperationsLabels = {
     'Enter a brief description of the evidence being uploaded. Max character limit 250.',
   uploadReasonLabel: 'Reason for uploading evidence',
   uploadReasonDescription: "Explain why you're accessing the case files.",
-  selectFileSubtext: 'All file types accepted. 5TB max file size.',
+  selectFileSubtext: 'All file types accepted. 5TB maximum file size.',
   auditLogLabel: 'Case File Audit Log',
   restoreSuccessful: 'Successfully initiated restore for selected files',
   restoreFail: 'Failed to restore selected files',
@@ -159,6 +159,12 @@ export const auditLogLabels = {
   loadingLabel: 'loading audit log',
   errorLabel: 'Error downloading audit logs. Audit query is empty or encountered an error or cancellation.',
   downloadCaseAuditFail: (fileName: string) => `Failed to download case file audit for ${fileName}`,
+};
+
+export const paginationLabels = {
+  nextPageLabel: 'Next page',
+  pageLabel: (pageNumber: number) => `Go to page ${pageNumber}`,
+  previousPageLabel: 'Previous page',
 };
 
 export const manageCaseAccessLabels = {
@@ -195,6 +201,11 @@ export const manageCaseAccessLabels = {
     'There access will be instantly removed and they will be notified by email.',
   saveSuccessMessage: 'Changes have been saved successfully.',
   saveFailMessage: 'Changes have not been saved.',
+};
+
+export const caseStatusLabels = {
+  active: 'Active',
+  inactive: 'Inactive',
 };
 
 export const createCaseLabels = {

--- a/source/dea-ui/ui/src/components/case-details/CaseFilesTable.tsx
+++ b/source/dea-ui/ui/src/components/case-details/CaseFilesTable.tsx
@@ -34,6 +34,7 @@ import {
   commonTableLabels,
   fileOperationsLabels,
   filesListLabels,
+  paginationLabels,
 } from '../../common/labels';
 import { useNotifications } from '../../context/NotificationsContext';
 import { formatDate } from '../../helpers/dateHelper';
@@ -73,7 +74,7 @@ function CaseFilesTable(props: CaseDetailsTabsProps): JSX.Element {
     },
   ];
 
-  const { items, filterProps, collectionProps } = useCollection(data, {
+  const { items, filterProps, collectionProps, paginationProps } = useCollection(data, {
     filtering: {
       empty: TableEmptyDisplay(filesListLabels.noFilesLabel, filesListLabels.noDisplayLabel),
       noMatch: TableNoMatchDisplay(filesListLabels.noFilesLabel),
@@ -88,6 +89,10 @@ function CaseFilesTable(props: CaseDetailsTabsProps): JSX.Element {
       filteringProperties: filteringProperties,
       empty: TableEmptyDisplay(filesListLabels.noFilesLabel, filesListLabels.noDisplayLabel),
       noMatch: TableNoMatchDisplay(filesListLabels.noFilesLabel),
+    },
+    pagination: {
+      defaultPage: 0,
+      pageSize: 50,
     },
     sorting: {},
     selection: {},
@@ -253,17 +258,7 @@ function CaseFilesTable(props: CaseDetailsTabsProps): JSX.Element {
     );
 
   // pagination element
-  const tablePagination = (
-    <Pagination
-      currentPageIndex={1}
-      pagesCount={1}
-      ariaLabels={{
-        nextPageLabel: 'Next page',
-        previousPageLabel: 'Previous page',
-        pageLabel: (pageNumber) => `Page ${pageNumber} of all pages`,
-      }}
-    />
-  );
+  const tablePagination = <Pagination {...paginationProps} ariaLabels={paginationLabels} />;
 
   async function downloadCaseFileAuditHandler() {
     const sleep = (delay: number) => new Promise((resolve) => setTimeout(resolve, delay));

--- a/source/dea-ui/ui/src/components/case-details/ManageAccessListItem.tsx
+++ b/source/dea-ui/ui/src/components/case-details/ManageAccessListItem.tsx
@@ -13,7 +13,6 @@ import {
   Multiselect,
   MultiselectProps,
   SelectProps,
-  TextContent,
 } from '@cloudscape-design/components';
 import { useMemo, useState } from 'react';
 import { caseActionOptions, commonLabels, manageCaseAccessLabels } from '../../common/labels';
@@ -67,11 +66,7 @@ function ManageAccessListItem(props: ManageAccessListItemProps): JSX.Element {
       gridDefinition={[{ colspan: { default: 12, xs: 10 } }, { colspan: { default: 12, xs: 2 } }]}
     >
       <ColumnLayout columns={2}>
-        <FormField label={`${caseMember.userFirstName} ${caseMember.userLastName}`}>
-          <TextContent>
-            <u>{manageCaseAccessLabels.manageMemberEmailLabel}</u>
-          </TextContent>
-        </FormField>
+        <FormField label={`${caseMember.userFirstName} ${caseMember.userLastName}`} />
         <FormField label={manageCaseAccessLabels.manageMemberPermissionsLabel}>
           <Multiselect
             data-testid={`${caseMember.userUlid}-multiselect`}

--- a/source/dea-ui/ui/src/components/case-list-table/CaseTable.tsx
+++ b/source/dea-ui/ui/src/components/case-list-table/CaseTable.tsx
@@ -9,11 +9,11 @@ import { CaseStatus } from '@aws/dea-app/lib/models/case-status';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 import {
   Button,
-  Icon,
   Link,
   Pagination,
   PropertyFilter,
   SpaceBetween,
+  StatusIndicator,
   Table,
   Toggle,
 } from '@cloudscape-design/components';
@@ -24,7 +24,13 @@ import * as React from 'react';
 import { useAvailableEndpoints } from '../../api/auth';
 import { DeaListResult, updateCaseStatus } from '../../api/cases';
 import { DeaCaseDTO } from '../../api/models/case';
-import { caseListLabels, commonLabels, commonTableLabels } from '../../common/labels';
+import {
+  caseListLabels,
+  caseStatusLabels,
+  commonLabels,
+  commonTableLabels,
+  paginationLabels,
+} from '../../common/labels';
 import { useNotifications } from '../../context/NotificationsContext';
 import { formatDateFromISOString } from '../../helpers/dateHelper';
 import { formatFileSize } from '../../helpers/fileHelper';
@@ -55,32 +61,39 @@ function CaseTable(props: CaseTableProps): JSX.Element {
   const { pushNotification } = useNotifications();
 
   // Property and date filter collections
-  const { items, filteredItemsCount, propertyFilterProps, collectionProps } = useCollection(data, {
-    filtering: {
-      empty: TableEmptyDisplay(caseListLabels.noCasesLabel, caseListLabels.noDisplayLabel),
-      noMatch: TableNoMatchDisplay(caseListLabels.noCasesMatchLabel),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      filteringFunction: (item: any, filteringText): any => {
-        const filteringTextLowerCase = filteringText.toLowerCase();
+  const { items, filteredItemsCount, propertyFilterProps, collectionProps, paginationProps } = useCollection(
+    data,
+    {
+      filtering: {
+        empty: TableEmptyDisplay(caseListLabels.noCasesLabel, caseListLabels.noDisplayLabel),
+        noMatch: TableNoMatchDisplay(caseListLabels.noCasesMatchLabel),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        filteringFunction: (item: any, filteringText): any => {
+          const filteringTextLowerCase = filteringText.toLowerCase();
 
-        return (
-          searchableColumns
-            // eslint-disable-next-line security/detect-object-injection
-            .map((key) => item[key])
-            .some(
-              (value) => typeof value === 'string' && value.toLowerCase().indexOf(filteringTextLowerCase) > -1
-            )
-        );
+          return (
+            searchableColumns
+              // eslint-disable-next-line security/detect-object-injection
+              .map((key) => item[key])
+              .some(
+                (value) =>
+                  typeof value === 'string' && value.toLowerCase().indexOf(filteringTextLowerCase) > -1
+              )
+          );
+        },
       },
-    },
-    propertyFiltering: {
-      filteringProperties: filteringProperties,
-      empty: TableEmptyDisplay(caseListLabels.noCasesLabel, caseListLabels.noDisplayLabel),
-      noMatch: TableNoMatchDisplay(caseListLabels.noCasesMatchLabel),
-    },
-    sorting: {},
-    selection: {},
-  });
+      propertyFiltering: {
+        filteringProperties: filteringProperties,
+        empty: TableEmptyDisplay(caseListLabels.noCasesLabel, caseListLabels.noDisplayLabel),
+        noMatch: TableNoMatchDisplay(caseListLabels.noCasesMatchLabel),
+      },
+      sorting: {},
+      selection: {},
+      pagination: {
+        pageSize: 15,
+      },
+    }
+  );
   function createNewCaseHandler() {
     return router.push('/create-cases');
   }
@@ -166,23 +179,9 @@ function CaseTable(props: CaseTableProps): JSX.Element {
 
   function statusCell(deaCase: DeaCaseDTO) {
     if (deaCase.status == CaseStatus.ACTIVE) {
-      return (
-        <Box>
-          <SpaceBetween direction="horizontal" size="xs" key={deaCase.ulid}>
-            <Icon name="check" variant="success" />
-            <span>{deaCase.status.slice(0, 1) + deaCase.status.slice(1).toLowerCase()}</span>
-          </SpaceBetween>
-        </Box>
-      );
+      return <StatusIndicator>{caseStatusLabels.active}</StatusIndicator>;
     } else {
-      return (
-        <Box>
-          <SpaceBetween direction="horizontal" size="xs" key={deaCase.ulid}>
-            <Icon name="status-stopped" variant="disabled" />
-            <span>{deaCase.status.slice(0, 1) + deaCase.status.slice(1).toLowerCase()}</span>
-          </SpaceBetween>
-        </Box>
-      );
+      return <StatusIndicator type="stopped">{caseStatusLabels.inactive}</StatusIndicator>;
     }
   }
 
@@ -359,17 +358,7 @@ function CaseTable(props: CaseTableProps): JSX.Element {
           />
         </SpaceBetween>
       }
-      pagination={
-        <Pagination
-          currentPageIndex={1}
-          pagesCount={1}
-          ariaLabels={{
-            nextPageLabel: 'Next page',
-            previousPageLabel: 'Previous page',
-            pageLabel: (pageNumber) => `Page ${pageNumber} of all pages`,
-          }}
-        />
-      }
+      pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
     />
   );
 }


### PR DESCRIPTION
- use an arbitrarily large limit to fetch records for client side pagination
- use appropriate pagination props along with useCollection hook on cases and files tables
- per F&F:
  - All file types accepted. 5TB max file size. -> All file types accepted. 5TB maximum file size.
  - Remove non-working 'view email' link from membership item
  - Use StatusIndicator for case status

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
