### PR TITLE
fix: parse cookie properly

### DIFF
--- a/source/dea-app/src/lambda-http-helpers.ts
+++ b/source/dea-app/src/lambda-http-helpers.ts
@@ -114,9 +114,20 @@ export const getRequiredHeader = (event: APIGatewayProxyEvent, headerName: strin
   throw new ValidationError(`Required header '${headerName}' is missing.`);
 };
 
+export const getCookieValue = (event: APIGatewayProxyEvent, cookieName: string): string | null => {
+  return (
+    event.headers['cookie']
+      ?.split(';')
+      .map((value) => value.trim())
+      .filter((cookie) => cookie.startsWith(`${cookieName}=`))
+      .map((cookie) => decodeURIComponent(cookie.substring(cookieName.length + 1)))[0] || null
+  );
+};
+
 export const getOauthToken = (event: APIGatewayProxyEvent): Oauth2Token => {
-  if (event.headers['cookie'] && event.headers['cookie'].includes('idToken=')) {
-    const token: Oauth2Token = JSON.parse(event.headers['cookie'].replace('idToken=', ''));
+  const tokenVal = getCookieValue(event, 'idToken');
+  if (tokenVal) {
+    const token: Oauth2Token = JSON.parse(tokenVal);
     Joi.assert(token, Oauth2TokenSchema);
     return token;
   }

--- a/source/dea-app/src/test/app/resources/lambda-preexecution-checks.integration.test.ts
+++ b/source/dea-app/src/test/app/resources/lambda-preexecution-checks.integration.test.ts
@@ -54,7 +54,7 @@ describe('lambda pre-execution checks', () => {
     const oauthToken = await cognitoHelper.getIdTokenForUser(testUser);
 
     const event = getDummyEvent();
-    event.headers['cookie'] = `idToken=${JSON.stringify(oauthToken)}`;
+    event.headers['cookie'] = `extraCookie=someval; idToken=${JSON.stringify(oauthToken)}`;
     const tokenPayload = await getTokenPayload(oauthToken.id_token, region);
     const tokenId = tokenPayload.sub;
 

--- a/source/dea-backend/src/handlers/create-dea-handler.ts
+++ b/source/dea-backend/src/handlers/create-dea-handler.ts
@@ -43,9 +43,9 @@ export const createDeaHandler = (
     try {
       const debugHeaders = removeSensitiveHeaders(event.headers);
       const { headers: _, multiValueHeaders: _1, ...debugEvent } = event;
-      logger.debug(`Headers`, { Data: JSON.stringify(debugHeaders, null, 2) });
-      logger.debug(`Event`, { Data: JSON.stringify(debugEvent, null, 2) });
-      logger.debug(`Context`, { Data: JSON.stringify(context, null, 2) });
+      logger.debug(`Headers`, debugHeaders);
+      logger.debug(`Event`, debugEvent);
+      logger.debug(`Context`, context);
 
       if (auditEvent.eventType === AuditEventType.UNKNOWN) {
         logger.error('An Audit Event was not found for the requested method', {
@@ -79,7 +79,7 @@ export const createDeaHandler = (
       }
       return result;
     } catch (error) {
-      logger.error('Error', { Body: JSON.stringify(error) });
+      logger.error('Error', error);
       if (typeof error === 'object') {
         const errorHandler = exceptionHandlers.get(getErrorName(error));
         if (errorHandler) {


### PR DESCRIPTION
- parse http cookie properly
- don't stringify where we don't need to


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
